### PR TITLE
fix: prevent Final Cut popup during pre-commit validation

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -31,6 +31,7 @@ export PATH="$node_bin:$PATH"
 # configured to run the live Final Cut MCP. No commit check may launch or
 # activate Final Cut Pro.
 export FRAMEKIT_EDITOR=fixture
+export FRAMEKIT_COMMIT_VALIDATION=1
 export FRAMEKIT_FINAL_CUT_HEADLESS=1
 export FRAMEKIT_FINAL_CUT_NATIVE_WRITES=0
 export FRAMEKIT_AUTO_CONNECT=0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,7 @@ media/project state. On non-macOS systems, native checks are reported as a CI
 requirement instead of blocking the commit.
 
 The hook also forces `FRAMEKIT_EDITOR=fixture`,
+`FRAMEKIT_COMMIT_VALIDATION=1`,
 `FRAMEKIT_FINAL_CUT_HEADLESS=1`, `FRAMEKIT_FINAL_CUT_NATIVE_WRITES=0`, and
 `FRAMEKIT_AUTO_CONNECT=0` while running validation. This prevents inherited
 shell configuration from launching or activating Final Cut Pro during a

--- a/tests/integration/final-cut-test-env.ts
+++ b/tests/integration/final-cut-test-env.ts
@@ -12,8 +12,12 @@ export function finalCutMcpEnvironment(overrides: NodeJS.ProcessEnv = {}): Recor
   return {
     ...environment,
     FRAMEKIT_EDITOR: "final-cut-live",
-    FRAMEKIT_FINAL_CUT_HEADLESS: commitValidation ? "1" : "0",
+    FRAMEKIT_FINAL_CUT_HEADLESS: commitValidation
+      ? "1"
+      : (environment.FRAMEKIT_FINAL_CUT_HEADLESS ?? "0"),
     FRAMEKIT_AUTO_CONNECT: "0",
-    FRAMEKIT_FINAL_CUT_NATIVE_WRITES: commitValidation ? "0" : "1",
+    FRAMEKIT_FINAL_CUT_NATIVE_WRITES: commitValidation
+      ? "0"
+      : (environment.FRAMEKIT_FINAL_CUT_NATIVE_WRITES ?? "1"),
   };
 }

--- a/tests/integration/final-cut-test-env.ts
+++ b/tests/integration/final-cut-test-env.ts
@@ -1,0 +1,19 @@
+/**
+ * Build the environment for live Final Cut contract tests without allowing
+ * commit validation to enable native UI automation.
+ */
+export function finalCutMcpEnvironment(overrides: NodeJS.ProcessEnv = {}): Record<string, string> {
+  const environment = Object.fromEntries(
+    Object.entries({ ...process.env, ...overrides })
+      .filter((entry): entry is [string, string] => typeof entry[1] === "string"),
+  );
+  const commitValidation = environment.FRAMEKIT_COMMIT_VALIDATION === "1";
+
+  return {
+    ...environment,
+    FRAMEKIT_EDITOR: "final-cut-live",
+    FRAMEKIT_FINAL_CUT_HEADLESS: commitValidation ? "1" : "0",
+    FRAMEKIT_AUTO_CONNECT: "0",
+    FRAMEKIT_FINAL_CUT_NATIVE_WRITES: commitValidation ? "0" : "1",
+  };
+}

--- a/tests/integration/finalcut-mcp.test.ts
+++ b/tests/integration/finalcut-mcp.test.ts
@@ -13,6 +13,7 @@ import type { NativeFinalCutEditor } from "@framekit/final-cut";
 import { AgentVideoRuntime } from "@framekit/runtime";
 import { InMemoryEditorAdapter } from "@framekit/testkit";
 import { createMcpServer } from "../../apps/mcp-server/src/server.js";
