### PR TITLE
Revise README for clarity and updated instructions

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,39 @@
+# Repository agent playbooks
+
+These playbooks describe repository-specific workflows for GitHub issues and
+pull requests. They are instructions for an agent using this checkout; they
+are not GitHub Actions or autonomous merge automation.
+
+## Playbooks
+
+- [`issue-create.md`](./issue-create.md): draft and create one GitHub issue
+  using the repository templates.
+- [`issue-read.md`](./issue-read.md): inspect an issue and its linked work
+  without mutating GitHub state.
+- [`review-pr.md`](./review-pr.md): review a pull request, validate findings,
+  apply safe fixes, and record the final review decision.
+
+## Shared rules
+
+- Read [`AGENTS.md`](../AGENTS.md) before changing repository files.
+- Use the repository's issue templates and `.github/labels/labels.json` as the
+  source of truth for issue metadata.
+- Do not invent issue facts, timeline state, test evidence, or editor
+  capabilities.
+- Never include credentials, private media, user-specific paths, or raw crash
+  dumps in issues, comments, or commits.
+- Treat live Final Cut capability errors as authoritative and fail closed.
+- Do not merge or close pull requests automatically.
+
+## Validation
+
+For repository changes, run the required checks from `AGENTS.md`:
+
+```sh
+pnpm install --frozen-lockfile
+pnpm run build
+pnpm run test
+pnpm run check:boundaries
+```
+
+When native files change, also run the required Xcode checks.

--- a/.agents/issue-create.md
+++ b/.agents/issue-create.md
@@ -1,0 +1,74 @@
+# Create a GitHub issue
+
+Use this playbook when the user explicitly asks to create an issue in the
+current repository.
+
+## Safety gate
+
+Issue creation is an external mutation. Always draft the issue first and ask
+for explicit approval before running `gh issue create`. For a batch, show the
+complete batch and require approval for the complete batch.
+
+Create one issue per user request unless the user explicitly asks for a batch.
+Do not split one request into multiple issues without approval.
+
+## Workflow
+
+1. Confirm the repository:
+
+   ```sh
+   gh repo view --json nameWithOwner -q .nameWithOwner
+   ```
+
+2. Inspect the available templates:
+
+   ```sh
+   find .github/ISSUE_TEMPLATE -maxdepth 1 -type f -print | sort
+   ```
+
+3. Select exactly one template:
+
+   - bug or regression → `bug.md`;
+   - feature or capability → `feature.md`;
+   - reliability, UX, testing, or documentation improvement → `improvement.md`;
+   - architecture or workflow proposal → `design.md`.
+
+4. Draft the title and body using only facts supplied by the user. Preserve
+   the selected template headings and write `Needs confirmation` where a
+   required detail is missing.
+
+5. Present the draft with the repository, template, title, body, metadata, and
+   close-equivalent `gh issue create` command.
+
+6. After approval, validate explicitly requested labels against both
+   `.github/labels/labels.json` and GitHub:
+
+   ```sh
+   gh label list --limit 200
+   ```
+
+   Do not add labels merely because a template has a default. Labels may be
+   selected from `.github/labels` only when the user asks for labels or asks
+   the agent to choose them.
+
+7. Prefer a body file for creation:
+
+   ```sh
+   gh issue create \
+     --repo OWNER/REPO \
+     --title "..." \
+     --body-file /path/to/body.md
+   ```
+
+   Add only approved labels or other metadata.
+
+8. Return the created issue URL and the metadata that was applied.
+
+## Content rules
+
+- Do not infer a root cause, affected file, reproduction step, or acceptance
+  criterion that the user did not provide.
+- Do not add milestones, assignees, projects, or labels without explicit
+  permission.
+- Do not claim the issue was created if GitHub or authentication fails.
+- If creation fails, return the draft and the exact command that can be rerun.

