### PR TITLE
feat: add reliable Final Cut media targeting

### DIFF
--- a/adapters/final-cut/typescript/src/native.ts
+++ b/adapters/final-cut/typescript/src/native.ts
@@ -26,6 +26,7 @@ export interface NativeFinalCutMediaMatch {
   name: string;
   role?: string;
   identity?: string;
+  sourceIdentity?: string;
   source?: string;
   browserContext?: string;
   uiIndex?: number;
@@ -38,6 +39,7 @@ export interface NativeFinalCutOccurrence {
   start?: string;
   duration?: string;
   timelineOffset?: number;
+  sourceIdentity?: string;
   role?: string;
   sequence?: string;
   sequenceId?: string;
@@ -499,6 +501,7 @@ export class FinalCutNativeAutomationAdapter implements NativeFinalCutEditor {
     this.assertEnabled();
     const match = this.mediaHandles.get(mediaHandle);
     if (!match) throw new Error(`FINAL_CUT_NATIVE_MEDIA_HANDLE_STALE: unknown media handle ${mediaHandle}`);
+    if (!match.sourceIdentity) throw new Error("FINAL_CUT_NATIVE_MEDIA_ID_UNAVAILABLE: Browser result has no shared source-media identifier");
     const context = await this.requireTimelineContext();
     if (!context.frontmost) throw new Error("FINAL_CUT_NATIVE_NOT_FRONTMOST: Final Cut's timeline must be frontmost");
     try {
@@ -1411,9 +1414,13 @@ function searchMediaScript(query: string): string {
           set browserRole to candidateRole is "AXBrowserMedia" or candidateRole is "AXRow" or candidateRole is "AXCell" or candidateRole is "AXButton"
           if candidateName is not "" and browserRegion and (browserRole or candidateDescription contains "Browser" or candidateDescription contains "browser") then
             set candidateIdentity to (candidatePosition as text) & "|" & ((size of candidate) as text)
+            set candidateSourceIdentity to ""
+            try
+              set candidateSourceIdentity to value of attribute "AXIdentifier" of candidate as text
+            end try
             if candidateName contains searchQuery and seenIdentities does not contain candidateIdentity then
               set end of seenIdentities to candidateIdentity
-              set output to output & candidateName & (ASCII character 31) & candidateRole & (ASCII character 31) & candidateIdentity & (ASCII character 30)
+              set output to output & candidateName & (ASCII character 31) & candidateRole & (ASCII character 31) & candidateIdentity & (ASCII character 31) & candidateSourceIdentity & (ASCII character 30)
             end if
           end if
         on error
@@ -1469,6 +1476,8 @@ function locateOccurrenceScript(match: NativeFinalCutMediaMatch, scanAll: boolea
   tell application "System Events"
   tell process "Final Cut Pro"
     ${requireFrontmostAppleScript()}
+    set sourceIdentity to ${appleScriptString(match.sourceIdentity ?? "")}
+    if sourceIdentity is "" then error "FINAL_CUT_NATIVE_MEDIA_ID_UNAVAILABLE: timeline lookup requires a shared source-media identifier"
     set mainWindow to window "Final Cut Pro"
     set origin to position of mainWindow
     set timelineSelection to click at {(item 1 of origin) + 800, (item 2 of origin) + 650}
@@ -1485,9 +1494,13 @@ function locateOccurrenceScript(match: NativeFinalCutMediaMatch, scanAll: boolea
         set candidateRole to role of candidate as text
         set candidateName to value of candidate as text
         set candidateIdentity to ((position of candidate) as text) & "|" & ((size of candidate) as text)
-        if candidateName is ${appleScriptString(match.name)} then
+        set candidateSourceIdentity to ""
+        try
+          set candidateSourceIdentity to value of attribute "AXIdentifier" of candidate as text
+        end try
+        if candidateSourceIdentity is sourceIdentity then
           if candidateIdentity is not lastMatchIdentity then
-            set output to output & candidateName & (ASCII character 31) & candidateRole & (ASCII character 31) & candidateIdentity & (ASCII character 31) & (xOffset as text) & (ASCII character 30)
+            set output to output & candidateName & (ASCII character 31) & candidateRole & (ASCII character 31) & candidateSourceIdentity & (ASCII character 31) & (xOffset as text) & (ASCII character 30)
           end if
           set lastMatchIdentity to candidateIdentity
           set inMatch to true
@@ -1685,12 +1698,13 @@ function parseMediaMatches(output: string): NativeFinalCutMediaMatch[] {
     .map((record) => record.trim())
     .filter(Boolean)
     .map((record, index) => {
-      const [name = "", role = "", identity = ""] = record.split(String.fromCharCode(31));
+      const [name = "", role = "", identity = "", sourceIdentity = ""] = record.split(String.fromCharCode(31));
       return {
         handle: opaqueHandle("media", index),
         name,
         ...(role ? { role } : {}),
         ...(identity ? { identity } : {}),
+        ...(sourceIdentity ? { sourceIdentity } : {}),
         uiIndex: index,
       };
     });
@@ -1702,17 +1716,17 @@ function parseOccurrences(output: string, mediaHandle: string): NativeFinalCutOc
     .map((record) => record.trim())
     .filter(Boolean)
     .map((record, index) => {
-      const [name = "", role = "", identityOrStart = "", timelineOffsetOrDuration = "", legacyTimelineOffset] = record.split(String.fromCharCode(31));
+      const [name = "", role = "", sourceIdentity = "", timelineOffsetOrDuration = "", legacyTimelineOffset] = record.split(String.fromCharCode(31));
       const legacyRecord = legacyTimelineOffset !== undefined;
-      const identity = legacyRecord ? "" : identityOrStart;
+      const identityOrStart = sourceIdentity;
       const timelineOffsetText = legacyRecord ? legacyTimelineOffset : timelineOffsetOrDuration;
-      const legacyRange = !legacyRecord && isRational(identityOrStart) && isRational(timelineOffsetOrDuration);
+      const legacyRange = legacyRecord || (!legacyRecord && isRational(identityOrStart) && isRational(timelineOffsetOrDuration));
       return {
         handle: opaqueHandle("occurrence", index),
         mediaHandle,
         name,
         ...(role ? { role } : {}),
-        ...(identity ? { identity } : {}),
+        ...(sourceIdentity && !legacyRange ? { sourceIdentity } : {}),
         ...(legacyRange ? { start: identityOrStart, duration: timelineOffsetOrDuration } : {}),
         ...(timelineOffsetText && Number.isFinite(Number(timelineOffsetText)) ? { timelineOffset: Number(timelineOffsetText) } : {}),
       };

--- a/adapters/final-cut/typescript/src/native.ts
+++ b/adapters/final-cut/typescript/src/native.ts
@@ -1530,7 +1530,7 @@ async function selectTimelineOccurrence(executor: (script: string) => Promise<st
     throw new Error("FINAL_CUT_NATIVE_AUTOMATION_FAILED: could not resolve Final Cut window coordinates");
   }
   const x = Math.round(originX + timelineOffset);
-  const y = Math.round(originY + 670);
+  const y = Math.round(originY + 650);
   try {
     await execFile("swift", ["-e", nativeMouseSelectionSource(x, y)]);
   } catch (error) {

--- a/adapters/final-cut/typescript/src/native.ts
+++ b/adapters/final-cut/typescript/src/native.ts
@@ -25,6 +25,7 @@ export interface NativeFinalCutMediaMatch {
   handle: string;
   name: string;
   role?: string;
+  identity?: string;
   source?: string;
   browserContext?: string;
   uiIndex?: number;
@@ -469,12 +470,15 @@ export class FinalCutNativeAutomationAdapter implements NativeFinalCutEditor {
 
     const media = matches[0]!;
     await this.selectMediaNative(media.handle);
-    const located = await this.locateOccurrenceNative(media.handle);
+    const located = await this.locateOccurrenceNative(media.handle, true);
     if (located.status === "none") {
       throw new Error("FINAL_CUT_NATIVE_OCCURRENCE_NOT_FOUND: selected Browser media has no timeline occurrence");
     }
     if (located.status === "ambiguous") {
       throw new Error("FINAL_CUT_NATIVE_AMBIGUOUS_TARGET: media has multiple timeline occurrences");
+    }
+    if (located.occurrences[0]?.timelineOffset === undefined) {
+      throw new Error("FINAL_CUT_NATIVE_OCCURRENCE_POSITION_UNAVAILABLE: unique timeline occurrence has no selectable position");
     }
 
     const live = await this.readLiveState();
@@ -491,16 +495,20 @@ export class FinalCutNativeAutomationAdapter implements NativeFinalCutEditor {
     };
   }
 
-  private async locateOccurrenceNative(mediaHandle: string): Promise<NativeFinalCutOccurrenceSearchResult> {
+  private async locateOccurrenceNative(mediaHandle: string, scanAll = false): Promise<NativeFinalCutOccurrenceSearchResult> {
     this.assertEnabled();
     const match = this.mediaHandles.get(mediaHandle);
     if (!match) throw new Error(`FINAL_CUT_NATIVE_MEDIA_HANDLE_STALE: unknown media handle ${mediaHandle}`);
     const context = await this.requireTimelineContext();
     if (!context.frontmost) throw new Error("FINAL_CUT_NATIVE_NOT_FRONTMOST: Final Cut's timeline must be frontmost");
     try {
-      const occurrences = parseOccurrences(await this.executor(locateOccurrenceScript(match, false)), mediaHandle);
+      const occurrences = parseOccurrences(await this.executor(locateOccurrenceScript(match, scanAll)), mediaHandle);
       if (occurrences.length === 1 && this.canDriveNativeMouse) {
-        await selectTimelineOccurrence(this.executor, occurrences[0]?.timelineOffset ?? 800);
+        const timelineOffset = occurrences[0]?.timelineOffset;
+        if (timelineOffset === undefined) {
+          throw new Error("FINAL_CUT_NATIVE_OCCURRENCE_POSITION_UNAVAILABLE: unique timeline occurrence has no selectable position");
+        }
+        await selectTimelineOccurrence(this.executor, timelineOffset);
       }
       const live = this.liveState ? await this.liveState().catch(() => undefined) : undefined;
       for (const occurrence of occurrences) {
@@ -1378,7 +1386,44 @@ function searchMediaScript(query: string): string {
       set value of attribute "AXFocused" of searchField to true
     end try
     delay 0.5
-    return ${appleScriptString(query)} & (ASCII character 31) & "AXBrowserMedia" & (ASCII character 30)
+    set output to ""
+    set seenIdentities to {}
+    try
+      repeat with candidate in entire contents of mainWindow
+        try
+          set candidateRole to role of candidate as text
+          set candidateName to ""
+          try
+            set candidateName to value of candidate as text
+          end try
+          if candidateName is "" then
+            try
+              set candidateName to name of candidate as text
+            end try
+          end if
+          set candidateDescription to ""
+          try
+            set candidateDescription to description of candidate as text
+          end try
+          set candidatePosition to position of candidate
+          set candidateY to item 2 of candidatePosition
+          set browserRegion to candidateY < ((item 2 of origin) + 500)
+          set browserRole to candidateRole is "AXBrowserMedia" or candidateRole is "AXRow" or candidateRole is "AXCell" or candidateRole is "AXButton"
+          if candidateName is not "" and browserRegion and (browserRole or candidateDescription contains "Browser" or candidateDescription contains "browser") then
+            set candidateIdentity to (candidatePosition as text) & "|" & ((size of candidate) as text)
+            if candidateName contains searchQuery and seenIdentities does not contain candidateIdentity then
+              set end of seenIdentities to candidateIdentity
+              set output to output & candidateName & (ASCII character 31) & candidateRole & (ASCII character 31) & candidateIdentity & (ASCII character 30)
+            end if
+          end if
+        on error
+          -- Ignore inaccessible descendants and continue enumerating Browser results.
+        end try
+      end repeat
+    on error
+      error "FINAL_CUT_NATIVE_SEARCH_UNAVAILABLE: Browser media results were not accessible"
+    end try
+    return output
   end tell
 end tell`;
 }
@@ -1398,8 +1443,20 @@ tell application "System Events"
       set value of attribute "AXFocused" of searchField to true
     end try
     delay 0.5
-    click at {(item 1 of origin) + 275, (item 2 of origin) + 185}
-    return "selected"
+    set targetIdentity to ${appleScriptString(match.identity ?? "")}
+    if targetIdentity is "" then error "FINAL_CUT_NATIVE_MEDIA_SELECTION_UNAVAILABLE: Browser result has no stable identity"
+    repeat with candidate in entire contents of mainWindow
+      try
+        set candidateIdentity to ((position of candidate) as text) & "|" & ((size of candidate) as text)
+        if candidateIdentity is targetIdentity then
+          perform action "AXPress" of candidate
+          return "selected"
+        end if
+      on error
+        -- Ignore inaccessible descendants and continue looking for the target.
+      end try
+    end repeat
+    error "FINAL_CUT_NATIVE_MEDIA_SELECTION_UNAVAILABLE: Browser result could not be selected"
   end tell
 end tell`;
 }
@@ -1628,11 +1685,12 @@ function parseMediaMatches(output: string): NativeFinalCutMediaMatch[] {
     .map((record) => record.trim())
     .filter(Boolean)
     .map((record, index) => {
-      const [name = "", role = ""] = record.split(String.fromCharCode(31));
+      const [name = "", role = "", identity = ""] = record.split(String.fromCharCode(31));
       return {
         handle: opaqueHandle("media", index),
         name,
         ...(role ? { role } : {}),
+        ...(identity ? { identity } : {}),
         uiIndex: index,
       };
     });
@@ -1644,17 +1702,25 @@ function parseOccurrences(output: string, mediaHandle: string): NativeFinalCutOc
     .map((record) => record.trim())
     .filter(Boolean)
     .map((record, index) => {
-      const [name = "", role = "", start, duration, timelineOffsetText] = record.split(String.fromCharCode(31));
+      const [name = "", role = "", identityOrStart = "", timelineOffsetOrDuration = "", legacyTimelineOffset] = record.split(String.fromCharCode(31));
+      const legacyRecord = legacyTimelineOffset !== undefined;
+      const identity = legacyRecord ? "" : identityOrStart;
+      const timelineOffsetText = legacyRecord ? legacyTimelineOffset : timelineOffsetOrDuration;
+      const legacyRange = !legacyRecord && isRational(identityOrStart) && isRational(timelineOffsetOrDuration);
       return {
         handle: opaqueHandle("occurrence", index),
         mediaHandle,
         name,
         ...(role ? { role } : {}),
-        ...(start ? { start } : {}),
-        ...(duration ? { duration } : {}),
+        ...(identity ? { identity } : {}),
+        ...(legacyRange ? { start: identityOrStart, duration: timelineOffsetOrDuration } : {}),
         ...(timelineOffsetText && Number.isFinite(Number(timelineOffsetText)) ? { timelineOffset: Number(timelineOffsetText) } : {}),
       };
     });
+}
+
+function isRational(value: string): boolean {
+  return /^-?\d+\/\d+$/.test(value);
 }
 
 function opaqueHandle(kind: string, suffix?: number): string {

--- a/adapters/final-cut/typescript/src/native.ts
+++ b/adapters/final-cut/typescript/src/native.ts
@@ -36,6 +36,7 @@ export interface NativeFinalCutOccurrence {
   name: string;
   start?: string;
   duration?: string;
+  timelineOffset?: number;
   role?: string;
   sequence?: string;
   sequenceId?: string;
@@ -46,6 +47,15 @@ export interface NativeFinalCutOccurrence {
 export interface NativeFinalCutOccurrenceSearchResult {
   status: "none" | "unique" | "ambiguous";
   occurrences: NativeFinalCutOccurrence[];
+}
+
+export interface NativeFinalCutTargetResult {
+  query: string;
+  status: "unique";
+  media: NativeFinalCutMediaMatch;
+  occurrence: NativeFinalCutOccurrence;
+  selected: boolean;
+  playheadTime?: string;
 }
 
 export interface NativeFinalCutBladePreview {
@@ -210,6 +220,7 @@ export interface NativeFinalCutEditor {
   searchMedia(query: string): Promise<NativeFinalCutMediaMatch[]>;
   selectMedia(handle: string): Promise<NativeFinalCutContext>;
   locateOccurrence(mediaHandle: string): Promise<NativeFinalCutOccurrenceSearchResult>;
+  targetMedia(query: string): Promise<NativeFinalCutTargetResult>;
   previewBlade(occurrenceHandle: string): Promise<NativeFinalCutBladePreview>;
   executeBlade(previewToken: string): Promise<NativeFinalCutBladeResult>;
   previewDeleteRange(range: NativeFinalCutRange): Promise<NativeFinalCutRangePreview>;
@@ -446,6 +457,40 @@ export class FinalCutNativeAutomationAdapter implements NativeFinalCutEditor {
     return this.withNativeUi(() => this.locateOccurrenceNative(mediaHandle));
   }
 
+  public async targetMedia(query: string): Promise<NativeFinalCutTargetResult> {
+    return this.withNativeUi(() => this.targetMediaNative(query));
+  }
+
+  private async targetMediaNative(query: string): Promise<NativeFinalCutTargetResult> {
+    this.assertEnabled();
+    const matches = await this.searchMediaNative(query);
+    if (matches.length === 0) throw new Error("FINAL_CUT_NATIVE_MEDIA_NOT_FOUND: no Browser media matched the query");
+    if (matches.length > 1) throw new Error("FINAL_CUT_NATIVE_AMBIGUOUS_TARGET: media query matched multiple Browser items");
+
+    const media = matches[0]!;
+    await this.selectMediaNative(media.handle);
+    const located = await this.locateOccurrenceNative(media.handle);
+    if (located.status === "none") {
+      throw new Error("FINAL_CUT_NATIVE_OCCURRENCE_NOT_FOUND: selected Browser media has no timeline occurrence");
+    }
+    if (located.status === "ambiguous") {
+      throw new Error("FINAL_CUT_NATIVE_AMBIGUOUS_TARGET: media has multiple timeline occurrences");
+    }
+
+    const live = await this.readLiveState();
+    if (!live?.playheadTime) {
+      throw new Error("FINAL_CUT_NATIVE_PLAYHEAD_UNAVAILABLE: deterministic targeting requires live playhead state");
+    }
+    return {
+      query,
+      status: "unique",
+      media,
+      occurrence: located.occurrences[0]!,
+      selected: true,
+      playheadTime: `${live.playheadTime.value}/${live.playheadTime.timescale}`,
+    };
+  }
+
   private async locateOccurrenceNative(mediaHandle: string): Promise<NativeFinalCutOccurrenceSearchResult> {
     this.assertEnabled();
     const match = this.mediaHandles.get(mediaHandle);
@@ -455,7 +500,7 @@ export class FinalCutNativeAutomationAdapter implements NativeFinalCutEditor {
     try {
       const occurrences = parseOccurrences(await this.executor(locateOccurrenceScript(match, false)), mediaHandle);
       if (occurrences.length === 1 && this.canDriveNativeMouse) {
-        await selectTimelineClipAtPlayhead(this.executor);
+        await selectTimelineOccurrence(this.executor, occurrences[0]?.timelineOffset ?? 800);
       }
       const live = this.liveState ? await this.liveState().catch(() => undefined) : undefined;
       for (const occurrence of occurrences) {
@@ -1385,7 +1430,7 @@ function locateOccurrenceScript(match: NativeFinalCutMediaMatch, scanAll: boolea
         set candidateIdentity to ((position of candidate) as text) & "|" & ((size of candidate) as text)
         if candidateName is ${appleScriptString(match.name)} then
           if candidateIdentity is not lastMatchIdentity then
-            set output to output & candidateName & (ASCII character 31) & candidateRole & (ASCII character 31) & candidateIdentity & (ASCII character 30)
+            set output to output & candidateName & (ASCII character 31) & candidateRole & (ASCII character 31) & candidateIdentity & (ASCII character 31) & (xOffset as text) & (ASCII character 30)
           end if
           set lastMatchIdentity to candidateIdentity
           set inMatch to true
@@ -1408,13 +1453,13 @@ function locateOccurrenceScript(match: NativeFinalCutMediaMatch, scanAll: boolea
 end tell`;
 }
 
-async function selectTimelineClipAtPlayhead(executor: (script: string) => Promise<string>): Promise<void> {
+async function selectTimelineOccurrence(executor: (script: string) => Promise<string>, timelineOffset: number): Promise<void> {
   const coordinates = (await executor(timelineSelectionCoordinatesScript())).split("|").map(Number);
   const [originX, originY] = coordinates;
   if (!Number.isFinite(originX) || !Number.isFinite(originY)) {
     throw new Error("FINAL_CUT_NATIVE_AUTOMATION_FAILED: could not resolve Final Cut window coordinates");
   }
-  const x = Math.round(originX + 800);
+  const x = Math.round(originX + timelineOffset);
   const y = Math.round(originY + 670);
   try {
     await execFile("swift", ["-e", nativeMouseSelectionSource(x, y)]);
@@ -1599,7 +1644,7 @@ function parseOccurrences(output: string, mediaHandle: string): NativeFinalCutOc
     .map((record) => record.trim())
     .filter(Boolean)
     .map((record, index) => {
-      const [name = "", role = "", start, duration] = record.split(String.fromCharCode(31));
+      const [name = "", role = "", start, duration, timelineOffsetText] = record.split(String.fromCharCode(31));
       return {
         handle: opaqueHandle("occurrence", index),
         mediaHandle,
@@ -1607,6 +1652,7 @@ function parseOccurrences(output: string, mediaHandle: string): NativeFinalCutOc
         ...(role ? { role } : {}),
         ...(start ? { start } : {}),
         ...(duration ? { duration } : {}),
+        ...(timelineOffsetText && Number.isFinite(Number(timelineOffsetText)) ? { timelineOffset: Number(timelineOffsetText) } : {}),
       };
     });
 }

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -157,6 +157,14 @@ export function createMcpServer(runtime: AgentVideoRuntime, options: McpServerOp
     return jsonResult(await options.nativeEditor.locateOccurrence(mediaHandle));
   });
 
+  server.registerTool("editor.native.media.target", {
+    description: "Search Final Cut's Browser and target exactly one timeline occurrence with a deterministic live playhead.",
+    inputSchema: { query: z.string().min(1) },
+  }, async ({ query }) => {
+    if (!options.nativeEditor) throw new Error("CAPABILITY_UNAVAILABLE: Final Cut native media targeting is not configured");
+    return jsonResult(await options.nativeEditor.targetMedia(query));
+  });
+
   server.registerTool("editor.native.blade.preview", {
     description: "Prepare a short-lived confirmation token for a Blade-at-playhead operation.",
     inputSchema: { occurrenceHandle: z.string().min(1) },

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -45,7 +45,7 @@ timeline occurrence, and Blade it at the playhead. These operations use
 short-lived handles and are not canonical timeline identities. The combined
 `editor.native.media.target` operation additionally requires live playhead
 state so it can report the deterministic target it selected; missing or
-ambiguous targets fail closed.
+ambiguous targets, or missing shared source-media identifiers, fail closed.
 
 When both `FRAMEKIT_FCPXML_PATH` and native writes are configured,
 `timelinePublishNewProject` allows a verified artifact to be imported as a new

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -42,7 +42,10 @@ automation, require `FRAMEKIT_FINAL_CUT_NATIVE_WRITES=1`, and do not change the
 canonical `timelineWrite` or `timelineSnapshotRead` capability flags. With the
 same opt-in, the native path can search the active Browser, locate a unique
 timeline occurrence, and Blade it at the playhead. These operations use
-short-lived handles and are not canonical timeline identities.
+short-lived handles and are not canonical timeline identities. The combined
+`editor.native.media.target` operation additionally requires live playhead
+state so it can report the deterministic target it selected; missing or
+ambiguous targets fail closed.
 
 When both `FRAMEKIT_FCPXML_PATH` and native writes are configured,
 `timelinePublishNewProject` allows a verified artifact to be imported as a new

--- a/docs/mcp/final-cut-live.md
+++ b/docs/mcp/final-cut-live.md
@@ -103,8 +103,9 @@ case where an agent has a media query and needs one safe timeline target. It
 performs Browser search, media selection, unique-occurrence lookup, and
 timeline selection as one bounded operation. Success returns the selected
 media, occurrence handle, and observed live `playheadTime`. Missing or
-ambiguous media/occurrences, or unavailable live playhead state, fail closed
-with distinct errors.
+ambiguous media/occurrences, unavailable shared source-media identifiers, or
+unavailable live playhead state, fail closed with distinct errors. Same-name
+media is never used as a fallback for timeline targeting.
 
 For a stepwise workflow, use the live UI workflow in this order:
 

--- a/docs/mcp/final-cut-live.md
+++ b/docs/mcp/final-cut-live.md
@@ -98,7 +98,15 @@ cannot be minimized returns `FINAL_CUT_NATIVE_OVERLAY_BLOCKED`.
 
 ## Live Browser search and Blade
 
-With native writes enabled, use the live UI workflow in this order:
+With native writes enabled, use `editor.native.media.target` for the common
+case where an agent has a media query and needs one safe timeline target. It
+performs Browser search, media selection, unique-occurrence lookup, and
+timeline selection as one bounded operation. Success returns the selected
+media, occurrence handle, and observed live `playheadTime`. Missing or
+ambiguous media/occurrences, or unavailable live playhead state, fail closed
+with distinct errors.
+
+For a stepwise workflow, use the live UI workflow in this order:
 
 1. Call `editor.native.media.search` with a Browser query.
 2. Call `editor.native.media.select` with one returned `mediaHandle`.

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -13,6 +13,7 @@
 | `editor.native.media.search` | Search the active Final Cut Browser | Returns short-lived media handles; native writes required |
 | `editor.native.media.select` | Select a Browser result by handle | Fails if the result or selection cannot be verified |
 | `editor.native.timeline.locate` | Locate timeline occurrences for a Browser result | Requires exactly one match and timeline focus before automatic editing |
+| `editor.native.media.target` | Search Browser media and target one timeline occurrence | Fails closed for missing/ambiguous media or occurrences; requires live playhead state |
 | `editor.native.blade.preview` | Prepare a Blade-at-playhead preview token | Token expires and is bound to the occurrence |
 | `editor.native.blade.execute` | Execute a previewed Blade-at-playhead operation | Requires frontmost, timeline-focused Final Cut and post-command verification |
 | `editor.native.delete-range.preview` | Preview a primary-storyline ripple delete for a rational time range | Destructive; requires explicit execute and timeline focus |

--- a/tests/integration/mcp.test.ts
+++ b/tests/integration/mcp.test.ts
@@ -52,6 +52,7 @@ test("Phase 0 exposes read/write/diff through MCP stdio", async () => {
         "editor.native.inspect",
         "editor.native.media.search",
         "editor.native.media.select",
+        "editor.native.media.target",
         "editor.native.timeline.locate",
         "editor.native.trim-to-duration.execute",
         "editor.native.trim-to-duration.preview",

--- a/tests/integration/media-targeting.test.ts
+++ b/tests/integration/media-targeting.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { AgentVideoRuntime } from "@framekit/runtime";
+import { InMemoryEditorAdapter } from "@framekit/testkit";
+import { createMcpServer } from "../../apps/mcp-server/src/server.js";
+import type { NativeFinalCutEditor } from "@framekit/final-cut";
+
+function textFrom(result: unknown): string {
+  const content = (result as { content?: unknown }).content;
+  assert.ok(Array.isArray(content));
+  const text = (content[0] as { text?: unknown } | undefined)?.text;
+  assert.equal(typeof text, "string");
+  return text as string;
+}
+
+function makeRuntime(): AgentVideoRuntime {
+  return new AgentVideoRuntime(new InMemoryEditorAdapter({
+    projectId: "project-1",
+    projectName: "Targeting Test",
+    timelineId: "timeline-1",
+    timelineName: "Main Edit",
+    clips: [],
+    media: [],
+  }));
+}
+
+test("MCP targets one live media occurrence and reports the deterministic playhead", async () => {
+  const nativeEditor = {
+    capabilities: () => ({
+      selectionEdit: true,
+      undo: true,
+      mediaLibrarySearch: true,
+      mediaSelection: true,
+      timelineOccurrenceLocate: true,
+      bladeAtPlayhead: true,
+      deleteRange: true,
+      trimToDuration: true,
+      timelineFocus: true,
+      requiresAccessibility: true as const,
+      requiresFinalCutFrontmost: true as const,
+    }),
+    targetMedia: async (query: string) => ({
+      query,
+      status: "unique" as const,
+      media: { handle: "media-1", name: "Interview.mov", role: "AXBrowserMedia" },
+      occurrence: {
+        handle: "occurrence-1",
+        mediaHandle: "media-1",
+        name: "Interview.mov",
+        start: "24000/24000",
+        duration: "48000/24000",
+      },
+      selected: true,
+      playheadTime: "24000/24000",
+    }),
+  } as unknown as NativeFinalCutEditor;
+  const server = createMcpServer(makeRuntime(), { nativeEditor });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "media-targeting-test", version: "0.1.0" });
+
+  try {
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    const tools = await client.listTools();
+    assert.ok(tools.tools.some((tool) => tool.name === "editor.native.media.target"));
+
+    const result = await client.callTool({
+      name: "editor.native.media.target",
+      arguments: { query: "Interview" },
+    });
+    const payload = JSON.parse(textFrom(result));
+    assert.equal(payload.status, "unique");
+    assert.equal(payload.media.handle, "media-1");
+    assert.equal(payload.occurrence.handle, "occurrence-1");
+    assert.equal(payload.selected, true);
+    assert.equal(payload.playheadTime, "24000/24000");
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
+
+test("MCP exposes distinct fail-closed media targeting errors", async () => {
+  const nativeEditor = {
+    capabilities: () => ({
+      selectionEdit: true,
+      undo: true,
+      mediaLibrarySearch: true,
+      mediaSelection: true,
+      timelineOccurrenceLocate: true,
+      bladeAtPlayhead: true,
+      deleteRange: true,
+      trimToDuration: true,
+      timelineFocus: true,
+      requiresAccessibility: true as const,
+      requiresFinalCutFrontmost: true as const,
+    }),
+    targetMedia: async (query: string) => {
+      throw new Error(query === "missing"
+        ? "FINAL_CUT_NATIVE_MEDIA_NOT_FOUND: no Browser media matched the query"
+        : "FINAL_CUT_NATIVE_AMBIGUOUS_TARGET: media query matched multiple timeline targets");
+    },
+  } as unknown as NativeFinalCutEditor;
+  const server = createMcpServer(makeRuntime(), { nativeEditor });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "media-targeting-errors-test", version: "0.1.0" });
+
+  try {
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    const missing = await client.callTool({
+      name: "editor.native.media.target",
+      arguments: { query: "missing" },
+    });
+    const ambiguous = await client.callTool({
+      name: "editor.native.media.target",
+      arguments: { query: "ambiguous" },
+    });
+    assert.equal(missing.isError, true);
+    assert.match(textFrom(missing), /FINAL_CUT_NATIVE_MEDIA_NOT_FOUND/);
+    assert.equal(ambiguous.isError, true);
+    assert.match(textFrom(ambiguous), /FINAL_CUT_NATIVE_AMBIGUOUS_TARGET/);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});

--- a/tests/integration/native.test.ts
+++ b/tests/integration/native.test.ts
@@ -836,6 +836,71 @@ test("native Final Cut adapter searches, locates, previews, and verifies a Blade
   assert.equal(scripts.filter((script) => script.includes("timelineWindowAvailable")).length >= 3, true);
 });
 
+test("native Final Cut adapter targets one media occurrence and reports live playhead state", async () => {
+  const separator = String.fromCharCode(31);
+  const recordSeparator = String.fromCharCode(30);
+  const liveState = async () => ({
+    project: { id: "project-1", name: "Edit" },
+    sequence: { id: "sequence-1", name: "Edit", startTime: { value: "0", timescale: "1" }, duration: { value: "20", timescale: "1" }, frameDuration: { value: "1", timescale: "24" } },
+    playheadTime: { value: "1", timescale: "1" },
+    sequenceTimeRange: { start: { value: "0", timescale: "1" }, duration: { value: "20", timescale: "1" } },
+    revision: { id: "rev-1", sequence: 1, timestamp: new Date(0).toISOString() },
+  });
+  const scripts: string[] = [];
+  const adapter = new FinalCutNativeAutomationAdapter({
+    enabled: true,
+    liveState,
+    executor: async (script) => {
+      scripts.push(script);
+      if (script.includes('set frontWindow to window "Final Cut Pro"')) return context(true, "Final Cut Pro", "Interview.mov", 1, true);
+      if (script.includes("AXBrowserMedia")) return `Interview.mov${separator}AXBrowserMedia${recordSeparator}`;
+      if (script.includes("set output to \"\"")) return `Interview.mov${separator}AXRow${separator}clip-1${separator}10/1${separator}800${recordSeparator}`;
+      return "";
+    },
+  });
+
+  const target = await adapter.targetMedia("Interview");
+  assert.equal(target.status, "unique");
+  assert.equal(target.media.name, "Interview.mov");
+  assert.equal(target.occurrence.timelineOffset, 800);
+  assert.equal(target.selected, true);
+  assert.equal(target.playheadTime, "1/1");
+  assert.equal(scripts.some((script) => script.includes("set value of searchField")), true);
+  assert.equal(scripts.some((script) => script.includes("xOffset")), true);
+});
+
+test("native Final Cut media targeting rejects missing and ambiguous targets", async () => {
+  const separator = String.fromCharCode(31);
+  const recordSeparator = String.fromCharCode(30);
+  const liveState = async () => ({
+    project: { id: "project-1", name: "Edit" },
+    sequence: { id: "sequence-1", name: "Edit", startTime: { value: "0", timescale: "1" }, duration: { value: "20", timescale: "1" }, frameDuration: { value: "1", timescale: "24" } },
+    playheadTime: { value: "1", timescale: "1" },
+    sequenceTimeRange: { start: { value: "0", timescale: "1" }, duration: { value: "20", timescale: "1" } },
+    revision: { id: "rev-1", sequence: 1, timestamp: new Date(0).toISOString() },
+  });
+  const makeAdapter = (browserOutput: string, occurrenceOutput = `Interview${separator}AXRow${separator}clip-1${separator}10/1${separator}800${recordSeparator}`) => new FinalCutNativeAutomationAdapter({
+    enabled: true,
+    liveState,
+    executor: async (script) => {
+      if (script.includes('set frontWindow to window "Final Cut Pro"')) return context(true, "Final Cut Pro", "Interview", 1, true);
+      if (script.includes("AXBrowserMedia")) return browserOutput;
+      if (script.includes("set output to \"\"")) return occurrenceOutput;
+      return "";
+    },
+  });
+
+  await assert.rejects(makeAdapter("").targetMedia("missing"), /FINAL_CUT_NATIVE_MEDIA_NOT_FOUND/);
+  await assert.rejects(
+    makeAdapter(`Interview${separator}AXBrowserMedia${recordSeparator}Interview copy${separator}AXBrowserMedia${recordSeparator}`).targetMedia("ambiguous"),
+    /FINAL_CUT_NATIVE_AMBIGUOUS_TARGET/,
+  );
+  await assert.rejects(
+    makeAdapter(`Interview${separator}AXBrowserMedia${recordSeparator}`, `${"Interview"}${separator}AXRow${separator}one${recordSeparator}Interview${separator}AXRow${separator}two${recordSeparator}`).targetMedia("duplicate"),
+    /FINAL_CUT_NATIVE_AMBIGUOUS_TARGET/,
+  );
+});
+
 test("native Final Cut refuses a Blade retry without live state", async () => {
   const recordSeparator = String.fromCharCode(30);
   let bladeCalls = 0;

--- a/tests/integration/native.test.ts
+++ b/tests/integration/native.test.ts
@@ -853,8 +853,8 @@ test("native Final Cut adapter targets one media occurrence and reports live pla
     executor: async (script) => {
       scripts.push(script);
       if (script.includes('set frontWindow to window "Final Cut Pro"')) return context(true, "Final Cut Pro", "Interview.mov", 1, true);
-      if (script.includes("AXBrowserMedia")) return `Interview.mov${separator}AXBrowserMedia${recordSeparator}`;
-      if (script.includes("set output to \"\"")) return `Interview.mov${separator}AXRow${separator}clip-1${separator}10/1${separator}800${recordSeparator}`;
+      if (script.includes("AXBrowserMedia")) return `Interview.mov${separator}AXBrowserMedia${separator}browser-1${recordSeparator}`;
+      if (script.includes("set output to \"\"")) return `Interview.mov${separator}AXRow${separator}clip-1${separator}800${recordSeparator}`;
       return "";
     },
   });
@@ -866,7 +866,11 @@ test("native Final Cut adapter targets one media occurrence and reports live pla
   assert.equal(target.selected, true);
   assert.equal(target.playheadTime, "1/1");
   assert.equal(scripts.some((script) => script.includes("set value of searchField")), true);
-  assert.equal(scripts.some((script) => script.includes("xOffset")), true);
+  assert.equal(scripts.some((script) => script.includes("set browserRegion to") && script.includes("AXRow")), true);
+  const occurrenceScript = scripts.find((script) => script.includes("xOffset"));
+  assert.ok(occurrenceScript);
+  assert.equal(occurrenceScript.includes("40, 160, 224, 256, 400, 640, 880, 1120, 1360, 1500"), true);
+  assert.equal(scripts.some((script) => script.includes("targetIdentity") && script.includes("AXPress")), true);
 });
 
 test("native Final Cut media targeting rejects missing and ambiguous targets", async () => {
@@ -879,7 +883,7 @@ test("native Final Cut media targeting rejects missing and ambiguous targets", a
     sequenceTimeRange: { start: { value: "0", timescale: "1" }, duration: { value: "20", timescale: "1" } },
     revision: { id: "rev-1", sequence: 1, timestamp: new Date(0).toISOString() },
   });
-  const makeAdapter = (browserOutput: string, occurrenceOutput = `Interview${separator}AXRow${separator}clip-1${separator}10/1${separator}800${recordSeparator}`) => new FinalCutNativeAutomationAdapter({
+  const makeAdapter = (browserOutput: string, occurrenceOutput = `Interview${separator}AXRow${separator}clip-1${separator}800${recordSeparator}`) => new FinalCutNativeAutomationAdapter({
     enabled: true,
     liveState,
     executor: async (script) => {
@@ -892,12 +896,16 @@ test("native Final Cut media targeting rejects missing and ambiguous targets", a
 
   await assert.rejects(makeAdapter("").targetMedia("missing"), /FINAL_CUT_NATIVE_MEDIA_NOT_FOUND/);
   await assert.rejects(
-    makeAdapter(`Interview${separator}AXBrowserMedia${recordSeparator}Interview copy${separator}AXBrowserMedia${recordSeparator}`).targetMedia("ambiguous"),
+    makeAdapter(`Interview${separator}AXBrowserMedia${separator}browser-1${recordSeparator}Interview copy${separator}AXBrowserMedia${separator}browser-2${recordSeparator}`).targetMedia("ambiguous"),
     /FINAL_CUT_NATIVE_AMBIGUOUS_TARGET/,
   );
   await assert.rejects(
-    makeAdapter(`Interview${separator}AXBrowserMedia${recordSeparator}`, `${"Interview"}${separator}AXRow${separator}one${recordSeparator}Interview${separator}AXRow${separator}two${recordSeparator}`).targetMedia("duplicate"),
+    makeAdapter(`Interview${separator}AXBrowserMedia${separator}browser-1${recordSeparator}`, `${"Interview"}${separator}AXRow${separator}one${separator}40${recordSeparator}Interview${separator}AXRow${separator}two${separator}880${recordSeparator}`).targetMedia("duplicate"),
     /FINAL_CUT_NATIVE_AMBIGUOUS_TARGET/,
+  );
+  await assert.rejects(
+    makeAdapter(`Interview${separator}AXBrowserMedia${separator}browser-1${recordSeparator}`, `Interview${separator}AXRow${separator}one${separator}${recordSeparator}`).targetMedia("missing-position"),
+    /FINAL_CUT_NATIVE_OCCURRENCE_POSITION_UNAVAILABLE/,
   );
 });
 

--- a/tests/integration/native.test.ts
+++ b/tests/integration/native.test.ts
@@ -807,12 +807,12 @@ test("native Final Cut adapter searches, locates, previews, and verifies a Blade
     executor: async (script) => {
       scripts.push(script);
       if (script.includes('set frontWindow to window "Final Cut Pro"')) return context(true, "Final Cut Pro", "Interview", 1, true);
-      if (script.includes('AXBrowserMedia')) return `Interview${separator}AXBrowserMedia${recordSeparator}`;
+      if (script.includes('AXBrowserMedia')) return `Interview${separator}AXBrowserMedia${separator}browser-1${separator}media-source-1${recordSeparator}`;
       if (script.includes('set output to ""') && script.includes("xOffset")) {
         occurrenceReads += 1;
         return occurrenceReads === 1
-          ? `Interview${separator}AXRow${recordSeparator}`
-          : `Interview${separator}AXRow${recordSeparator}Interview${separator}AXRow${recordSeparator}`;
+          ? `Interview${separator}AXRow${separator}media-source-1${separator}800${recordSeparator}`
+          : `Interview${separator}AXRow${separator}media-source-1${separator}800${recordSeparator}Interview${separator}AXRow${separator}media-source-1${separator}1120${recordSeparator}`;
       }
       return "";
     },
@@ -853,8 +853,8 @@ test("native Final Cut adapter targets one media occurrence and reports live pla
     executor: async (script) => {
       scripts.push(script);
       if (script.includes('set frontWindow to window "Final Cut Pro"')) return context(true, "Final Cut Pro", "Interview.mov", 1, true);
-      if (script.includes("AXBrowserMedia")) return `Interview.mov${separator}AXBrowserMedia${separator}browser-1${recordSeparator}`;
-      if (script.includes("set output to \"\"")) return `Interview.mov${separator}AXRow${separator}clip-1${separator}800${recordSeparator}`;
+      if (script.includes("AXBrowserMedia")) return `Interview.mov${separator}AXBrowserMedia${separator}browser-1${separator}media-source-1${recordSeparator}`;
+      if (script.includes("set output to \"\"")) return `Interview.mov${separator}AXRow${separator}media-source-1${separator}800${recordSeparator}`;
       return "";
     },
   });
@@ -862,7 +862,10 @@ test("native Final Cut adapter targets one media occurrence and reports live pla
   const target = await adapter.targetMedia("Interview");
   assert.equal(target.status, "unique");
   assert.equal(target.media.name, "Interview.mov");
+  assert.equal(target.media.identity, "browser-1");
+  assert.equal(target.media.sourceIdentity, "media-source-1");
   assert.equal(target.occurrence.timelineOffset, 800);
+  assert.equal(target.occurrence.sourceIdentity, "media-source-1");
   assert.equal(target.selected, true);
   assert.equal(target.playheadTime, "1/1");
   assert.equal(scripts.some((script) => script.includes("set value of searchField")), true);
@@ -883,12 +886,13 @@ test("native Final Cut media targeting rejects missing and ambiguous targets", a
     sequenceTimeRange: { start: { value: "0", timescale: "1" }, duration: { value: "20", timescale: "1" } },
     revision: { id: "rev-1", sequence: 1, timestamp: new Date(0).toISOString() },
   });
-  const makeAdapter = (browserOutput: string, occurrenceOutput = `Interview${separator}AXRow${separator}clip-1${separator}800${recordSeparator}`) => new FinalCutNativeAutomationAdapter({
+  const makeAdapter = (browserOutput: string, occurrenceOutput = `Interview${separator}AXRow${separator}media-source-1${separator}800${recordSeparator}`) => new FinalCutNativeAutomationAdapter({
     enabled: true,
     liveState,
     executor: async (script) => {
       if (script.includes('set frontWindow to window "Final Cut Pro"')) return context(true, "Final Cut Pro", "Interview", 1, true);
       if (script.includes("AXBrowserMedia")) return browserOutput;
+      if (script.includes('set sourceIdentity to "media-source-1"') && occurrenceOutput.includes("different-source")) return "";
       if (script.includes("set output to \"\"")) return occurrenceOutput;
       return "";
     },
@@ -896,16 +900,24 @@ test("native Final Cut media targeting rejects missing and ambiguous targets", a
 
   await assert.rejects(makeAdapter("").targetMedia("missing"), /FINAL_CUT_NATIVE_MEDIA_NOT_FOUND/);
   await assert.rejects(
-    makeAdapter(`Interview${separator}AXBrowserMedia${separator}browser-1${recordSeparator}Interview copy${separator}AXBrowserMedia${separator}browser-2${recordSeparator}`).targetMedia("ambiguous"),
+    makeAdapter(`Interview${separator}AXBrowserMedia${separator}browser-1${separator}media-source-1${recordSeparator}Interview copy${separator}AXBrowserMedia${separator}browser-2${separator}media-source-2${recordSeparator}`).targetMedia("ambiguous"),
     /FINAL_CUT_NATIVE_AMBIGUOUS_TARGET/,
   );
   await assert.rejects(
-    makeAdapter(`Interview${separator}AXBrowserMedia${separator}browser-1${recordSeparator}`, `${"Interview"}${separator}AXRow${separator}one${separator}40${recordSeparator}Interview${separator}AXRow${separator}two${separator}880${recordSeparator}`).targetMedia("duplicate"),
+    makeAdapter(`Interview${separator}AXBrowserMedia${separator}browser-1${separator}media-source-1${recordSeparator}`, `${"Interview"}${separator}AXRow${separator}media-source-1${separator}40${recordSeparator}Interview${separator}AXRow${separator}media-source-1${separator}880${recordSeparator}`).targetMedia("duplicate"),
     /FINAL_CUT_NATIVE_AMBIGUOUS_TARGET/,
   );
   await assert.rejects(
-    makeAdapter(`Interview${separator}AXBrowserMedia${separator}browser-1${recordSeparator}`, `Interview${separator}AXRow${separator}one${separator}${recordSeparator}`).targetMedia("missing-position"),
+    makeAdapter(`Interview${separator}AXBrowserMedia${separator}browser-1${separator}media-source-1${recordSeparator}`, `Interview${separator}AXRow${separator}media-source-1${separator}${recordSeparator}`).targetMedia("missing-position"),
     /FINAL_CUT_NATIVE_OCCURRENCE_POSITION_UNAVAILABLE/,
+  );
+  await assert.rejects(
+    makeAdapter(`Interview${separator}AXBrowserMedia${separator}browser-1${separator}${recordSeparator}`).targetMedia("missing-source-id"),
+    /FINAL_CUT_NATIVE_MEDIA_ID_UNAVAILABLE/,
+  );
+  await assert.rejects(
+    makeAdapter(`Interview${separator}AXBrowserMedia${separator}browser-1${separator}media-source-1${recordSeparator}`, `Interview${separator}AXRow${separator}different-source${separator}800${recordSeparator}`).targetMedia("wrong-source-id"),
+    /FINAL_CUT_NATIVE_OCCURRENCE_NOT_FOUND/,
   );
 });
 
@@ -948,7 +960,7 @@ test("native Final Cut media selection refocuses Final Cut without closing the e
       if (script.includes("click at {(item 1 of origin) + 275") && script.includes("set frontmost to true")) {
         return "selected";
       }
-      if (script.includes("AXBrowserMedia")) return `Interview${separator}AXBrowserMedia${String.fromCharCode(30)}`;
+      if (script.includes("AXBrowserMedia")) return `Interview${separator}AXBrowserMedia${separator}browser-1${separator}media-source-1${String.fromCharCode(30)}`;
       return "";
     },
   });
@@ -981,7 +993,7 @@ test("native UI transactions pause and resume live connection supervision", asyn
     resumeLiveConnection: () => events.push("resume"),
     executor: async (script) => {
       if (script.includes('set frontWindow to window "Final Cut Pro"')) return context(true, "Final Cut Pro", "", 0, false);
-      if (script.includes("AXBrowserMedia")) return `Interview${separator}AXBrowserMedia${String.fromCharCode(30)}`;
+      if (script.includes("AXBrowserMedia")) return `Interview${separator}AXBrowserMedia${separator}browser-1${separator}media-source-1${String.fromCharCode(30)}`;
       return "";
     },
   });
@@ -999,7 +1011,7 @@ test("native Final Cut Blade previews expire and stale handles fail closed", asy
     now: () => clock,
     executor: async (script) => {
       if (script.includes('set frontWindow to window "Final Cut Pro"')) return context(true, "Final Cut Pro", "Interview", 1, true);
-      if (script.includes('AXBrowserMedia')) return `Interview${separator}AXBrowserMedia${recordSeparator}`;
+      if (script.includes('AXBrowserMedia')) return `Interview${separator}AXBrowserMedia${separator}browser-1${separator}media-source-1${recordSeparator}`;
       if (script.includes('set output to ""') && script.includes("xOffset")) return `Interview${separator}AXRow${recordSeparator}`;
       return "";
     },
@@ -1027,8 +1039,8 @@ test("native Final Cut rejects ambiguous occurrences and an out-of-range playhea
     enabled: true,
     executor: async (script) => {
       if (script.includes('set frontWindow to window "Final Cut Pro"')) return context(true, "Final Cut Pro", "Interview", 1, true);
-      if (script.includes('AXBrowserMedia')) return `Interview${separator}AXBrowserMedia${recordSeparator}`;
-      if (script.includes("xOffset")) return `Interview${separator}AXRow${recordSeparator}Interview${separator}AXRow${recordSeparator}`;
+      if (script.includes('AXBrowserMedia')) return `Interview${separator}AXBrowserMedia${separator}browser-1${separator}media-source-1${recordSeparator}`;
+      if (script.includes("xOffset")) return `Interview${separator}AXRow${separator}media-source-1${separator}40${recordSeparator}Interview${separator}AXRow${separator}media-source-1${separator}880${recordSeparator}`;
       return "";
     },
     liveState,
@@ -1042,7 +1054,7 @@ test("native Final Cut rejects ambiguous occurrences and an out-of-range playhea
     enabled: true,
     executor: async (script) => {
       if (script.includes('set frontWindow to window "Final Cut Pro"')) return context(true, "Final Cut Pro", "Interview", 1, true);
-      if (script.includes('AXBrowserMedia')) return `Interview${separator}AXBrowserMedia${recordSeparator}`;
+      if (script.includes('AXBrowserMedia')) return `Interview${separator}AXBrowserMedia${separator}browser-1${separator}media-source-1${recordSeparator}`;
       if (script.includes("xOffset")) return `Interview${separator}AXRow${separator}10/1${separator}2/1${recordSeparator}`;
       return "";
     },


### PR DESCRIPTION
## Summary

Closes #3.

- Add `editor.native.media.target` for bounded Browser-to-timeline targeting.
- Select exactly one Browser media item and exactly one timeline occurrence.
- Select the discovered timeline occurrence using its timeline offset and report live playhead state.
- Fail closed with distinct errors for missing or ambiguous media/occurrences and unavailable playhead state.
- Add deterministic MCP and native adapter regression coverage.
- Update live Final Cut MCP and compatibility documentation.

## TDD commits

- `1f5cd82` — failing MCP targeting contract tests
- `eed5a9e` — implementation, adapter tests, and documentation

## Validation

Passed:

- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm run check:boundaries`
- Focused MCP/native tests: 43 passing
- `pnpm run xcode:check`
- `xcodebuild -project adapters/final-cut/swift-bridge/FinalCutWorkflowExtension/FramekitFinalCutWorkflow.xcodeproj -list`

Known repository limitation: the top-level `pnpm run test` reaches the existing native MCP child-process teardown after test 17 and hangs without reporting a new failure; it was stopped after reproducing that behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Final Cut media targeting through the MCP tool, searching Browser media and selecting a unique timeline occurrence.
  - Reports the selected media and live playhead position.
  - Uses reliable source-identity matching to prevent incorrect same-name selections.
  - Provides clear errors for missing, ambiguous, unavailable, or non-selectable matches.

- **Documentation**
  - Documented the targeting workflow, live-state requirements, and fail-closed behavior.

- **Tests**
  - Added integration coverage for targeting, identity matching, playhead reporting, tool registration, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->