+import { finalCutMcpEnvironment } from "./final-cut-test-env.js";
 
 function textFrom(result: unknown): string {
   const content = (result as { content?: unknown }).content;
@@ -52,18 +53,14 @@ test("Final Cut MCP composes FCPXML reads, local analysis, assets, edits, and un
   const transport = new StdioClientTransport({
     command: process.execPath,
     args: ["--import", "tsx", join(here, "../../apps/mcp-server/src/main.ts")],
-    env: {
-      ...process.env,
-      FRAMEKIT_EDITOR: "final-cut-live",
-      FRAMEKIT_FINAL_CUT_HEADLESS: "0",
-      FRAMEKIT_AUTO_CONNECT: "0",
+    env: finalCutMcpEnvironment({
       FRAMEKIT_FINAL_CUT_SOCKET: join(directory, "missing.sock"),
       FRAMEKIT_FCPXML_PATH: xmlPath,
       FRAMEKIT_FINAL_CUT_ASSET_ROOTS: join(directory, "Motion Templates.localized"),
       FRAMEKIT_SPEECH_ANALYZER: speech,
       FRAMEKIT_AUDIO_ANALYZER: audio,
       FRAMEKIT_VISUAL_ANALYZER: visual,
-    },
+    }),
     stderr: "pipe",
   });
   const client = new Client({ name: "finalcut-mcp-test", version: "0.1.0" });
@@ -141,6 +138,7 @@ test("local analyzer commands fail closed for unavailable media and invalid outp
 });
 
 test("Final Cut live MCP exposes native range contracts and capabilities", async () => {
+  const commitValidation = process.env.FRAMEKIT_COMMIT_VALIDATION === "1";
   const directory = await mkdtemp(join(os.tmpdir(), "framekit-native-mcp-contract-"));
   const socketPath = join(directory, "bridge.sock");
   const bridge = createServer((socket) => {
@@ -201,14 +199,10 @@ test("Final Cut live MCP exposes native range contracts and capabilities", async
   const transport = new StdioClientTransport({
     command: process.execPath,
     args: ["--import", "tsx", join(here, "../../apps/mcp-server/src/main.ts")],
-    env: {
-      ...process.env,
-      FRAMEKIT_EDITOR: "final-cut-live",
-      FRAMEKIT_FINAL_CUT_HEADLESS: "0",
-      FRAMEKIT_AUTO_CONNECT: "0",
+    env: finalCutMcpEnvironment({
       FRAMEKIT_FINAL_CUT_NATIVE_WRITES: "1",
       FRAMEKIT_FINAL_CUT_SOCKET: socketPath,
-    },
+    }),
     stderr: "pipe",
   });
   const client = new Client({ name: "native-contract-test", version: "0.1.0" });
@@ -224,19 +218,21 @@ test("Final Cut live MCP exposes native range contracts and capabilities", async
     assert.deepEqual(Object.keys(trimPreview.inputSchema.properties ?? {}).sort(), ["duration"]);
 
     const editor = JSON.parse(textFrom(await client.callTool({ name: "editor.inspect", arguments: {} })));
-    assert.equal(editor.native.deleteRange, true);
-    assert.equal(editor.native.trimToDuration, true);
-    assert.equal(editor.native.timelineFocus, true);
+    assert.equal(editor.native.deleteRange, !commitValidation);
+    assert.equal(editor.native.trimToDuration, !commitValidation);
+    assert.equal(editor.native.timelineFocus, !commitValidation);
 
     const native = JSON.parse(textFrom(await client.callTool({ name: "editor.native.inspect", arguments: {} })));
+    if (commitValidation) assert.equal(native.error?.code, "CAPABILITY_UNAVAILABLE");
     assert.equal(typeof native.timelineWindowAvailable, "boolean");
     assert.equal(typeof native.timelineFocused, "boolean");
     assert.ok(["timeline", "browser", "text-field", "modal", "unknown", "none"].includes(native.focusTarget));
     if (native.error) {
-      assert.match(native.error.code, /^FINAL_CUT_NATIVE_/);
+      assert.match(native.error.code, commitValidation ? /^CAPABILITY_UNAVAILABLE$/ : /^FINAL_CUT_NATIVE_/);
       assert.equal(typeof native.error.message, "string");
     }
     const focus = JSON.parse(textFrom(await client.callTool({ name: "editor.native.focus", arguments: {} })));
+    if (commitValidation) assert.equal(focus.error?.code, "CAPABILITY_UNAVAILABLE");
     assert.equal(typeof focus.timelineWindowAvailable, "boolean");
     assert.equal(typeof focus.timelineFocused, "boolean");
     assert.ok(["timeline", "browser", "text-field", "modal", "unknown", "none"].includes(focus.focusTarget));
@@ -249,7 +245,7 @@ test("Final Cut live MCP exposes native range contracts and capabilities", async
       },
     });
     if (preview.isError) {
-      assert.match(textFrom(preview), /FINAL_CUT_NATIVE_/);
+      assert.match(textFrom(preview), /CAPABILITY_UNAVAILABLE|FINAL_CUT_NATIVE_/);
     } else {
       const payload = JSON.parse(textFrom(preview));
       assert.equal(payload.operation, "delete-range");

--- a/tests/integration/git-hooks.test.ts
+++ b/tests/integration/git-hooks.test.ts
@@ -65,5 +65,15 @@ test("pre-commit hook forces headless fixture validation", async () => {
   });
   assert.equal(environment.FRAMEKIT_EDITOR, "final-cut-live");
   assert.equal(environment.FRAMEKIT_FINAL_CUT_HEADLESS, "1");
+  assert.equal(environment.FRAMEKIT_AUTO_CONNECT, "0");
   assert.equal(environment.FRAMEKIT_FINAL_CUT_NATIVE_WRITES, "0");
+
+  const explicitSafeEnvironment = finalCutMcpEnvironment({
+    FRAMEKIT_COMMIT_VALIDATION: "0",
+    FRAMEKIT_FINAL_CUT_HEADLESS: "1",
+    FRAMEKIT_FINAL_CUT_NATIVE_WRITES: "0",
+  });
+  assert.equal(explicitSafeEnvironment.FRAMEKIT_FINAL_CUT_HEADLESS, "1");
+  assert.equal(explicitSafeEnvironment.FRAMEKIT_AUTO_CONNECT, "0");
+  assert.equal(explicitSafeEnvironment.FRAMEKIT_FINAL_CUT_NATIVE_WRITES, "0");
 });

--- a/tests/integration/git-hooks.test.ts
+++ b/tests/integration/git-hooks.test.ts
@@ -60,8 +60,8 @@ test("pre-commit hook forces headless fixture validation", async () => {
   const environment = finalCutMcpEnvironment({
     FRAMEKIT_COMMIT_VALIDATION: "1",
     FRAMEKIT_EDITOR: "fixture",
-    FRAMEKIT_FINAL_CUT_HEADLESS: "1",
-    FRAMEKIT_FINAL_CUT_NATIVE_WRITES: "0",
+    FRAMEKIT_FINAL_CUT_HEADLESS: "0",
+    FRAMEKIT_FINAL_CUT_NATIVE_WRITES: "1",
   });
   assert.equal(environment.FRAMEKIT_EDITOR, "final-cut-live");
   assert.equal(environment.FRAMEKIT_FINAL_CUT_HEADLESS, "1");

--- a/tests/integration/git-hooks.test.ts
+++ b/tests/integration/git-hooks.test.ts
@@ -10,6 +10,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 import { hasNativeChanges, isNativePath } from "../../scripts/staged-native-changes.mjs";
 import { installHooks } from "../../scripts/install-git-hooks.mjs";
+import { finalCutMcpEnvironment } from "./final-cut-test-env.js";
 
 const exec = promisify(execFile);
 const repository = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
@@ -51,7 +52,18 @@ test("pre-commit hook is executable and shell-valid", async () => {
 test("pre-commit hook forces headless fixture validation", async () => {
   const hook = await readFile(join(repository, ".githooks", "pre-commit"), "utf8");
   assert.match(hook, /export FRAMEKIT_EDITOR=fixture/);
+  assert.match(hook, /export FRAMEKIT_COMMIT_VALIDATION=1/);
   assert.match(hook, /export FRAMEKIT_FINAL_CUT_HEADLESS=1/);
   assert.match(hook, /export FRAMEKIT_FINAL_CUT_NATIVE_WRITES=0/);
   assert.match(hook, /export FRAMEKIT_AUTO_CONNECT=0/);
+
+  const environment = finalCutMcpEnvironment({
+    FRAMEKIT_COMMIT_VALIDATION: "1",
+    FRAMEKIT_EDITOR: "fixture",
+    FRAMEKIT_FINAL_CUT_HEADLESS: "1",
+    FRAMEKIT_FINAL_CUT_NATIVE_WRITES: "0",
+  });
+  assert.equal(environment.FRAMEKIT_EDITOR, "final-cut-live");
+  assert.equal(environment.FRAMEKIT_FINAL_CUT_HEADLESS, "1");
+  assert.equal(environment.FRAMEKIT_FINAL_CUT_NATIVE_WRITES, "0");
 });


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #24 

## Summary

Pre-commit validation exported safe Final Cut settings, but the live MCP integration tests overwrote them with FRAMEKIT_FINAL_CUT_HEADLESS=0 and FRAMEKIT_FINAL_CUT_NATIVE_WRITES=1. When the Workflow Extension was installed, those tests could invoke Accessibility automation and open or focus Final Cut Pro.

This change:

- adds FRAMEKIT_COMMIT_VALIDATION=1 to the pre-commit environment;
- makes live Final Cut contract-test environments preserve headless/native-disabled settings during commit validation;
- asserts fail-closed CAPABILITY_UNAVAILABLE behavior in hook mode;
- documents the validation guard.

<!-- Please provide a summary of what you did in this pull request -->
<!-- Example: Added △△ functionality to resolve the issue with 〇〇 -->
<!-- Please attach a Github Label to indicate the type of PR -->
<!-- open -->

<!-- close -->

## Validation

<!-- List the commands you ran and summarize the result. -->

```bash
pnpm run build
pnpm run test
pnpm run check:boundaries
```

Native changes should also include the relevant macOS/Xcode validation.

## Architecture and compatibility

- [ ] Runtime remains independent of MCP and editor-specific implementations.
- [ ] Public MCP behavior or package interfaces are documented if changed.
- [ ] Existing adapters and test fixtures remain compatible, or the migration is explained above.

## Safety

- [ ] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [ ] Generated files and build artifacts are excluded.
- [ ] Documentation reflects any changed commands, paths, or environment variables.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved integration coverage for validation workflows and media-editing connectivity.
  - Added checks confirming native capabilities and write operations are safely unavailable during validation.
  - Expanded pre-commit verification for headless operation, editor settings, and safe native behavior.
  - Standardized environment handling and error reporting across integration scenarios.

- **Chores**
  - Aligned commit-validation settings across automated checks and developer workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->