--- a/.agents/issue-read.md
+++ b/.agents/issue-read.md
@@ -1,0 +1,39 @@
+# Read a GitHub issue
+
+Use this playbook for a read-only status report on an issue.
+
+## Inputs
+
+Accept an issue number or URL. If no issue is supplied, identify the current
+repository with:
+
+```sh
+gh repo view --json nameWithOwner -q .nameWithOwner
+```
+
+## Workflow
+
+1. Read the issue metadata, body, labels, comments, and state:
+
+   ```sh
+   gh issue view ISSUE --comments --json number,title,body,state,labels,assignees,milestone,comments,url
+   ```
+
+2. Inspect related pull requests and current checks when they are linked or
+   discoverable from the issue timeline.
+
+3. Read repository files only when needed to verify a claim in the issue. Use
+   the issue body and live GitHub state as the primary sources of truth.
+
+4. Report the objective, current state, acceptance criteria, completed
+   evidence, linked PRs and CI status, unresolved questions, blockers, and
+   recommended next action.
+
+## Output rules
+
+- Separate confirmed evidence from assumptions.
+- Link directly to the issue, PRs, checks, and relevant repository files.
+- Do not modify the issue, comments, labels, milestones, projects, or linked
+  pull requests.
+- Do not infer completion from an open PR alone; inspect its checks and review
+  state.

--- a/.agents/review-pr.md
+++ b/.agents/review-pr.md
@@ -1,0 +1,97 @@
+# Review a pull request and remediate findings
+
+Use this playbook to review a PR against its linked issue and repository
+contracts. The workflow may fix validated findings, but it must never merge or
+close the PR.
+
+## Review inputs
+
+Accept a PR number or URL. Read the current PR head; never rely on an old
+local checkout.
+
+```sh
+gh pr view PR --json title,body,files,url,headRefName,baseRefName,headRefOid
+gh pr diff PR
+gh pr view PR --comments
+gh api repos/OWNER/REPO/pulls/NUMBER/comments \
+  --jq '.[] | {file: .path, user: .user.login, comment: .body, line: .line, side: .side}'
+gh pr checks PR
+```
+
+## Review checklist
+
+Review the change against the linked issue, `AGENTS.md`, runtime dependency
+boundaries, public MCP schemas, capability flags, fail-closed behavior,
+tests, documentation, compatibility claims, security, privacy, performance,
+and required Final Cut validation.
+
+Summarize each changed file by explaining the before/after behavior and
+whether it serves the PR purpose. Classify findings as `blocker`, `required`,
+`concern`, or `none`.
+
+## Validate existing comments
+
+For every existing review comment:
+
+1. Check whether it still applies to the current PR head.
+2. Confirm it against the current code and tests.
+3. If valid and safely fixable, apply the fix below.
+4. If valid but not safely fixable, keep or add a concise inline comment.
+5. If invalid or outdated, reply to the thread with evidence explaining why
+   no code change is needed.
+
+Do not silently dismiss a review thread.
+
+## Apply a validated fix
+
+Only fix findings that are clearly in scope and supported by repository
+evidence.
+
+1. Confirm the current worktree is clean before any local mutation. If it is
+   dirty, do not overwrite user changes.
+2. Create an isolated worktree from the PR head rather than checking out the
+   PR over the user's current branch.
+3. Apply the smallest fix and add a regression test when behavior changes.
+4. Run the required checks:
+
+   ```sh
+   pnpm install --frozen-lockfile
+   pnpm run build
+   pnpm run test
+   pnpm run check:boundaries
+   ```
+
+   Run the native Xcode checks when native files changed.
+
+5. Commit with a concise imperative message.
+6. Push only to the PR's same-repository head branch after confirming the
+   branch and commit target:
+
+   ```sh
+   git push origin HEAD:PR_HEAD_BRANCH
+   ```
+
+   If the PR is from a fork or push permission is unavailable, do not force a
+   push; report the patch and leave the review comment instead.
+7. Reply to the relevant review thread with the commit hash and validation
+   evidence.
+8. Refresh the PR checks before deciding the final review outcome.
+
+## Review comments and final decision
+
+Use short, polite comments with a severity prefix:
+
+- `[must]` for a blocker or required fix;
+- `[want]` for a non-blocking improvement;
+- `[ask]` for clarification;
+- `[info]` for evidence or context.
+
+If blockers remain, submit a `REQUEST_CHANGES` review with the inline comments.
+If no blockers remain and required checks pass, submit `APPROVE`. Do not
+approve merely because CI is green when a correctness issue remains.
+
+## Final report
+
+Return the PR purpose and changed-file summary, CI and validation status,
+findings and comment links, fixes pushed with commit hashes and test evidence,
+the final review decision, and unresolved risks or follow-up work.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
+<p align="center">
+  <img src="https://img.shields.io/badge/Swift-5.9%2B-F05138?logo=swift&logoColor=white" alt="Swift 5.9 or newer" />
+  <img src="https://img.shields.io/badge/Python-3.13-3776AB?logo=python&logoColor=white" alt="Python 3.13" />
+  <img src="https://img.shields.io/badge/platform-Apple%20Silicon%20macOS-000000?logo=apple&logoColor=white" alt="Apple Silicon macOS" />
+</p>
+
 # Framekit
 
