### PR TITLE
fix: keep FCPXML project identities stable

### DIFF
--- a/adapters/final-cut/typescript/src/fcpxml.ts
+++ b/adapters/final-cut/typescript/src/fcpxml.ts
@@ -470,19 +470,19 @@ function hash(content: string): string {
 }
 
 function stableProjectId(project: XmlNode): string {
-  const uid = attribute(project, "uid");
-  if (uid === undefined || String(uid).trim().length === 0) {
-    throw new Error("FCPXML_PROJECT_IDENTITY_UNAVAILABLE: project has no immutable uid");
-  }
-  return `fcpxml:project:${String(uid)}`;
+  return `fcpxml:project:${immutableUid(project, "PROJECT")}`;
 }
 
 function stableSequenceId(sequence: XmlNode | undefined): string {
-  const uid = sequence ? attribute(sequence, "uid") : undefined;
+  return `fcpxml:sequence:${immutableUid(sequence, "SEQUENCE")}`;
+}
+
+function immutableUid(node: XmlNode | undefined, kind: "PROJECT" | "SEQUENCE"): string {
+  const uid = node ? attribute(node, "uid") : undefined;
   if (uid === undefined || String(uid).trim().length === 0) {
-    throw new Error("FCPXML_SEQUENCE_IDENTITY_UNAVAILABLE: sequence has no immutable uid");
+    throw new Error(`FCPXML_${kind}_IDENTITY_UNAVAILABLE: ${kind.toLowerCase()} has no immutable uid`);
   }
-  return `fcpxml:sequence:${String(uid)}`;
+  return String(uid);
 }
 
 function stableTimelineId(project: XmlNode, sequence: XmlNode | undefined): string {

--- a/adapters/final-cut/typescript/src/fcpxml.ts
+++ b/adapters/final-cut/typescript/src/fcpxml.ts
@@ -89,7 +89,7 @@ export class FcpxmlDocumentAdapter implements EditorPort {
     const sequence = sequenceNode ?? {};
     const spine = findElement(sequence, "spine") ?? {};
     const projectName = String(attribute(project, "name") ?? "Final Cut Project");
-    const projectId = stableProjectId(project, projectName);
+    const projectId = stableProjectId(project);
     const sequenceName = String(attribute(sequenceNode ?? {}, "name") ?? projectName);
     const timelineId = stableTimelineId(project, sequenceNode);
     const elements = storyEntries(spine);
@@ -125,10 +125,10 @@ export class FcpxmlDocumentAdapter implements EditorPort {
     await this.ensureLoaded();
     const project = this.projectNode();
     const projectName = String(attribute(project, "name") ?? "Final Cut Project");
-    const projectId = stableProjectId(project, projectName);
+    const projectId = stableProjectId(project);
     const sequence = findElement(project, "sequence");
     const sequenceName = String(attribute(sequence ?? {}, "name") ?? projectName);
-    const sequenceId = stableSequenceId(sequence, projectId, sequenceName);
+    const sequenceId = stableSequenceId(sequence);
     return {
       projects: [{
         id: projectId,
@@ -469,21 +469,25 @@ function hash(content: string): string {
   return createHash("sha256").update(content).digest("hex");
 }
 
-function stableProjectId(project: XmlNode, projectName: string): string {
+function stableProjectId(project: XmlNode): string {
   const uid = attribute(project, "uid");
-  return `fcpxml:project:${String(uid ?? hash(projectName).slice(0, 16))}`;
+  if (uid === undefined || String(uid).trim().length === 0) {
+    throw new Error("FCPXML_PROJECT_IDENTITY_UNAVAILABLE: project has no immutable uid");
+  }
+  return `fcpxml:project:${String(uid)}`;
 }
 
-function stableSequenceId(sequence: XmlNode | undefined, projectId: string, sequenceName: string): string {
+function stableSequenceId(sequence: XmlNode | undefined): string {
   const uid = sequence ? attribute(sequence, "uid") : undefined;
-  return `fcpxml:sequence:${String(uid ?? hash(`${projectId}:${sequenceName}`).slice(0, 16))}`;
+  if (uid === undefined || String(uid).trim().length === 0) {
+    throw new Error("FCPXML_SEQUENCE_IDENTITY_UNAVAILABLE: sequence has no immutable uid");
+  }
+  return `fcpxml:sequence:${String(uid)}`;
 }
 
 function stableTimelineId(project: XmlNode, sequence: XmlNode | undefined): string {
-  const projectName = String(attribute(project, "name") ?? "Final Cut Project");
-  const projectId = stableProjectId(project, projectName);
-  const sequenceName = String(attribute(sequence ?? {}, "name") ?? projectName);
-  return stableSequenceId(sequence, projectId, sequenceName);
+  stableProjectId(project);
+  return stableSequenceId(sequence);
 }
 
 function sameRevision(left: ContextRevision, right: ContextRevision): boolean {

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -7,7 +7,7 @@ authoritative at runtime; unsupported operations must fail with an explicit
 | Adapter | Backend | Project read | Timeline write | Read-after-write | Rollback | Speech/audio | Visual | Native assets |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | In-memory fixture | deterministic test fixture | yes | yes | yes | yes | fixture providers | fixture provider | fixture assets |
-| Final Cut document | FCPXML file interchange | yes | artifact only | yes | yes | external provider required | no | no |
+| Final Cut document | FCPXML file interchange | yes, with project and sequence UIDs | artifact only | yes | yes | external provider required | no | no |
 | Final Cut session | document + Workflow Extension | document provider | artifact only | document provider | document provider | configured local provider | configured local provider | Motion-template registry |
 | Final Cut live | Workflow Extension live IPC | active project/sequence metadata only; catalog/selection unavailable | no | no | no | no | no | no |
 
@@ -26,6 +26,11 @@ This is a local verification record, not a claim that every nearby editor or
 OS version is supported.
 
 The FCPXML adapter is intentionally not a live Final Cut automation backend.
+It uses non-empty FCPXML `uid` attributes as the only stable project and
+sequence identities. UID-less documents fail closed with
+`FCPXML_PROJECT_IDENTITY_UNAVAILABLE` or
+`FCPXML_SEQUENCE_IDENTITY_UNAVAILABLE`; names are never used as ID fallbacks.
+Renaming a UID-backed project or sequence therefore does not change its ID.
 The session adapter composes independent snapshot, mutation, live-state,
 analyzer, and asset ports. The Workflow Extension backend is a separate
 live-state port: it exposes active project metadata and a project-scoped

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -62,7 +62,11 @@ backend. The current Workflow Extension exposes only the active project and
 sequence metadata, not a project browser or project-selection API, so a
 live-only session rejects these tools with `CAPABILITY_UNAVAILABLE`. An
 FCPXML-backed session can inspect and select its single managed project;
-selection never silently changes the open Final Cut project.
+selection never silently changes the open Final Cut project. Its project and
+sequence nodes must both provide non-empty `uid` attributes; otherwise project
+inspection and catalog operations fail with `FCPXML_PROJECT_IDENTITY_UNAVAILABLE`
+or `FCPXML_SEQUENCE_IDENTITY_UNAVAILABLE` instead of deriving IDs from mutable
+names.
 
 `media.search` remains canonical snapshot search. Live Browser import and search
 use the explicit `editor.native.media.*` tools because Browser media identity and

--- a/tests/integration/finalcut-mcp.test.ts
+++ b/tests/integration/finalcut-mcp.test.ts
@@ -35,7 +35,7 @@ test("Final Cut MCP composes FCPXML reads, local analysis, assets, edits, and un
   await writeFile(xmlPath, `<?xml version="1.0" encoding="UTF-8"?>
 <fcpxml version="1.11">
   <resources><asset id="r1" name="Interview.wav" src="interview.wav" /></resources>
-  <library><event name="Event"><project name="MCP Final Cut"><sequence duration="10s"><spine>
+  <library><event name="Event"><project uid="project-mcp" name="MCP Final Cut"><sequence uid="sequence-mcp" duration="10s"><spine>
     <asset-clip ref="r1" name="Interview" offset="0s" start="0s" duration="10s" lane="1" />
   </spine></sequence></project></event></library>
 </fcpxml>`);

--- a/tests/integration/phase1.test.ts
+++ b/tests/integration/phase1.test.ts
@@ -86,7 +86,7 @@ test("Final Cut adapter reads and writes a supported FCPXML timeline", async () 
   await writeFile(path, `<?xml version="1.0" encoding="UTF-8"?>
 <fcpxml version="1.11">
   <resources><asset id="r1" name="Interview.wav" src="file:///Interview.wav" /></resources>
-  <library><event name="Event"><project name="Phase 1 Fixture"><sequence duration="10s"><spine>
+  <library><event name="Event"><project name="Phase 1 Fixture" uid="project-phase-1"><sequence uid="sequence-phase-1" duration="10s"><spine>
     <asset-clip ref="r1" name="Interview" offset="0s" start="0s" duration="1001/24000s" lane="1" />
   </spine></sequence></project></event></library>
 </fcpxml>`);
@@ -133,10 +133,61 @@ test("Final Cut adapter reads and writes a supported FCPXML timeline", async () 
   assert.match(await readFile(path, "utf8"), /adjust-volume amount="2dB"/);
 });
 
+test("FCPXML project identity fails closed without an immutable uid", async () => {
+  const directory = await mkdtemp(join(os.tmpdir(), "framekit-fcpxml-project-identity-"));
+  const path = join(directory, "project.fcpxml");
+  await writeFile(path, `<?xml version="1.0"?><fcpxml><resources/><library><event><project name="Mutable Project"><sequence uid="sequence-stable" name="Stable Sequence" duration="1s"><spine><gap duration="1s" /></spine></sequence></project></event></library></fcpxml>`);
+  const adapter = new FcpxmlDocumentAdapter(path);
+
+  await assert.rejects(adapter.listProjects(), /FCPXML_PROJECT_IDENTITY_UNAVAILABLE/);
+  await assert.rejects(adapter.readProject(), /FCPXML_PROJECT_IDENTITY_UNAVAILABLE/);
+});
+
+test("FCPXML sequence identity fails closed without an immutable uid", async () => {
+  const directory = await mkdtemp(join(os.tmpdir(), "framekit-fcpxml-sequence-identity-"));
+  const path = join(directory, "project.fcpxml");
+  await writeFile(path, `<?xml version="1.0"?><fcpxml><resources/><library><event><project uid="project-stable" name="Stable Project"><sequence name="Mutable Sequence" duration="1s"><spine><gap duration="1s" /></spine></sequence></project></event></library></fcpxml>`);
+  const adapter = new FcpxmlDocumentAdapter(path);
+
+  await assert.rejects(adapter.listProjects(), /FCPXML_SEQUENCE_IDENTITY_UNAVAILABLE/);
+  await assert.rejects(adapter.readProject(), /FCPXML_SEQUENCE_IDENTITY_UNAVAILABLE/);
+});
+
+test("UID-backed FCPXML identities remain stable across project and sequence renames", async () => {
+  const directory = await mkdtemp(join(os.tmpdir(), "framekit-fcpxml-identity-rename-"));
+  const path = join(directory, "project.fcpxml");
+  await writeFile(path, `<?xml version="1.0"?><fcpxml><resources/><library><event><project uid="project-stable" name="Before Project"><sequence uid="sequence-stable" name="Before Sequence" duration="1s"><spine><gap duration="1s" /></spine></sequence></project></event></library></fcpxml>`);
+  const adapter = new FcpxmlDocumentAdapter(path);
+  const before = await adapter.listProjects();
+
+  await writeFile(path, (await readFile(path, "utf8"))
+    .replace("Before Project", "After Project")
+    .replace("Before Sequence", "After Sequence"));
+  const after = await adapter.listProjects();
+
+  assert.equal(after.activeProjectId, before.activeProjectId);
+  assert.equal(after.activeSequenceId, before.activeSequenceId);
+});
+
+test("UID-backed same-name FCPXML targets remain distinct", async () => {
+  const directory = await mkdtemp(join(os.tmpdir(), "framekit-fcpxml-identity-collision-"));
+  const firstPath = join(directory, "first.fcpxml");
+  const secondPath = join(directory, "second.fcpxml");
+  const document = (projectUid: string, sequenceUid: string) => `<?xml version="1.0"?><fcpxml><resources/><library><event><project uid="${projectUid}" name="Shared Project"><sequence uid="${sequenceUid}" name="Shared Sequence" duration="1s"><spine><gap duration="1s" /></spine></sequence></project></event></library></fcpxml>`;
+  await writeFile(firstPath, document("project-first", "sequence-first"));
+  await writeFile(secondPath, document("project-second", "sequence-second"));
+
+  const first = await new FcpxmlDocumentAdapter(firstPath).listProjects();
+  const second = await new FcpxmlDocumentAdapter(secondPath).listProjects();
+
+  assert.notEqual(first.activeProjectId, second.activeProjectId);
+  assert.notEqual(first.activeSequenceId, second.activeSequenceId);
+});
+
 test("Final Cut adapter turns external FCPXML edits into a new revision", async () => {
   const directory = await mkdtemp(join(os.tmpdir(), "framekit-fcpxml-external-"));
   const path = join(directory, "project.fcpxml");
-  await writeFile(path, `<?xml version="1.0"?><fcpxml><resources/><library><event><project name="External"><sequence duration="2s"><spine><asset-clip ref="r1" name="Original" offset="0s" duration="2s" /></spine></sequence></project></event></library></fcpxml>`);
+  await writeFile(path, `<?xml version="1.0"?><fcpxml><resources/><library><event><project uid="project-external" name="External"><sequence uid="sequence-external" duration="2s"><spine><asset-clip ref="r1" name="Original" offset="0s" duration="2s" /></spine></sequence></project></event></library></fcpxml>`);
   const adapter = new FcpxmlDocumentAdapter(path);
   const before = await adapter.readProject();
   await writeFile(path, (await readFile(path, "utf8")).replace("Original", "External Edit"));
@@ -152,7 +203,7 @@ test("Final Cut adapter turns external FCPXML edits into a new revision", async 
 test("FCPXML preserves heterogeneous spine order and distinct clip occurrences", async () => {
   const directory = await mkdtemp(join(os.tmpdir(), "framekit-fcpxml-order-"));
   const path = join(directory, "project.fcpxml");
-  await writeFile(path, `<?xml version="1.0"?><fcpxml><resources><asset id="r1" src="file:///interview.mov" /></resources><library><event><project name="Ordered"><sequence duration="8s"><spine>
+  await writeFile(path, `<?xml version="1.0"?><fcpxml><resources><asset id="r1" src="file:///interview.mov" /></resources><library><event><project uid="project-ordered" name="Ordered"><sequence uid="sequence-ordered" duration="8s"><spine>
     <asset-clip ref="r1" offset="0s" duration="2s" />
     <gap offset="2s" duration="1s" />
     <title offset="3s" duration="1s" name="Card" />
@@ -180,7 +231,7 @@ test("FCPXML preserves heterogeneous spine order and distinct clip occurrences",
 test("Final Cut session composes document snapshot and live state providers", async () => {
   const directory = await mkdtemp(join(os.tmpdir(), "framekit-fcpxml-session-"));
   const path = join(directory, "project.fcpxml");
-  await writeFile(path, `<?xml version="1.0"?><fcpxml><resources/><library><event><project name="Session"><sequence duration="1s"><spine><gap duration="1s" /></spine></sequence></project></event></library></fcpxml>`);
+  await writeFile(path, `<?xml version="1.0"?><fcpxml><resources/><library><event><project uid="project-session" name="Session"><sequence uid="sequence-session" duration="1s"><spine><gap duration="1s" /></spine></sequence></project></event></library></fcpxml>`);
   const live = new FinalCutLiveAdapter(new FakeFinalCutLiveTransport());
   const session = new FinalCutSessionAdapter({
     snapshot: new FcpxmlDocumentAdapter(path),
@@ -199,7 +250,7 @@ test("Final Cut session composes document snapshot and live state providers", as
 test("snapshot-only Final Cut sessions advertise and select their project target", async () => {
   const directory = await mkdtemp(join(os.tmpdir(), "framekit-fcpxml-snapshot-selection-"));
   const path = join(directory, "project.fcpxml");
-  await writeFile(path, `<?xml version="1.0"?><fcpxml><resources/><library><event><project name="Snapshot Only"><sequence duration="1s"><spine><gap duration="1s" /></spine></sequence></project></event></library></fcpxml>`);
+  await writeFile(path, `<?xml version="1.0"?><fcpxml><resources/><library><event><project uid="project-snapshot" name="Snapshot Only"><sequence uid="sequence-snapshot" duration="1s"><spine><gap duration="1s" /></spine></sequence></project></event></library></fcpxml>`);
   const document = new FcpxmlDocumentAdapter(path);
   const session = new FinalCutSessionAdapter({ snapshot: document });
   const capabilities = await session.getCapabilities();


### PR DESCRIPTION
## Summary

- reject UID-less FCPXML project and sequence identities instead of hashing mutable names
- preserve stable IDs across renames and distinguish same-name UID-backed targets
- document the FCPXML UID requirement and explicit fail-closed errors

## TDD checkpoints

- `f9e94e5` — Red: add missing-UID regressions and UID-backed characterization coverage
- `fd152da` — Green: remove mutable-name fallbacks and fail closed on unavailable immutable identity
- `2909bf8` — Refactor: consolidate UID validation and document the contract

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm run test` — 117 passed
- `pnpm run check:boundaries`

No native files changed, so Xcode validation was not required.

Closes #38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Project and sequence identities now remain stable when names change.
  - Same-named projects or sequences in different documents are distinguished reliably.
  - Documents without required immutable identifiers now fail clearly instead of using potentially changing names.

- **Documentation**
  - Final Cut compatibility and project-selection requirements now explain identifier requirements and failure behavior.

- **Tests**
  - Added coverage for renamed items, duplicate names, missing identifiers, and related editing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->