### PR TITLE
fix: reject cross-target restore and undo

### DIFF
--- a/docs/final-cut/basic-editing-mvp.md
+++ b/docs/final-cut/basic-editing-mvp.md
@@ -145,6 +145,8 @@ export manifest and output digest. The required verification tiers are:
   for this MVP.
 
 `edit.undo` must restore the pre-edit snapshot for a completed transaction.
+The transaction is scoped to its original project and sequence; if another
+target is active, undo fails with `TARGET_MISMATCH` before requesting a restore.
 After undo, `project.inspect` must show the original timeline digest and no
 MVP-created media or title occurrence may remain. A failed verification must
 rollback before returning a failed result.

--- a/docs/mcp/capabilities-and-errors.md
+++ b/docs/mcp/capabilities-and-errors.md
@@ -42,6 +42,8 @@ Important error codes include:
 - `FINAL_CUT_LIVE_PROTOCOL`: framing, JSON, or version failure.
 - `EDITOR_NOT_CONNECTED`: no usable editor backend is connected.
 - `STALE_CONTEXT`: an edit used an old revision.
+- `TARGET_MISMATCH`: restore or undo targets a different project or sequence
+  from the active editor target.
 - `ANALYZER_MEDIA_UNAVAILABLE`: the configured analyzer cannot read the media source.
 - `ANALYZER_TIMEOUT`: a configured analyzer exceeded its time limit.
 - `ANALYZER_FAILED`: a configured analyzer exited unsuccessfully.

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -255,6 +255,14 @@ export class AgentVideoRuntime {
   public async undo(transactionId: string): Promise<ProjectSnapshot> {
     const transaction = this.getTransaction(transactionId);
     const current = await this.inspectProject();
+    if (
+      current.projectId !== transaction.before.projectId
+      || current.timeline.id !== transaction.before.timeline.id
+    ) {
+      throw new Error(
+        `TARGET_MISMATCH: cannot undo ${transaction.before.projectId}/${transaction.before.timeline.id} while ${current.projectId}/${current.timeline.id} is active`,
+      );
+    }
     await this.adapter.restore(transaction.before, current.revision);
     return this.inspectProject();
   }

--- a/packages/testkit/src/in-memory-editor.ts
+++ b/packages/testkit/src/in-memory-editor.ts
@@ -237,6 +237,11 @@ export class InMemoryEditorAdapter implements EditorPort {
     if (this.snapshot.revision.id !== expectedRevision.id) {
       throw new Error("STALE_CONTEXT: editor revision changed before rollback");
     }
+    if (snapshot.projectId !== this.activeProjectId || snapshot.timeline.id !== this.activeSequenceId) {
+      throw new Error(
+        `TARGET_MISMATCH: cannot restore ${snapshot.projectId}/${snapshot.timeline.id} while ${this.activeProjectId}/${this.activeSequenceId} is active`,
+      );
+    }
     this.snapshot = {
       ...structuredClone(snapshot),
       revision: {

--- a/tests/integration/basic-editing-mvp.test.ts
+++ b/tests/integration/basic-editing-mvp.test.ts
@@ -43,6 +43,7 @@ test("Basic Final Cut editing MVP has an executable design contract", async () =
 
   assert.match(contract, /base revision/i);
   assert.match(contract, /CAPABILITY_UNAVAILABLE/);
+  assert.match(contract, /TARGET_MISMATCH/);
   assert.match(contract, /deterministic fixture/i);
   assert.match(contract, /live Final Cut/i);
   assert.match(contract, /success metrics/i);

--- a/tests/integration/project-selection.test.ts
+++ b/tests/integration/project-selection.test.ts
@@ -15,8 +15,8 @@ function textFrom(result: unknown): string {
   return first.text as string;
 }
 
-test("MCP lists stable project identities, selects an explicit timeline, and rejects ambiguity", async () => {
-  const adapter = new InMemoryEditorAdapter({
+function multiProjectAdapter(): InMemoryEditorAdapter {
+  return new InMemoryEditorAdapter({
     projectId: "project-alpha",
     projectName: "Alpha",
     timelineId: "sequence-alpha-main",
@@ -61,6 +61,10 @@ test("MCP lists stable project identities, selects an explicit timeline, and rej
       },
     ],
   });
+}
+
+test("MCP lists stable project identities, selects an explicit timeline, and rejects ambiguity", async () => {
+  const adapter = multiProjectAdapter();
   const client = new Client({ name: "project-selection-test", version: "0.1.0" });
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   const server = createMcpServer(new AgentVideoRuntime(adapter));
@@ -109,4 +113,39 @@ test("MCP lists stable project identities, selects an explicit timeline, and rej
     await client.close();
     await server.close();
   }
+});
+
+test("in-memory restore rejects another project's snapshot without mutating the active target", async () => {
+  const adapter = multiProjectAdapter();
+  const alpha = await adapter.readProject();
+  await adapter.selectProject({ projectId: "project-beta", sequenceId: "sequence-beta-main" });
+  const beta = await adapter.readProject();
+
+  await assert.rejects(adapter.restore(alpha, beta.revision), /TARGET_MISMATCH/);
+
+  const inspected = await adapter.readProject();
+  const catalog = await adapter.listProjects();
+  assert.equal(inspected.projectId, "project-beta");
+  assert.equal(inspected.timeline.id, "sequence-beta-main");
+  assert.equal(catalog.activeProjectId, inspected.projectId);
+  assert.equal(catalog.activeSequenceId, inspected.timeline.id);
+
+  await adapter.selectProject({ projectId: "project-alpha", sequenceId: "sequence-alpha-main" });
+  assert.equal((await adapter.readProject()).projectId, "project-alpha");
+});
+
+test("in-memory restore rejects another sequence's snapshot without mutating the active target", async () => {
+  const adapter = multiProjectAdapter();
+  const main = await adapter.readProject();
+  await adapter.selectProject({ projectId: "project-alpha", sequenceId: "sequence-alpha-social" });
+  const social = await adapter.readProject();
+
+  await assert.rejects(adapter.restore(main, social.revision), /TARGET_MISMATCH/);
+
+  const inspected = await adapter.readProject();
+  const catalog = await adapter.listProjects();
+  assert.equal(inspected.projectId, "project-alpha");
+  assert.equal(inspected.timeline.id, "sequence-alpha-social");
+  assert.equal(catalog.activeProjectId, inspected.projectId);
+  assert.equal(catalog.activeSequenceId, inspected.timeline.id);
 });

--- a/tests/integration/project-selection.test.ts
+++ b/tests/integration/project-selection.test.ts
@@ -149,3 +149,30 @@ test("in-memory restore rejects another sequence's snapshot without mutating the
   assert.equal(catalog.activeProjectId, inspected.projectId);
   assert.equal(catalog.activeSequenceId, inspected.timeline.id);
 });
+
+test("runtime undo rejects a transaction after the active target changes without delegating restore", async () => {
+  const adapter = multiProjectAdapter();
+  const originalRestore = adapter.restore.bind(adapter);
+  let restoreCalls = 0;
+  adapter.restore = async (snapshot, expectedRevision) => {
+    restoreCalls += 1;
+    return originalRestore(snapshot, expectedRevision);
+  };
+  const runtime = new AgentVideoRuntime(adapter);
+  const transaction = await runtime.edit({
+    type: "add-marker",
+    timelineId: "sequence-alpha-main",
+    marker: { id: "marker-alpha", start: 0, duration: 0, name: "Alpha marker" },
+  });
+  await runtime.selectProject({ projectId: "project-beta", sequenceId: "sequence-beta-main" });
+
+  await assert.rejects(runtime.undo(transaction.id), /TARGET_MISMATCH/);
+
+  assert.equal(restoreCalls, 0);
+  const inspected = await runtime.inspectProject();
+  const catalog = await runtime.listProjects();
+  assert.equal(inspected.projectId, "project-beta");
+  assert.equal(inspected.timeline.id, "sequence-beta-main");
+  assert.equal(catalog.activeProjectId, inspected.projectId);
+  assert.equal(catalog.activeSequenceId, inspected.timeline.id);
+});


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [x] Github issue: Closes: #39

## Summary

- reject in-memory snapshot restores when the snapshot project or sequence differs from the active target
- reject runtime undo before delegating restore when the transaction belongs to another target
- preserve the active snapshot/catalog state and document the new `TARGET_MISMATCH` error
- add direct cross-project, cross-sequence, and runtime undo regression coverage

## Validation

```bash
pnpm install --frozen-lockfile
pnpm run build
pnpm run test
pnpm run check:boundaries
```

All 116 tests pass. No native files changed, so macOS/Xcode validation is not required.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Public MCP behavior or package interfaces are documented if changed.
- [x] Existing adapters and test fixtures remain compatible, or the migration is explained above.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [x] Documentation reflects any changed commands, paths, or environment variables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Undo and restore operations now verify that the original project and timeline are still active.
  - Prevented accidental state changes when undo or restore targets no longer match the active editor context.
  - Added a clear `TARGET_MISMATCH` error for invalid targets.

- **Documentation**
  - Documented the new target-mismatch error and editing behavior.

- **Tests**
  - Added coverage for switching projects or timelines before undo and restore operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->