-Agentic video editing runtime. Phase 2 extends the Phase 0 read → write →
-read-after-write → diff loop with incremental context synchronization, visual
-analysis, combined media understanding, native asset discovery, and the Phase
-1 Final Cut runtime.
+Agentic video editing runtime. 
 
-## Development
+## Installation
 
-Contributor setup, including the local pre-commit hook, is documented in
-[`CONTRIBUTOR.md`](CONTRIBUTOR.md).
+Requirements:
 
 ```sh
 pnpm install --frozen-lockfile
@@ -17,13 +19,9 @@ pnpm run test
 pnpm run build
 ```
 
-The documentation index is in [`docs/README.md`](docs/README.md). The MCP
-contract is documented in [`docs/mcp/`](docs/mcp/), and reproducible Phase 0,
-Phase 1, and Final Cut live tests are documented in [`docs/tests/`](docs/tests/).
+## Quick Start
 
-The reproducible Node shell and native toolchain contract live under
-[`nix/`](nix/). Enter it with `nix develop ./nix`, then run
-`pnpm run xcode:check` before building the Final Cut Workflow Extension.
+The reproducible Node shell and native toolchain contract live under [`nix/`](nix/). Enter it with `nix develop ./nix`, then run `pnpm run xcode:check` before building the Final Cut Workflow Extension.
 
 ## MCP server
 
