### PR TITLE
fix: preserve imported media handles across searches

### DIFF
--- a/adapters/final-cut/typescript/src/native.ts
+++ b/adapters/final-cut/typescript/src/native.ts
@@ -1854,14 +1854,23 @@ tell application "System Events"
       set value of attribute "AXFocused" of searchField to true
     end try
     delay 0.5
+    set targetSourceIdentity to ${appleScriptString(match.sourceIdentity ?? "")}
     set targetIdentity to ${appleScriptString(match.identity ?? "")}
-    if targetIdentity is "" then error "FINAL_CUT_NATIVE_MEDIA_SELECTION_UNAVAILABLE: Browser result has no stable identity"
+    if targetSourceIdentity is "" and targetIdentity is "" then error "FINAL_CUT_NATIVE_MEDIA_SELECTION_UNAVAILABLE: Browser result has no stable identity"
     repeat with candidate in entire contents of mainWindow
       try
-        set candidateIdentity to ((position of candidate) as text) & "|" & ((size of candidate) as text)
-        if candidateIdentity is targetIdentity then
-          perform action "AXPress" of candidate
-          return "selected"
+        if targetSourceIdentity is not "" then
+          set candidateSourceIdentity to value of attribute "AXIdentifier" of candidate as text
+          if candidateSourceIdentity is targetSourceIdentity then
+            perform action "AXPress" of candidate
+            return "selected"
+          end if
+        else
+          set candidateIdentity to ((position of candidate) as text) & "|" & ((size of candidate) as text)
+          if candidateIdentity is targetIdentity then
+            perform action "AXPress" of candidate
+            return "selected"
+          end if
         end if
       on error
         -- Ignore inaccessible descendants and continue looking for the target.

--- a/adapters/final-cut/typescript/src/native.ts
+++ b/adapters/final-cut/typescript/src/native.ts
@@ -592,7 +592,10 @@ export class FinalCutNativeAutomationAdapter implements NativeFinalCutEditor {
         const stableHandle = identity ? this.stableMediaHandles.get(identity) : undefined;
         return stableHandle ? { ...match, handle: stableHandle } : match;
       });
-      this.mediaHandles.clear();
+      const stableHandles = new Set(this.stableMediaHandles.values());
+      for (const handle of this.mediaHandles.keys()) {
+        if (!stableHandles.has(handle)) this.mediaHandles.delete(handle);
+      }
       this.selectedMediaHandle = undefined;
       for (const match of matches) this.mediaHandles.set(match.handle, match);
       return matches;

--- a/tests/integration/native.test.ts
+++ b/tests/integration/native.test.ts
@@ -1309,6 +1309,40 @@ test("native Final Cut imports local video and audio, waits for Browser availabi
   assert.equal(selected.target.name, "interview.mov");
 });
 
+test("native Final Cut keeps an imported media handle usable after an unrelated Browser search", async () => {
+  const directory = await mkdtemp(join(os.tmpdir(), "framekit-native-media-stable-handle-"));
+  const sourcePath = join(directory, "interview.mov");
+  await writeFile(sourcePath, "video fixture");
+
+  const recordSeparator = String.fromCharCode(30);
+  let interviewSearches = 0;
+  const adapter = new FinalCutNativeAutomationAdapter({
+    enabled: true,
+    executor: async (script) => {
+      if (script.includes('set frontWindow to window "Final Cut Pro"')) return context(true, "Final Cut Pro", "", 0, false);
+      if (script.includes("FRAMEKIT_IMPORT_MEDIA")) return "import-requested";
+      if (script.includes("AXBrowserMedia") && script.includes("interview.mov")) {
+        interviewSearches += 1;
+        return interviewSearches === 1
+          ? ""
+          : `interview.mov${separator}AXBrowserMedia${separator}browser-interview${separator}file:///imported/interview.mov${recordSeparator}`;
+      }
+      if (script.includes("AXBrowserMedia") && script.includes("other.mov")) {
+        return `other.mov${separator}AXBrowserMedia${separator}browser-other${separator}file:///library/other.mov${recordSeparator}`;
+      }
+      return "";
+    },
+  });
+
+  const imported = await adapter.importMedia(sourcePath);
+  const unrelated = await adapter.searchMedia("other.mov");
+  assert.equal(unrelated[0]?.name, "other.mov");
+
+  const selected = await adapter.selectMedia(imported.mediaHandle);
+  assert.equal(selected.target.kind, "browser-media");
+  assert.equal(selected.target.name, "interview.mov");
+});
+
 test("native Final Cut ignores a pre-existing same-name Browser item during import", async () => {
   const directory = await mkdtemp(join(os.tmpdir(), "framekit-native-media-identity-"));
   const sourcePath = join(directory, "interview.mov");

--- a/tests/integration/native.test.ts
+++ b/tests/integration/native.test.ts
@@ -1321,6 +1321,14 @@ test("native Final Cut keeps an imported media handle usable after an unrelated 
     executor: async (script) => {
       if (script.includes('set frontWindow to window "Final Cut Pro"')) return context(true, "Final Cut Pro", "", 0, false);
       if (script.includes("FRAMEKIT_IMPORT_MEDIA")) return "import-requested";
+      if (script.includes("set targetIdentity to")) {
+        const selectsBySourceIdentity = script.includes('set targetSourceIdentity to "file:///imported/interview.mov"')
+          && script.includes("if candidateSourceIdentity is targetSourceIdentity then");
+        if (!selectsBySourceIdentity) {
+          throw new Error("selection used stale Browser geometry");
+        }
+        return "selected";
+      }
       if (script.includes("AXBrowserMedia") && script.includes("interview.mov")) {
         interviewSearches += 1;
         return interviewSearches === 1


### PR DESCRIPTION
- [ ] Request PR review
- [x] Github issue: Closes: #46

## Summary

- Preserve imported session media handles when later Browser searches return unrelated assets.
- Continue clearing short-lived search handles and Browser selection state.
- Add a public-adapter regression test covering import, unrelated search, and selection by the original handle.

## TDD commits

- `c38ff57` Red: reproduce `FINAL_CUT_NATIVE_MEDIA_HANDLE_STALE`.
- `65a7cf7` Green: retain only handles registered as session-stable imports.

## Validation

```bash
pnpm install --frozen-lockfile
pnpm run build
pnpm run test # 114 passed
pnpm run test:final-cut-headless # 66 passed
pnpm run check:boundaries
pnpm run xcode:check
xcodebuild -project adapters/final-cut/swift-bridge/FinalCutWorkflowExtension/FramekitFinalCutWorkflow.xcodeproj -list
```

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Public MCP behavior or package interfaces are documented if changed. No public contract changed; this restores the documented session-stable import behavior.
- [x] Existing adapters and test fixtures remain compatible.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [x] Documentation remains accurate; no commands, paths, or environment variables changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Imported media remains selectable after searching for unrelated content.
  - Searches now preserve stable media references, improving reliability when switching between imported and searched media.

- **Tests**
  - Added coverage for selecting imported media after an unrelated search.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->