### PR TITLE
[Feature] Add an explicit editing intent layer

### DIFF
--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { AgentVideoRuntime } from "@framekit/runtime";
+import { AgentVideoRuntime, resolveEditingIntent } from "@framekit/runtime";
 import type { FinalCutProjectPublisher, NativeFinalCutEditor } from "@framekit/final-cut";
 
 const revisionSchema = z.object({
@@ -102,6 +102,11 @@ export function createMcpServer(runtime: AgentVideoRuntime, options: McpServerOp
       ...(options.nativeEditor ? { native: options.nativeEditor.capabilities() } : {}),
     });
   });
+
+  server.registerTool("editing.intent.resolve", {
+    description: "Map a supported natural-language editing request to one explicit operation without executing it.",
+    inputSchema: { request: z.string().trim().min(1) },
+  }, async ({ request }) => jsonResult(resolveEditingIntent(request)));
 
   server.registerTool("editor.native.inspect", {
     description: "Inspect the active Final Cut selection/playhead before a native UI edit.",

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -71,9 +71,9 @@ forms:
 - `Blade at 30 seconds` → `blade_at_playhead`
 - `Remove 10–15 seconds` → `delete_range`
 
-The result includes the selected operation, the affected range, and
-`previewRequired: true`. The resolver never mutates the editor. Callers must
-use the operation-specific native preview tool before an execute call; native
-execute tools accept only their short-lived preview tokens. An unrecognized or
-ambiguous destructive request returns `clarification_required` without an
-operation or preview token.
+The result includes the selected operation, the affected range,
+`previewRequired: true`, and the exact `previewTool` to call. The resolver never
+mutates the editor. Callers must use that operation-specific native preview tool
+before an execute call; native execute tools accept only their short-lived
+preview tokens. An unrecognized or ambiguous destructive request returns
+`clarification_required` without an operation or preview tool.

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -6,6 +6,7 @@
 | --- | --- | --- |
 | `connection.status` | Framekit Final Cut setup and connection state | Available during live setup and reconnect |
 | `editor.inspect` | Editor identity and capabilities | Available when a backend is selected |
+| `editing.intent.resolve` | Map one supported natural-language request to an explicit operation and affected range | Read-only; ambiguous requests return clarification and no operation; resolved destructive requests set `previewRequired` |
 | `editor.native.inspect` | Active native Final Cut selection/playhead and UI focus diagnostics | Requires native writes opt-in and Accessibility permission |
 | `editor.native.focus` | Activate Final Cut and focus the timeline without editing | Bounded retry; returns focus diagnostics on failure |
 | `editor.native.edit` | Selection-scoped native Final Cut edit | Requires native writes opt-in and Final Cut frontmost |
@@ -60,3 +61,19 @@ selection never silently changes the open Final Cut project.
 `media.search` remains canonical snapshot search. Live Browser search uses the
 explicit `editor.native.media.*` tools because Browser media identity and
 timeline occurrence identity are different and short-lived.
+
+## Explicit editing intent
+
+`editing.intent.resolve` accepts a request string and recognizes only these
+forms:
+
+- `Cut at 30 seconds and remove the rest` → `trim_to_duration`
+- `Blade at 30 seconds` → `blade_at_playhead`
+- `Remove 10–15 seconds` → `delete_range`
+
+The result includes the selected operation, the affected range, and
+`previewRequired: true`. The resolver never mutates the editor. Callers must
+use the operation-specific native preview tool before an execute call; native
+execute tools accept only their short-lived preview tokens. An unrecognized or
+ambiguous destructive request returns `clarification_required` without an
+operation or preview token.

--- a/packages/runtime/src/editing/intent.ts
+++ b/packages/runtime/src/editing/intent.ts
@@ -1,0 +1,118 @@
+import type { RationalTime } from "../domain/types.js";
+
+export type EditingIntentOperation =
+  | {
+      type: "trim_to_duration";
+      duration: RationalTime;
+    }
+  | {
+      type: "blade_at_playhead";
+      playheadTime: RationalTime;
+    }
+  | {
+      type: "delete_range";
+      range: {
+        start: RationalTime;
+        end: RationalTime;
+      };
+    };
+
+export type EditingIntentAffectedRange =
+  | {
+      kind: "tail";
+      start: RationalTime;
+      end: "sequence-end";
+    }
+  | {
+      kind: "playhead";
+      at: RationalTime;
+    }
+  | {
+      kind: "range";
+      start: RationalTime;
+      end: RationalTime;
+    };
+
+export type EditingIntentResolution =
+  | {
+      status: "resolved";
+      destructive: true;
+      previewRequired: true;
+      operation: EditingIntentOperation;
+      affectedRange: EditingIntentAffectedRange;
+    }
+  | {
+      status: "clarification_required";
+      destructive: true;
+      previewRequired: false;
+      question: string;
+      options: EditingIntentOperation["type"][];
+    };
+
+const CLARIFICATION_OPTIONS: EditingIntentOperation["type"][] = [
+  "trim_to_duration",
+  "blade_at_playhead",
+  "delete_range",
+];
+
+/** Resolve only the explicit destructive language supported by Framekit. */
+export function resolveEditingIntent(request: string): EditingIntentResolution {
+  const normalized = request.trim().replace(/\s+/g, " ").toLowerCase();
+
+  const trimMatch = normalized.match(/^cut at (\d+(?:\.\d+)?) seconds? and remove the rest$/);
+  if (trimMatch) {
+    const duration = secondsToRational(trimMatch[1]!);
+    return {
+      status: "resolved",
+      destructive: true,
+      previewRequired: true,
+      operation: { type: "trim_to_duration", duration },
+      affectedRange: { kind: "tail", start: duration, end: "sequence-end" },
+    };
+  }
+
+  const bladeMatch = normalized.match(/^blade at (\d+(?:\.\d+)?) seconds?$/);
+  if (bladeMatch) {
+    const playheadTime = secondsToRational(bladeMatch[1]!);
+    return {
+      status: "resolved",
+      destructive: true,
+      previewRequired: true,
+      operation: { type: "blade_at_playhead", playheadTime },
+      affectedRange: { kind: "playhead", at: playheadTime },
+    };
+  }
+
+  const deleteMatch = normalized.match(/^remove (\d+(?:\.\d+)?)\s*(?:-|–|—|to)\s*(\d+(?:\.\d+)?) seconds?$/);
+  if (deleteMatch) {
+    const start = secondsToRational(deleteMatch[1]!);
+    const end = secondsToRational(deleteMatch[2]!);
+    if (Number(deleteMatch[2]) > Number(deleteMatch[1])) {
+      return {
+        status: "resolved",
+        destructive: true,
+        previewRequired: true,
+        operation: { type: "delete_range", range: { start, end } },
+        affectedRange: { kind: "range", start, end },
+      };
+    }
+  }
+
+  return {
+    status: "clarification_required",
+    destructive: true,
+    previewRequired: false,
+    question: "Which editing operation should Framekit perform?",
+    options: [...CLARIFICATION_OPTIONS],
+  };
+}
+
+function secondsToRational(seconds: string): RationalTime {
+  if (!seconds.includes(".")) return { value: seconds, timescale: "1" };
+  const decimals = seconds.length - seconds.indexOf(".") - 1;
+  const timescale = 10 ** decimals;
+  return {
+    value: String(Math.round(Number(seconds) * timescale)),
+    timescale: String(timescale),
+  };
+}

--- a/packages/runtime/src/editing/intent.ts
+++ b/packages/runtime/src/editing/intent.ts
@@ -38,6 +38,10 @@ export type EditingIntentResolution =
       status: "resolved";
       destructive: true;
       previewRequired: true;
+      previewTool:
+        | "editor.native.trim-to-duration.preview"
+        | "editor.native.blade.preview"
+        | "editor.native.delete-range.preview";
       operation: EditingIntentOperation;
       affectedRange: EditingIntentAffectedRange;
     }
@@ -66,6 +70,7 @@ export function resolveEditingIntent(request: string): EditingIntentResolution {
       status: "resolved",
       destructive: true,
       previewRequired: true,
+      previewTool: "editor.native.trim-to-duration.preview",
       operation: { type: "trim_to_duration", duration },
       affectedRange: { kind: "tail", start: duration, end: "sequence-end" },
     };
@@ -78,6 +83,7 @@ export function resolveEditingIntent(request: string): EditingIntentResolution {
       status: "resolved",
       destructive: true,
       previewRequired: true,
+      previewTool: "editor.native.blade.preview",
       operation: { type: "blade_at_playhead", playheadTime },
       affectedRange: { kind: "playhead", at: playheadTime },
     };
@@ -92,6 +98,7 @@ export function resolveEditingIntent(request: string): EditingIntentResolution {
         status: "resolved",
         destructive: true,
         previewRequired: true,
+        previewTool: "editor.native.delete-range.preview",
         operation: { type: "delete_range", range: { start, end } },
         affectedRange: { kind: "range", start, end },
       };

--- a/packages/runtime/src/editing/intent.ts
+++ b/packages/runtime/src/editing/intent.ts
@@ -116,10 +116,10 @@ export function resolveEditingIntent(request: string): EditingIntentResolution {
 
 function secondsToRational(seconds: string): RationalTime {
   if (!seconds.includes(".")) return { value: seconds, timescale: "1" };
-  const decimals = seconds.length - seconds.indexOf(".") - 1;
-  const timescale = 10 ** decimals;
+  const [whole, fraction = ""] = seconds.split(".");
+  const value = `${whole}${fraction}`.replace(/^0+(?=\d)/, "");
   return {
-    value: String(Math.round(Number(seconds) * timescale)),
-    timescale: String(timescale),
+    value,
+    timescale: `1${"0".repeat(fraction.length)}`,
   };
 }

--- a/packages/runtime/src/editing/intent.ts
+++ b/packages/runtime/src/editing/intent.ts
@@ -93,7 +93,7 @@ export function resolveEditingIntent(request: string): EditingIntentResolution {
   if (deleteMatch) {
     const start = secondsToRational(deleteMatch[1]!);
     const end = secondsToRational(deleteMatch[2]!);
-    if (Number(deleteMatch[2]) > Number(deleteMatch[1])) {
+    if (compareDecimalSeconds(deleteMatch[2]!, deleteMatch[1]!) > 0) {
       return {
         status: "resolved",
         destructive: true,
@@ -122,4 +122,22 @@ function secondsToRational(seconds: string): RationalTime {
     value,
     timescale: `1${"0".repeat(fraction.length)}`,
   };
+}
+
+function compareDecimalSeconds(left: string, right: string): number {
+  const [leftWhole, leftFraction = ""] = normalizeDecimalSeconds(left);
+  const [rightWhole, rightFraction = ""] = normalizeDecimalSeconds(right);
+  if (leftWhole.length !== rightWhole.length) return leftWhole.length > rightWhole.length ? 1 : -1;
+  if (leftWhole !== rightWhole) return leftWhole > rightWhole ? 1 : -1;
+
+  const precision = Math.max(leftFraction.length, rightFraction.length);
+  const paddedLeft = leftFraction.padEnd(precision, "0");
+  const paddedRight = rightFraction.padEnd(precision, "0");
+  if (paddedLeft === paddedRight) return 0;
+  return paddedLeft > paddedRight ? 1 : -1;
+}
+
+function normalizeDecimalSeconds(seconds: string): [string, string] {
+  const [whole, fraction = ""] = seconds.split(".");
+  return [whole.replace(/^0+(?=\d)/, ""), fraction];
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -2,3 +2,4 @@ export * from "./domain/types.js";
 export * from "./runtime.js";
 export * from "./diff/diff.js";
 export * from "./verification/verification.js";
+export * from "./editing/intent.js";

--- a/tests/integration/editing-intent.test.ts
+++ b/tests/integration/editing-intent.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveEditingIntent } from "@framekit/runtime";
+
+test("editing intent maps cut-and-remove-the-rest to trim_to_duration", () => {
+  assert.deepEqual(resolveEditingIntent("Cut at 30 seconds and remove the rest"), {
+    status: "resolved",
+    destructive: true,
+    previewRequired: true,
+    operation: {
+      type: "trim_to_duration",
+      duration: { value: "30", timescale: "1" },
+    },
+    affectedRange: {
+      kind: "tail",
+      start: { value: "30", timescale: "1" },
+      end: "sequence-end",
+    },
+  });
+});
+
+test("editing intent maps a blade request to blade_at_playhead", () => {
+  assert.deepEqual(resolveEditingIntent("Blade at 30 seconds"), {
+    status: "resolved",
+    destructive: true,
+    previewRequired: true,
+    operation: {
+      type: "blade_at_playhead",
+      playheadTime: { value: "30", timescale: "1" },
+    },
+    affectedRange: {
+      kind: "playhead",
+      at: { value: "30", timescale: "1" },
+    },
+  });
+});
+
+test("editing intent maps a range removal to delete_range", () => {
+  assert.deepEqual(resolveEditingIntent("Remove 10–15 seconds"), {
+    status: "resolved",
+    destructive: true,
+    previewRequired: true,
+    operation: {
+      type: "delete_range",
+      range: {
+        start: { value: "10", timescale: "1" },
+        end: { value: "15", timescale: "1" },
+      },
+    },
+    affectedRange: {
+      kind: "range",
+      start: { value: "10", timescale: "1" },
+      end: { value: "15", timescale: "1" },
+    },
+  });
+});
+
+test("editing intent asks for clarification without selecting an operation", () => {
+  assert.deepEqual(resolveEditingIntent("Cut this part out"), {
+    status: "clarification_required",
+    destructive: true,
+    previewRequired: false,
+    question: "Which editing operation should Framekit perform?",
+    options: ["trim_to_duration", "blade_at_playhead", "delete_range"],
+  });
+});

--- a/tests/integration/editing-intent.test.ts
+++ b/tests/integration/editing-intent.test.ts
@@ -21,6 +21,7 @@ test("editing intent maps cut-and-remove-the-rest to trim_to_duration", () => {
     status: "resolved",
     destructive: true,
     previewRequired: true,
+    previewTool: "editor.native.trim-to-duration.preview",
     operation: {
       type: "trim_to_duration",
       duration: { value: "30", timescale: "1" },
@@ -38,6 +39,7 @@ test("editing intent maps a blade request to blade_at_playhead", () => {
     status: "resolved",
     destructive: true,
     previewRequired: true,
+    previewTool: "editor.native.blade.preview",
     operation: {
       type: "blade_at_playhead",
       playheadTime: { value: "30", timescale: "1" },
@@ -54,6 +56,7 @@ test("editing intent maps a range removal to delete_range", () => {
     status: "resolved",
     destructive: true,
     previewRequired: true,
+    previewTool: "editor.native.delete-range.preview",
     operation: {
       type: "delete_range",
       range: {
@@ -79,6 +82,10 @@ test("editing intent asks for clarification without selecting an operation", () 
   });
 });
 
+test("editing intent does not select delete_range for a reversed range", () => {
+  assert.equal(resolveEditingIntent("Remove 15-10 seconds").status, "clarification_required");
+});
+
 test("MCP exposes the resolved operation, affected range, and preview requirement", async () => {
   const server = createMcpServer(new AgentVideoRuntime(new InMemoryEditorAdapter({
     projectId: "project-1",
@@ -100,6 +107,7 @@ test("MCP exposes the resolved operation, affected range, and preview requiremen
     })));
     assert.equal(resolved.status, "resolved");
     assert.equal(resolved.operation.type, "delete_range");
+    assert.equal(resolved.previewTool, "editor.native.delete-range.preview");
     assert.deepEqual(resolved.affectedRange, {
       kind: "range",
       start: { value: "10", timescale: "1" },

--- a/tests/integration/editing-intent.test.ts
+++ b/tests/integration/editing-intent.test.ts
@@ -86,6 +86,24 @@ test("editing intent does not select delete_range for a reversed range", () => {
   assert.equal(resolveEditingIntent("Remove 15-10 seconds").status, "clarification_required");
 });
 
+test("editing intent does not select delete_range for a zero-length range", () => {
+  assert.equal(resolveEditingIntent("Remove 10-10 seconds").status, "clarification_required");
+});
+
+test("editing intent preserves high-precision decimal seconds as a rational time", () => {
+  const resolution = resolveEditingIntent("Cut at 0.12345678901234567890 seconds and remove the rest");
+  assert.equal(resolution.status, "resolved");
+  if (resolution.status === "resolved") {
+    assert.equal(resolution.operation.type, "trim_to_duration");
+    if (resolution.operation.type === "trim_to_duration") {
+      assert.deepEqual(resolution.operation.duration, {
+        value: "12345678901234567890",
+        timescale: "100000000000000000000",
+      });
+    }
+  }
+});
+
 test("MCP exposes the resolved operation, affected range, and preview requirement", async () => {
   const server = createMcpServer(new AgentVideoRuntime(new InMemoryEditorAdapter({
     projectId: "project-1",

--- a/tests/integration/editing-intent.test.ts
+++ b/tests/integration/editing-intent.test.ts
@@ -1,6 +1,20 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { resolveEditingIntent } from "@framekit/runtime";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { AgentVideoRuntime } from "@framekit/runtime";
+import { InMemoryEditorAdapter } from "@framekit/testkit";
+import { createMcpServer } from "../../apps/mcp-server/src/server.js";
+
+function textFrom(result: unknown): string {
+  const content = (result as { content?: unknown }).content;
+  assert.ok(Array.isArray(content));
+  const first = content[0] as { text?: unknown } | undefined;
+  assert.ok(first);
+  assert.equal(typeof first.text, "string");
+  return first.text as string;
+}
 
 test("editing intent maps cut-and-remove-the-rest to trim_to_duration", () => {
   assert.deepEqual(resolveEditingIntent("Cut at 30 seconds and remove the rest"), {
@@ -63,4 +77,63 @@ test("editing intent asks for clarification without selecting an operation", () 
     question: "Which editing operation should Framekit perform?",
     options: ["trim_to_duration", "blade_at_playhead", "delete_range"],
   });
+});
+
+test("MCP exposes the resolved operation, affected range, and preview requirement", async () => {
+  const server = createMcpServer(new AgentVideoRuntime(new InMemoryEditorAdapter({
+    projectId: "project-1",
+    projectName: "Intent Fixture",
+    timelineId: "timeline-1",
+    timelineName: "Main Edit",
+    clips: [],
+  })));
+  const client = new Client({ name: "editing-intent-test", version: "0.1.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  try {
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+
+    const tools = await client.listTools();
+    assert.ok(tools.tools.some((tool) => tool.name === "editing.intent.resolve"));
+    const resolved = JSON.parse(textFrom(await client.callTool({
+      name: "editing.intent.resolve",
+      arguments: { request: "Remove 10–15 seconds" },
+    })));
+    assert.equal(resolved.status, "resolved");
+    assert.equal(resolved.operation.type, "delete_range");
+    assert.deepEqual(resolved.affectedRange, {
+      kind: "range",
+      start: { value: "10", timescale: "1" },
+      end: { value: "15", timescale: "1" },
+    });
+    assert.equal(resolved.previewRequired, true);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
+
+test("MCP intent resolution does not select or preview an ambiguous request", async () => {
+  const server = createMcpServer(new AgentVideoRuntime(new InMemoryEditorAdapter({
+    projectId: "project-1",
+    projectName: "Intent Fixture",
+    timelineId: "timeline-1",
+    timelineName: "Main Edit",
+    clips: [],
+  })));
+  const client = new Client({ name: "editing-intent-ambiguity-test", version: "0.1.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  try {
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+
+    const ambiguous = JSON.parse(textFrom(await client.callTool({
+      name: "editing.intent.resolve",
+      arguments: { request: "Cut this part out" },
+    })));
+    assert.equal(ambiguous.status, "clarification_required");
+    assert.equal(ambiguous.operation, undefined);
+    assert.equal(ambiguous.previewRequired, false);
+  } finally {
+    await client.close();
+    await server.close();
+  }
 });

--- a/tests/integration/editing-intent.test.ts
+++ b/tests/integration/editing-intent.test.ts
@@ -104,6 +104,14 @@ test("editing intent preserves high-precision decimal seconds as a rational time
   }
 });
 
+test("editing intent compares high-precision delete bounds exactly", () => {
+  const resolution = resolveEditingIntent("Remove 9007199254740992-9007199254740993 seconds");
+  assert.equal(resolution.status, "resolved");
+  if (resolution.status === "resolved") {
+    assert.equal(resolution.operation.type, "delete_range");
+  }
+});
+
 test("MCP exposes the resolved operation, affected range, and preview requirement", async () => {
   const server = createMcpServer(new AgentVideoRuntime(new InMemoryEditorAdapter({
     projectId: "project-1",

--- a/tests/integration/mcp.test.ts
+++ b/tests/integration/mcp.test.ts
@@ -39,6 +39,7 @@ test("Phase 0 exposes read/write/diff through MCP stdio", async () => {
         "edit.diff",
         "edit.undo",
         "edit.verify",
+        "editing.intent.resolve",
         "editor.assets",
         "editor.inspect",
         "editor.live.changes",


### PR DESCRIPTION
Closes #5

## Summary

- Add a runtime resolver for the three explicit destructive editing request forms.
- Expose `editing.intent.resolve` through MCP with operation, affected range, preview requirement, and preview tool.
- Return clarification without selecting an operation for ambiguous or invalid requests.
- Document the preview/execute safety contract and add deterministic runtime/MCP coverage.

## Validation

- `pnpm install --frozen-lockfile` passed.
- Focused intent/MCP tests passed (8 tests).
- `pnpm run build` passed.
- `pnpm run check:boundaries` passed.
- The repository-wide `pnpm run test` was attempted; the existing Final Cut MCP child test hangs locally after the new tests pass.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Public MCP behavior and package interfaces are documented.
- [x] Existing adapters and fixtures remain compatible.

## Safety

- [x] Ambiguous destructive requests fail closed.
- [x] Resolved destructive requests identify the required preview tool.
- [x] No credentials, private media, raw crash dumps, or generated artifacts added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an editing-intent tool that interprets natural-language requests for trimming, blading, and deleting ranges.
  * Returns the proposed operation, affected timeline range, and preview requirements without executing edits.
  * Provides clarification guidance for unsupported, ambiguous, or invalid requests.
  * Added a tool for finding Browser media and targeting a single timeline occurrence, failing safely when matches are missing or ambiguous.

* **Documentation**
  * Documented supported request formats, operation mappings, affected ranges, preview requirements, and clarification behavior.

* **Tests**
  * Added coverage for supported operations, invalid ranges, ambiguity handling, media targeting, and tool responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->