@@ -33,71 +31,7 @@ The local MCP server uses the deterministic in-memory Phase 2 fixture:
 pnpm run mcp
 ```
 
-It exposes these tools over stdio:
-
-- `connection.status`
-- `editor.inspect`
-- `editor.native.inspect`, `editor.native.focus`, `editor.native.edit`,
-  `editor.native.undo`
-- `editor.native.media.search`, `editor.native.media.select`,
-  `editor.native.timeline.locate`
-- `editor.native.blade.preview`, `editor.native.blade.execute`
-- `project.inspect`
-- `timeline.inspect`
-- `timeline.changes`
-- `timeline.edit` (`rename-clip`, `trim-clip`, `set-gain`, `ripple-delete`, and `add-marker`)
-- `timeline.publish.new-project` (imports a verified FCPXML artifact as a new
-  Final Cut project when native writes are enabled)
-- `media.inspect`
-- `media.search`
-- `speech.analyze`
-- `audio.analyze`
-- `visual.analyze`
-- `media.understand`
-- `editor.assets` (queryable native asset registry)
-- `context.inspect`
-- `context.changes`
-- `edit.diff`
-- `edit.verify`
-- `edit.undo`
-
-The runtime core does not import MCP SDK packages. The stdio server is an
-adapter around `AgentVideoRuntime`, as required by the SDD.
-`FcpxmlDocumentAdapter` reads and writes an ordered FCPXML interchange
-artifact; it does not claim to mutate the open Final Cut session. The
-`FinalCutSessionAdapter` composes that snapshot/mutation provider with the
-live Workflow Extension provider. Set `FRAMEKIT_FCPXML_PATH` alongside
-`FRAMEKIT_EDITOR=final-cut-live` to enable canonical reads, artifact edits,
-read-after-write, diffs, verification, and undo.
-
-Final Cut analysis providers can be configured as local JSON commands with
-`FRAMEKIT_SPEECH_ANALYZER`, `FRAMEKIT_AUDIO_ANALYZER`, and
-`FRAMEKIT_VISUAL_ANALYZER`. Each command receives one JSON request on stdin
-and returns one typed JSON result on stdout. Set
-`FRAMEKIT_ANALYZER_TIMEOUT_MS` to change the default timeout. Installed Motion
-templates are indexed from standard locations; override them with the
-colon-separated `FRAMEKIT_FINAL_CUT_ASSET_ROOTS` variable.
-
-The live bridge uses the shared per-user sandbox endpoint
-`~/Library/Containers/com.framekit.finalcut.workflow.extension/Data/framekit.sock`
-(or the same explicit `FRAMEKIT_FINAL_CUT_SOCKET` override on both processes). It
-exposes live project/sequence metadata, playhead, selected range, and change
-events. The live Workflow Extension remains read-only; canonical timeline
-operations use the explicit FCPXML artifact path. Optional selection-scoped
-native UI edits are enabled only with `FRAMEKIT_FINAL_CUT_NATIVE_WRITES=1`
-and require macOS Accessibility/Automation permission. Editor, analyzer, and
-native capabilities are reported separately by `editor.inspect`.
-
-With native writes enabled, the live UI path can search the active Final Cut
-Browser, select a media result, locate a matching timeline occurrence, and
-prepare/execute a Blade-at-playhead operation. Media and timeline occurrence
-handles are short-lived and fail closed when Final Cut changes. Full canonical
-timeline edits remain FCPXML artifact edits; `timeline.publish.new-project`
-imports the verified artifact as a new project and never replaces the active
-project automatically.
-
-See [`docs/tests/final-cut-live-e2e.md`](docs/tests/final-cut-live-e2e.md) for
-the read-only Final Cut validation procedure.
+The default `.env.example` starts the Diffusers visual service without the optional music stack. `Cmd-D` toggles Developer Mode and `Cmd-F` toggles the borderless exhibition presentation.
 
 ## Connect Codex to Final Cut
 
@@ -107,29 +41,11 @@ Register the local MCP server with Codex:
 codex mcp add framekit -- framekit mcp --editor final-cut-live --headless
 ```
 
-Headless mode probes an already-running Workflow Extension socket and never
-launches, activates, focuses, or edits Final Cut Pro through Accessibility. It
-is suitable for live metadata reads and FCPXML artifact work. Native Blade,
-range deletion, duration trimming, and other UI edits remain unavailable in
-this mode; use the deterministic headless suite to validate those contracts.
+## Further Docs
 
-In normal (non-headless) mode, the live server automatically detects Final Cut
-Pro, installs a configured Workflow Extension artifact under the user's
-Applications directory, activates it, and reconnects when the socket
-disappears. Headless mode skips that lifecycle recovery and only probes the
-existing socket. Inspect setup progress with:
+- [Documentation index](./docs/README.md)
+- [Architecture](./docs/ARCHITECTURE.md)
 
-```sh
-framekit doctor finalcut --json
-```
+## Development
 
-For a development checkout, build and connect the native extension in one
-command:
-
-```sh
-framekit connect finalcut --development
-```
-
-The live connection fails closed for capabilities that Final Cut does not
-expose through the Workflow Extension. Native UI writes are a separate,
-explicitly enabled selection-scoped path.
+Contributor setup, including the local pre-commit hook, is documented in [`CONTRIBUTOR.md`](CONTRIBUTOR.md).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,27 @@
+# Architecture
+
+Framekit keeps the editor-independent runtime separate from MCP transport and
+Final Cut integration:
+
+```text
+Agent → MCP stdio → TypeScript runtime → adapter → local IPC → Swift extension → Final Cut Pro
+```
+
+The runtime owns domain types, context, transactions, diffs, editing, and
+verification. The MCP server only exposes those runtime contracts. Final Cut
+adapters provide FCPXML document access, live Workflow Extension state,
+optional local analysis providers, and explicitly guarded native UI actions.
+
+`FcpxmlDocumentAdapter` reads and writes an ordered FCPXML interchange artifact;
+it does not claim to mutate the open Final Cut session. The
+`FinalCutSessionAdapter` composes that document provider with live state and
+optional native capabilities. Live metadata and canonical timeline state are
+therefore separate surfaces, and unavailable capabilities must fail closed.
+
+Read the detailed architecture documents for the individual boundaries:
+
+- [Runtime boundaries](./architecture/runtime-boundaries.md)
+- [Backend selection](./architecture/backend-selection.md)
+- [Capability model](./architecture/capability-model.md)
+- [Software Design Description](./SDD.md)
+- [Architecture decision records](./adr/)

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,12 +2,14 @@
 
 This directory is the shareable knowledge base for Framekit.
 
+- [Getting started](./getting-started.md): development setup, MCP, and Final Cut connection.
 - [PRD](./PRD.md): product goals and roadmap.
 - [SDD](./SDD.md): architecture and design contracts.
 - [Compatibility](./COMPATIBILITY.md): verified editor and toolchain support.
 - [MCP](./mcp/README.md): agent-facing protocol and tools.
 - [Tests](./tests/README.md): reproducible checks and evidence.
 - [Final Cut](./final-cut/README.md): native integration and operations.
+- [Architecture overview](./ARCHITECTURE.md): runtime, MCP, and adapter boundaries.
 - [Architecture](./architecture/runtime-boundaries.md): runtime boundaries.
 - [ADRs](./adr/): durable implementation decisions.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,9 @@
 
 This directory is the shareable knowledge base for Framekit.
 
+Repository-local GitHub agent playbooks are documented in
+[`../.agents/README.md`](../.agents/README.md).
+
 - [Getting started](./getting-started.md): development setup, MCP, and Final Cut connection.
 - [PRD](./PRD.md): product goals and roadmap.
 - [SDD](./SDD.md): architecture and design contracts.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,110 @@
+# Getting Started
+
+Framekit is an agentic video editing runtime. Phase 2 extends the Phase 0
+read → write → read-after-write → diff loop with incremental context
+synchronization, visual analysis, combined media understanding, native asset
+discovery, and the Phase 1 Final Cut runtime.
+
+## Development setup
+
+Install the JavaScript dependencies and run the deterministic checks from the
+repository root:
+
+```sh
+pnpm install --frozen-lockfile
+pnpm run hooks:install
+pnpm run test
+pnpm run build
+pnpm run check:boundaries
+```
+
+The reproducible Node shell and native toolchain are provided by the
+repository's Nix shell:
+
+```sh
+nix develop ./nix
+pnpm run xcode:check
+```
+
+See [Contributing](../CONTRIBUTING.md) for repository layout, native build
+checks, and commit-hook behavior.
+
+## Run the local MCP server
+
+The default server uses the deterministic in-memory Phase 2 fixture and
+exposes the runtime over stdio:
+
+```sh
+pnpm run mcp
+```
+
+The complete tool inventory, including canonical timeline tools, analysis,
+context, verification, and native Final Cut tools, is documented in
+[MCP tools](./mcp/tools.md). The runtime core remains editor-independent; MCP
+is an adapter around it.
+
+For a live Final Cut session, select the live backend explicitly:
+
+```sh
+FRAMEKIT_EDITOR=final-cut-live pnpm run mcp
+```
+
+The live backend reports its capabilities separately. Live Workflow Extension
+state includes project/sequence metadata, playhead, selected range, and change
+events, but it is not a complete canonical timeline snapshot. Unsupported
+operations fail closed with an explicit capability error. See the
+[compatibility matrix](./COMPATIBILITY.md) and [live Final Cut guide](./mcp/final-cut-live.md).
+
+## Canonical documents and analysis providers
+
+Set `FRAMEKIT_FCPXML_PATH` with `FRAMEKIT_EDITOR=final-cut-live` to enable
+canonical project and timeline reads, FCPXML artifact edits,
+read-after-write, diffs, verification, and undo. The FCPXML artifact is
+managed explicitly; Framekit does not silently replace the open Final Cut
+project.
+
+Optional local JSON analysis providers are configured with:
+
+- `FRAMEKIT_SPEECH_ANALYZER`
+- `FRAMEKIT_AUDIO_ANALYZER`
+- `FRAMEKIT_VISUAL_ANALYZER`
+
+Each command receives one JSON request on stdin and returns one typed JSON
+result on stdout. Set `FRAMEKIT_ANALYZER_TIMEOUT_MS` to change the default
+timeout. Motion templates are discovered from standard locations; restrict
+those locations with the colon-separated `FRAMEKIT_FINAL_CUT_ASSET_ROOTS`
+variable. The complete provider setup is documented in the
+[Final Cut installation guide](./final-cut/installation.md).
+
+## Connect Codex to Final Cut
+
+Register the local MCP server with Codex in headless mode:
+
+```sh
+codex mcp add framekit -- framekit mcp --editor final-cut-live --headless
+```
+
+Headless mode probes an already-running Workflow Extension socket. It does
+not launch, activate, focus, or edit Final Cut through Accessibility. It is
+appropriate for live metadata reads and FCPXML artifact work; native UI edit
+contracts are validated by the deterministic headless suite.
+
+For normal development mode, build and connect the native extension with:
+
+```sh
+framekit connect finalcut --development
+```
+
+Inspect automatic setup and reconnect progress with:
+
+```sh
+framekit doctor finalcut --json
+```
+
+The live bridge uses the per-user socket at
+`~/Library/Containers/com.framekit.finalcut.workflow.extension/Data/framekit.sock`.
+Use `FRAMEKIT_FINAL_CUT_SOCKET` to provide the same explicit socket path to
+both processes. The Workflow Extension remains read-only for canonical
+timeline operations. Selection-scoped native UI edits require
+`FRAMEKIT_FINAL_CUT_NATIVE_WRITES=1` plus macOS Accessibility and Automation
+permission; see [live Final Cut operations](./mcp/final-cut-live.md).

--- a/tests/integration/agents-playbooks.test.ts
+++ b/tests/integration/agents-playbooks.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const playbooks = {
+  readme: [".agents/README.md", ["issue-create.md", "issue-read.md", "review-pr.md"]],
+  issueCreate: [".agents/issue-create.md", ["gh issue create", "explicit approval", ".github/ISSUE_TEMPLATE"]],
+  issueRead: [".agents/issue-read.md", ["gh issue view", "read-only", "recommended next action"]],
+  reviewPr: [".agents/review-pr.md", ["gh pr diff", "REQUEST_CHANGES", "APPROVE", "git push", "existing review comment"]],
+} as const;
+
+for (const [name, [relativePath, requiredText]] of Object.entries(playbooks)) {
+  test(`repository agent playbook ${name} is present and governed`, async () => {
+    const content = await readFile(resolve(relativePath), "utf8");
+    for (const expected of requiredText) {
+      assert.match(content, new RegExp(escapeRegExp(expected), "i"));
+    }
+  });
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}


### PR DESCRIPTION
Updated README to improve clarity and organization, including installation instructions and additional documentation links.

## Summary

<!-- What changed, and why? Link the issue or design decision when applicable. -->

## Scope

- [ ] Runtime or domain model
- [ ] MCP server
- [ ] Editor adapter
- [ ] Native Final Cut bridge
- [ ] Tests or fixtures
- [ ] Documentation

## Validation

<!-- List the commands you ran and summarize the result. -->

```text
pnpm run build
pnpm run test
pnpm run check:boundaries
```

Native changes should also include the relevant macOS/Xcode validation.

## Architecture and compatibility

- [ ] Runtime remains independent of MCP and editor-specific implementations.
- [ ] Public MCP behavior or package interfaces are documented if changed.
- [ ] Existing adapters and test fixtures remain compatible, or the migration is explained above.

## Safety

- [ ] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [ ] Generated files and build artifacts are excluded.
- [ ] Documentation reflects any changed commands, paths, or environment variables.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive Getting Started guide covering setup, validation, server usage, Final Cut workflows, diagnostics, and configuration.
  - Added architecture documentation describing system components, integrations, data access, and capability handling.
  - Updated documentation indexes and streamlined the main README with installation, Quick Start, shortcuts, and further-reading links.
- **Chores**
  - Added repository playbooks for issue management and pull-request reviews.
- **Tests**
  - Added checks confirming required playbooks and governance guidance are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->