### PR TITLE
feat: distribute Framekit as a Codex plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "framekit",
+  "interface": {
+    "displayName": "Framekit"
+  },
+  "plugins": [
+    {
+      "name": "framekit",
+      "source": {
+        "source": "local",
+        "path": "./plugins/framekit"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,3 +29,34 @@ jobs:
         uses: Songmu/tagpr@v1
         env:
           GITHUB_TOKEN: ${{ secrets.TAGPR_TOKEN }}
+
+  publish-npm:
+    if: needs.tagpr.outputs.tagpr-tag != ''
+    needs: tagpr
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.10.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.14.0
+          registry-url: https://registry.npmjs.org
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Publish npm package
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -67,6 +67,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install Codex CLI
+        run: npm install --global @openai/codex
+
+      - name: Validate clean Codex plugin installation
+        run: pnpm run test:codex-plugin
+
       - name: Run unit and integration tests
         run: pnpm run test
 

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -68,7 +68,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Codex CLI
-        run: npm install --global @openai/codex
+        run: npm install --global @openai/codex@0.144.1
 
       - name: Validate clean Codex plugin installation
         run: pnpm run test:codex-plugin

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+dist-package/
 .DS_Store
 
 PLAN.md

--- a/.tagpr
+++ b/.tagpr
@@ -5,4 +5,4 @@
 	releaseBranch = main
 	release = draft
 	changelog = true
-	versionFile = -
+	versionFile = package.json,plugins/framekit/.codex-plugin/plugin.json

--- a/README.md
+++ b/README.md
@@ -39,11 +39,21 @@ The default `.env.example` starts the Diffusers visual service without the optio
 
 ## Connect Codex to Final Cut
 
-Register the local MCP server with Codex:
+Install the signed Framekit Workflow Extension from the latest release, then
+configure the Framekit marketplace once:
 
 ```sh
-codex mcp add framekit -- framekit mcp --editor final-cut-live --headless
+codex plugin marketplace add morshoto/framekit
 ```
+
+Open `/plugins` in Codex, find **Framekit**, and select **Install**. Start a new
+Codex session to load the Framekit MCP tools. No repository checkout or manual
+`codex mcp add` is required.
+
+The plugin runs the published package in headless mode. It connects only to an
+existing Workflow Extension bridge and does not launch, activate, focus, or
+edit Final Cut through macOS UI automation. See the
+[first-run setup and capability boundaries](./docs/final-cut/installation.md).
 
 ## Further Docs
 

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -65,8 +65,9 @@ async function runMcp(args: string[]): Promise<void> {
     throw new Error("Usage: --headless is only supported with --editor final-cut-live");
   }
   const root = repoRoot();
-  const entrypoint = join(root, "apps/mcp-server/src/main.ts");
-  const child = spawn(process.execPath, ["--import", "tsx", entrypoint], {
+  const compiled = fileURLToPath(import.meta.url).endsWith(".js");
+  const entrypoint = join(root, `apps/mcp-server/src/main.${compiled ? "js" : "ts"}`);
+  const child = spawn(process.execPath, [...(compiled ? [] : ["--import", "tsx"]), entrypoint], {
     stdio: "inherit",
     env: {
       ...process.env,

--- a/bin/framekit.mjs
+++ b/bin/framekit.mjs
@@ -1,13 +1,20 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-const entrypoint = fileURLToPath(new URL("../apps/cli/src/main.ts", import.meta.url));
-const child = spawn(process.execPath, ["--import", "tsx", entrypoint, ...process.argv.slice(2)], {
-  stdio: "inherit",
-  env: process.env,
-});
+const packagedEntrypoint = fileURLToPath(new URL("../dist-package/apps/cli/src/main.js", import.meta.url));
+const developmentEntrypoint = fileURLToPath(new URL("../apps/cli/src/main.ts", import.meta.url));
+const packaged = existsSync(packagedEntrypoint);
+const child = spawn(
+  process.execPath,
+  [...(packaged ? [] : ["--import", "tsx"]), packaged ? packagedEntrypoint : developmentEntrypoint, ...process.argv.slice(2)],
+  {
+    stdio: "inherit",
+    env: process.env,
+  },
+);
 
 child.once("error", (error) => {
   process.stderr.write(`framekit failed to start: ${String(error)}\n`);

--- a/docs/final-cut/installation.md
+++ b/docs/final-cut/installation.md
@@ -44,7 +44,7 @@ edits. Open Final Cut and its Framekit Workflow Extension before asking Codex to
 connect.
 
 Start troubleshooting with `connection.status`. A missing application,
-extension, socket, or permission must remain an actionable non-ready state;
+extension, or socket must remain an actionable non-ready state;
 `FINAL_CUT_HEADLESS_SOCKET_UNAVAILABLE` and `CAPABILITY_UNAVAILABLE` are not
 successful connections. Live metadata access also does not imply canonical
 timeline snapshot or write capability: inspect the active backend's capability
@@ -57,7 +57,7 @@ execute, frontmost, focus, post-command verification, and undo requirements.
 Check the connection without starting MCP:
 
 ```sh
-framekit doctor finalcut
+npx -y @morshoto/framekit doctor finalcut
 ```
 
 In headed mode, macOS may ask once for permission to let Framekit activate Final

--- a/docs/final-cut/installation.md
+++ b/docs/final-cut/installation.md
@@ -34,7 +34,7 @@ requires neither a repository checkout nor manual `codex mcp add`. The plugin
 starts the published package as:
 
 ```sh
-npx -y framekit mcp --editor final-cut-live --headless
+npx -y @morshoto/framekit mcp --editor final-cut-live --headless
 ```
 
 Headless mode only probes an existing Workflow Extension bridge. It does not

--- a/docs/final-cut/installation.md
+++ b/docs/final-cut/installation.md
@@ -18,17 +18,41 @@ The verified native baseline is Xcode 16.4 / build 16F6 with macOS SDK 15.5.
 
 ## End-user setup
 
-Register the local MCP server with Codex:
+The Codex plugin installs the Framekit MCP integration, but it does not replace
+the Final Cut Workflow Extension. Install the signed extension application from
+the latest Framekit release before the first live session. The install is
+per-user and does not require administrator privileges.
+
+Configure the Framekit marketplace once:
 
 ```sh
-codex mcp add framekit -- framekit mcp --editor final-cut-live
+codex plugin marketplace add morshoto/framekit
 ```
 
-When the MCP process starts, Framekit automatically detects Final Cut Pro,
-installs the signed Workflow Extension into the user's Applications directory,
-launches it, activates the Framekit extension, and waits for the local socket.
-No manual `ditto` or Window → Extensions step is required for a release build.
-Background MCP startup does not quit or reopen Final Cut Pro.
+Open `/plugins`, install **Framekit**, and start a new Codex session. Installation
+requires neither a repository checkout nor manual `codex mcp add`. The plugin
+starts the published package as:
+
+```sh
+npx -y framekit mcp --editor final-cut-live --headless
+```
+
+Headless mode only probes an existing Workflow Extension bridge. It does not
+install the extension, launch or activate Final Cut Pro, focus its windows,
+request Accessibility or Automation access, or perform native destructive
+edits. Open Final Cut and its Framekit Workflow Extension before asking Codex to
+connect.
+
+Start troubleshooting with `connection.status`. A missing application,
+extension, socket, or permission must remain an actionable non-ready state;
+`FINAL_CUT_HEADLESS_SOCKET_UNAVAILABLE` and `CAPABILITY_UNAVAILABLE` are not
+successful connections. Live metadata access also does not imply canonical
+timeline snapshot or write capability: inspect the active backend's capability
+flags before using project, timeline, or edit tools.
+
+Accessibility and Automation permission are required only for an explicit
+headed native-write setup. Native destructive edits retain their preview,
+execute, frontmost, focus, post-command verification, and undo requirements.
 
 Check the connection without starting MCP:
 
@@ -36,8 +60,8 @@ Check the connection without starting MCP:
 framekit doctor finalcut
 ```
 
-The default install is per-user and does not require administrator privileges.
-macOS may still ask once for permission to let Framekit activate Final Cut Pro.
+In headed mode, macOS may ask once for permission to let Framekit activate Final
+Cut Pro. Grant only the permissions needed by the intended workflow.
 
 ## Development build
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -93,8 +93,12 @@ The plugin starts Framekit with `--editor final-cut-live --headless`. Headless
 mode probes an already-running Workflow Extension socket and does not launch,
 activate, focus, or edit Final Cut through Accessibility. Start with
 `connection.status`, then inspect the live capability flags before choosing
-other tools. Missing Final Cut, extension, socket, or permission prerequisites
+other tools. Missing Final Cut, extension, or socket prerequisites
 remain actionable failures rather than a ready connection.
+
+Accessibility and Automation permissions are required only for an explicit
+headed native-write setup; they are not prerequisites for headless read-only
+access.
 
 For normal repository development mode, build and connect the native extension
 with:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -78,18 +78,26 @@ variable. The complete provider setup is documented in the
 
 ## Connect Codex to Final Cut
 
-Register the local MCP server with Codex in headless mode:
+Install the signed Framekit Workflow Extension from a Framekit release. Then
+add the Framekit marketplace once without cloning the repository:
 
 ```sh
-codex mcp add framekit -- framekit mcp --editor final-cut-live --headless
+codex plugin marketplace add morshoto/framekit
 ```
 
-Headless mode probes an already-running Workflow Extension socket. It does
-not launch, activate, focus, or edit Final Cut through Accessibility. It is
-appropriate for live metadata reads and FCPXML artifact work; native UI edit
-contracts are validated by the deterministic headless suite.
+Open `/plugins` in Codex, install **Framekit**, and start a new Codex session.
+The plugin automatically registers the published package as the Framekit MCP
+server; no repository checkout or manual `codex mcp add` is required.
 
-For normal development mode, build and connect the native extension with:
+The plugin starts Framekit with `--editor final-cut-live --headless`. Headless
+mode probes an already-running Workflow Extension socket and does not launch,
+activate, focus, or edit Final Cut through Accessibility. Start with
+`connection.status`, then inspect the live capability flags before choosing
+other tools. Missing Final Cut, extension, socket, or permission prerequisites
+remain actionable failures rather than a ready connection.
+
+For normal repository development mode, build and connect the native extension
+with:
 
 ```sh
 framekit connect finalcut --development

--- a/docs/mcp/final-cut-live.md
+++ b/docs/mcp/final-cut-live.md
@@ -1,10 +1,14 @@
 # Selecting the Live Final Cut Backend
 
-Connect Codex with the standard local MCP registration:
+For end users, configure the Framekit marketplace once:
 
 ```sh
-codex mcp add framekit -- framekit mcp --editor final-cut-live --headless
+codex plugin marketplace add morshoto/framekit
 ```
+
+Open `/plugins`, install **Framekit**, and start a new Codex session. The plugin
+registers `npx -y framekit mcp --editor final-cut-live --headless`; a repository
+checkout and manual `codex mcp add` are not required.
 
 In normal (non-headless) mode, the Framekit MCP process automatically:
 
@@ -32,10 +36,11 @@ framekit doctor finalcut --json
 
 ## Headless mode
 
-When Codex must not touch the Final Cut UI, register the live server with:
+For repository development without the plugin, start the equivalent headless
+live server with:
 
 ```sh
-codex mcp add framekit -- framekit mcp --editor final-cut-live --headless
+framekit mcp --editor final-cut-live --headless
 ```
 
 Headless mode only probes the existing Workflow Extension socket. It does not

--- a/docs/mcp/final-cut-live.md
+++ b/docs/mcp/final-cut-live.md
@@ -7,7 +7,7 @@ codex plugin marketplace add morshoto/framekit
 ```
 
 Open `/plugins`, install **Framekit**, and start a new Codex session. The plugin
-registers `npx -y framekit mcp --editor final-cut-live --headless`; a repository
+registers `npx -y @morshoto/framekit mcp --editor final-cut-live --headless`; a repository
 checkout and manual `codex mcp add` are not required.
 
 In normal (non-headless) mode, the Framekit MCP process automatically:

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build": "tsc -p tsconfig.json",
     "build:package": "tsc -p tsconfig.package.json && tsc-alias -p tsconfig.package.json",
     "test": "tsx --test tests/integration/*.test.ts tests/evaluation/*.test.ts",
+    "test:codex-plugin": "node scripts/codex-plugin-smoke.mjs",
     "evaluate": "tsx scripts/run-mcp-evaluation.ts",
     "test:final-cut-headless": "tsx --test tests/integration/connection.test.ts tests/integration/finalcut-mcp.test.ts tests/integration/native.test.ts",
     "test:final-cut-overlay-headed": "node scripts/final-cut-overlay-headed-e2e.mjs",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "framekit",
+  "name": "@morshoto/framekit",
   "version": "0.1.0",
   "packageManager": "pnpm@11.10.0",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -2,14 +2,22 @@
   "name": "framekit",
   "version": "0.1.0",
   "packageManager": "pnpm@11.10.0",
-  "private": true,
+  "private": false,
   "type": "module",
-  "description": "Agentic video editing runtime spikes",
+  "description": "Agentic video editing runtime and MCP server for Final Cut Pro",
+  "files": [
+    "bin",
+    "dist-package"
+  ],
   "bin": {
     "framekit": "./bin/framekit.mjs"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "build:package": "tsc -p tsconfig.package.json && tsc-alias -p tsconfig.package.json",
     "test": "tsx --test tests/integration/*.test.ts tests/evaluation/*.test.ts",
     "evaluate": "tsx scripts/run-mcp-evaluation.ts",
     "test:final-cut-headless": "tsx --test tests/integration/connection.test.ts tests/integration/finalcut-mcp.test.ts tests/integration/native.test.ts",
@@ -19,6 +27,7 @@
     "mcp": "tsx apps/mcp-server/src/main.ts",
     "framekit": "node ./bin/framekit.mjs",
     "package:final-cut-release": "bash scripts/package-final-cut-release.sh",
+    "prepack": "pnpm run build:package",
     "xcode:check": "bash nix/check-xcode.sh",
     "check:boundaries": "node scripts/check-boundaries.mjs"
   },
@@ -39,6 +48,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.15.0",
+    "tsc-alias": "^1.8.16",
     "tsx": "^4.19.4",
     "typescript": "^5.8.3"
   }

--- a/plugins/framekit/.codex-plugin/plugin.json
+++ b/plugins/framekit/.codex-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "framekit",
+  "version": "0.1.0",
+  "description": "Connect Codex to Framekit's MCP tools for Final Cut Pro",
+  "author": {
+    "name": "Framekit Contributors",
+    "url": "https://github.com/morshoto/framekit"
+  },
+  "homepage": "https://github.com/morshoto/framekit#readme",
+  "repository": "https://github.com/morshoto/framekit",
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Framekit",
+    "shortDescription": "Inspect Final Cut Pro through Framekit MCP",
+    "longDescription": "Connect to an existing Framekit Workflow Extension bridge and inspect live Final Cut Pro state with explicit capability and safety boundaries.",
+    "developerName": "Framekit Contributors",
+    "category": "Developer Tools",
+    "capabilities": ["Interactive"],
+    "defaultPrompt": [
+      "Check my live Final Cut connection and available capabilities",
+      "Inspect the current Final Cut project and playhead state"
+    ]
+  },
+  "mcpServers": "./.mcp.json"
+}

--- a/plugins/framekit/.mcp.json
+++ b/plugins/framekit/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "framekit": {
+      "command": "npx",
+      "args": ["-y", "framekit", "mcp", "--editor", "final-cut-live", "--headless"]
+    }
+  }
+}

--- a/plugins/framekit/.mcp.json
+++ b/plugins/framekit/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "framekit": {
       "command": "npx",
-      "args": ["-y", "framekit", "mcp", "--editor", "final-cut-live", "--headless"]
+      "args": ["-y", "@morshoto/framekit", "mcp", "--editor", "final-cut-live", "--headless"]
     }
   }
 }

--- a/plugins/framekit/skills/framekit/SKILL.md
+++ b/plugins/framekit/skills/framekit/SKILL.md
@@ -13,9 +13,11 @@ Framekit.
 1. Call `connection.status` before relying on the live bridge.
 2. Call `editor.live.inspect` to read the current project, sequence, playhead,
    revision, and advertised capabilities.
-3. Treat missing Final Cut Pro, Workflow Extension, socket, Accessibility, or
-   Automation access as an actionable prerequisite error. Never describe the
-   connection as ready when the server reports otherwise.
+3. Treat missing Final Cut Pro, Workflow Extension, or socket as an actionable
+   prerequisite error. Never describe the connection as ready when the server
+   reports otherwise. Accessibility and Automation permissions are required
+   only for an explicit headed native-write setup; they are not prerequisites
+   for headless read-only access.
 4. Treat `CAPABILITY_UNAVAILABLE` as a hard boundary for the active backend.
    Do not invent timeline snapshots, media results, or edit success.
 
@@ -30,6 +32,6 @@ through macOS UI automation.
 - Native destructive operations are disabled by the plugin's headless startup.
   If the user deliberately switches to a headed native-write setup, retain the
   existing preview, execute, frontmost, focus, verification, and undo workflow.
-- Ask the user to complete missing first-run macOS permissions or Workflow
-  Extension setup; do not broaden filesystem or application access on their
-  behalf.
+- Ask the user to complete missing Workflow Extension setup. Ask for first-run
+  macOS permissions only when the selected headed native-write capability
+  requires them; do not broaden filesystem or application access on their behalf.

--- a/plugins/framekit/skills/framekit/SKILL.md
+++ b/plugins/framekit/skills/framekit/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: framekit
+description: Inspect a live Final Cut Pro session through Framekit MCP while preserving explicit capability and native-edit safety boundaries.
+---
+
+# Framekit Live Final Cut
+
+Use this skill when the user asks to inspect or work with Final Cut Pro through
+Framekit.
+
+## Connection preflight
+
+1. Call `connection.status` before relying on the live bridge.
+2. Call `editor.live.inspect` to read the current project, sequence, playhead,
+   revision, and advertised capabilities.
+3. Treat missing Final Cut Pro, Workflow Extension, socket, Accessibility, or
+   Automation access as an actionable prerequisite error. Never describe the
+   connection as ready when the server reports otherwise.
+4. Treat `CAPABILITY_UNAVAILABLE` as a hard boundary for the active backend.
+   Do not invent timeline snapshots, media results, or edit success.
+
+The plugin always starts Framekit with `--headless`. That mode probes an existing
+Workflow Extension bridge and does not launch, activate, focus, or edit Final Cut
+through macOS UI automation.
+
+## Capability boundaries
+
+- Live metadata availability does not prove canonical timeline snapshot or write
+  access. Inspect the reported capability flags before selecting a tool.
+- Native destructive operations are disabled by the plugin's headless startup.
+  If the user deliberately switches to a headed native-write setup, retain the
+  existing preview, execute, frontmost, focus, verification, and undo workflow.
+- Ask the user to complete missing first-run macOS permissions or Workflow
+  Extension setup; do not broaden filesystem or application access on their
+  behalf.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@types/node':
         specifier: ^22.15.0
         version: 22.20.1
+      tsc-alias:
+        specifier: ^1.8.16
+        version: 1.9.2
       tsx:
         specifier: ^4.19.4
         version: 4.23.12
@@ -314,6 +317,18 @@ packages:
   '@nodable/entities@3.0.0':
     resolution: {integrity: sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==}
 
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
   '@simple-libs/stream-utils@2.0.0':
     resolution: {integrity: sha512-fCTuZK4QBa+39Oz9l4OGfJfz+GpwCp3AqO7Zch3to99xHPgstVsRFpeQ8LNd2o1Gv8raL2mCFwiaHh7bFSp5DQ==}
     engines: {node: '>=22'}
@@ -352,6 +367,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
   anynum@1.0.1:
     resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
 
@@ -362,6 +381,10 @@ packages:
     resolution: {integrity: sha512-DhBpBfXL4SS2uC0N922MMajKR3CdrTG0u2or1PNYgXMsrSzViJrbtvT0nCLlLGUI0plam/ZZCs7aAauHtW9thw==}
     engines: {node: '>=22'}
 
+  array-union@2.1.0:
+    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
+    engines: {node: '>=8'}
+
   at-least-node@1.0.0:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
@@ -371,6 +394,10 @@ packages:
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  binary-extensions@2.3.0:
+    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
+    engines: {node: '>=8'}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -420,6 +447,10 @@ packages:
   chardet@2.2.0:
     resolution: {integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==}
 
+  chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
+    engines: {node: '>= 8.10.0'}
+
   cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
     engines: {node: '>=8'}
@@ -448,6 +479,10 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@9.5.0:
+    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
+    engines: {node: ^12.20.0 || >=14}
 
   commitizen@4.3.2:
     resolution: {integrity: sha512-1Zs37z9JPvAcuTSSricZZwBhOPVNNxJouuY4yDEt+eD70EoxT2TU9kViG8CuB/PmVg2G4XsAGQiK4YCst97aDQ==}
@@ -541,6 +576,10 @@ packages:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
 
+  dir-glob@3.0.1:
+    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
+    engines: {node: '>=8'}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -618,6 +657,10 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
   fast-uri@3.1.5:
     resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
@@ -627,6 +670,9 @@ packages:
   fast-xml-parser@5.10.1:
     resolution: {integrity: sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==}
     hasBin: true
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
@@ -681,9 +727,16 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-tsconfig@4.14.3:
+    resolution: {integrity: sha512-++QEw4DIY7WGoukz+/+A/8dGYPT9l9yIadnmSgZ8Rjr3YVSVDipQSO9CdnJo9ePqFqUUqh+wk9uIaoiAwsiPkA==}
+
   git-cz@4.9.0:
     resolution: {integrity: sha512-cSRL8IIOXU7UFLdbziCYqg8f8InwLwqHezkiRHNSph7oZqGv0togId1kMTfKil6gzK0VaSXeVBb4oDl0fQCHiw==}
     hasBin: true
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -700,6 +753,10 @@ packages:
   global-prefix@1.0.2:
     resolution: {integrity: sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==}
     engines: {node: '>=0.10.0'}
+
+  globby@11.1.0:
+    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
+    engines: {node: '>=10'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -743,6 +800,10 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -775,6 +836,10 @@ packages:
 
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-binary-path@2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -875,6 +940,10 @@ packages:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
 
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
   merge@2.1.1:
     resolution: {integrity: sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w==}
 
@@ -906,9 +975,17 @@ packages:
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
 
+  mylas@2.1.14:
+    resolution: {integrity: sha512-BzQguy9W9NJgoVn2mRWzbFrFWWztGCcng2QI9+41frfk+Athwgx3qhqhvStz7ExeUUu7Kzw427sNzHpEZNINog==}
+    engines: {node: '>=16.0.0'}
+
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -964,6 +1041,10 @@ packages:
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
+  path-type@4.0.0:
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -975,6 +1056,10 @@ packages:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
+  plimit-lit@1.6.1:
+    resolution: {integrity: sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==}
+    engines: {node: '>=12'}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -982,6 +1067,13 @@ packages:
   qs@6.15.3:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
+
+  queue-lit@1.5.2:
+    resolution: {integrity: sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==}
+    engines: {node: '>=12'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   range-parser@1.3.0:
     resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
@@ -994,6 +1086,10 @@ packages:
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -1011,9 +1107,16 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   restore-cursor@3.1.0:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
     engines: {node: '>=8'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
@@ -1022,6 +1125,9 @@ packages:
   run-async@2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
     engines: {node: '>=0.12.0'}
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
@@ -1070,6 +1176,10 @@ packages:
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
+  slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    engines: {node: '>=8'}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -1114,6 +1224,11 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tsc-alias@1.9.2:
+    resolution: {integrity: sha512-VTWQGMv0xXCEyHDLpmV2DEvGYHMxwsyx87dZeou2ynkM0+WOFdHe+KWiRucavMPUEdQysr7xSu60Y/WY0R4YKA==}
+    engines: {node: '>=16.20.2'}
+    hasBin: true
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -1354,6 +1469,18 @@ snapshots:
 
   '@nodable/entities@3.0.0': {}
 
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
+
   '@simple-libs/stream-utils@2.0.0':
     optional: true
 
@@ -1391,6 +1518,11 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.2
+
   anynum@1.0.1: {}
 
   argparse@2.0.1:
@@ -1399,11 +1531,15 @@ snapshots:
   argue-cli@3.1.0:
     optional: true
 
+  array-union@2.1.0: {}
+
   at-least-node@1.0.0: {}
 
   balanced-match@1.0.2: {}
 
   base64-js@1.5.1: {}
+
+  binary-extensions@2.3.0: {}
 
   bl@4.1.0:
     dependencies:
@@ -1469,6 +1605,18 @@ snapshots:
 
   chardet@2.2.0: {}
 
+  chokidar@3.6.0:
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.3
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   cli-cursor@3.1.0:
     dependencies:
       restore-cursor: 3.1.0
@@ -1490,6 +1638,8 @@ snapshots:
   color-name@1.1.3: {}
 
   color-name@1.1.4: {}
+
+  commander@9.5.0: {}
 
   commitizen@4.3.2(@types/node@22.20.1)(typescript@5.9.3):
     dependencies:
@@ -1589,6 +1739,10 @@ snapshots:
   detect-file@1.0.0: {}
 
   detect-indent@6.1.0: {}
+
+  dir-glob@3.0.1:
+    dependencies:
+      path-type: 4.0.0
 
   dunder-proto@1.0.1:
     dependencies:
@@ -1709,6 +1863,14 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
   fast-uri@3.1.5: {}
 
   fast-xml-builder@1.3.1:
@@ -1724,6 +1886,10 @@ snapshots:
       path-expression-matcher: 1.6.2
       strnum: 2.4.2
       xml-naming: 0.3.0
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
 
   figures@3.2.0:
     dependencies:
@@ -1794,7 +1960,15 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.2
 
+  get-tsconfig@4.14.3:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   git-cz@4.9.0: {}
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
 
   glob@7.2.3:
     dependencies:
@@ -1823,6 +1997,15 @@ snapshots:
       ini: 1.3.8
       is-windows: 1.0.2
       which: 1.3.1
+
+  globby@11.1.0:
+    dependencies:
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.3.3
+      ignore: 5.3.2
+      merge2: 1.4.1
+      slash: 3.0.0
 
   gopd@1.2.0: {}
 
@@ -1857,6 +2040,8 @@ snapshots:
       safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
+
+  ignore@5.3.2: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -1902,6 +2087,10 @@ snapshots:
 
   is-arrayish@0.2.1:
     optional: true
+
+  is-binary-path@2.1.0:
+    dependencies:
+      binary-extensions: 2.3.0
 
   is-extglob@2.1.1: {}
 
@@ -1976,6 +2165,8 @@ snapshots:
 
   merge-descriptors@2.0.0: {}
 
+  merge2@1.4.1: {}
+
   merge@2.1.1: {}
 
   micromatch@4.0.8:
@@ -2001,7 +2192,11 @@ snapshots:
 
   mute-stream@0.0.8: {}
 
+  mylas@2.1.14: {}
+
   negotiator@1.0.0: {}
+
+  normalize-path@3.0.0: {}
 
   object-assign@4.1.1: {}
 
@@ -2056,12 +2251,18 @@ snapshots:
 
   path-to-regexp@8.4.2: {}
 
+  path-type@4.0.0: {}
+
   picocolors@1.1.1:
     optional: true
 
   picomatch@2.3.2: {}
 
   pkce-challenge@5.0.1: {}
+
+  plimit-lit@1.6.1:
+    dependencies:
+      queue-lit: 1.5.2
 
   proxy-addr@2.0.7:
     dependencies:
@@ -2072,6 +2273,10 @@ snapshots:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1
+
+  queue-lit@1.5.2: {}
+
+  queue-microtask@1.2.3: {}
 
   range-parser@1.3.0: {}
 
@@ -2088,6 +2293,10 @@ snapshots:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
+  readdirp@3.6.0:
+    dependencies:
+      picomatch: 2.3.2
+
   require-from-string@2.0.2: {}
 
   resolve-dir@1.0.1:
@@ -2101,10 +2310,14 @@ snapshots:
   resolve-from@5.0.0:
     optional: true
 
+  resolve-pkg-maps@1.0.0: {}
+
   restore-cursor@3.1.0:
     dependencies:
       onetime: 5.1.2
       signal-exit: 3.0.7
+
+  reusify@1.1.0: {}
 
   router@2.2.0:
     dependencies:
@@ -2117,6 +2330,10 @@ snapshots:
       - supports-color
 
   run-async@2.4.1: {}
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
 
   rxjs@7.8.2:
     dependencies:
@@ -2189,6 +2406,8 @@ snapshots:
 
   signal-exit@3.0.7: {}
 
+  slash@3.0.0: {}
+
   statuses@2.0.2: {}
 
   string-width@4.2.3:
@@ -2228,6 +2447,16 @@ snapshots:
       is-number: 7.0.0
 
   toidentifier@1.0.1: {}
+
+  tsc-alias@1.9.2:
+    dependencies:
+      chokidar: 3.6.0
+      commander: 9.5.0
+      get-tsconfig: 4.14.3
+      globby: 11.1.0
+      mylas: 2.1.14
+      normalize-path: 3.0.0
+      plimit-lit: 1.6.1
 
   tslib@2.8.1: {}
 

--- a/scripts/codex-plugin-smoke.mjs
+++ b/scripts/codex-plugin-smoke.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -11,6 +11,14 @@ const repository = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const codex = process.env.CODEX_BIN ?? "codex";
 const codexHome = await mkdtemp(join(os.tmpdir(), "framekit-codex-plugin-"));
 const environment = { ...process.env, CODEX_HOME: codexHome };
+const CODEX_TIMEOUT_MS = 30_000;
+
+const packageManifest = JSON.parse(await readFile(join(repository, "package.json"), "utf8"));
+const pluginManifest = JSON.parse(
+  await readFile(join(repository, "plugins/framekit/.codex-plugin/plugin.json"), "utf8"),
+);
+assert.equal(packageManifest.version, pluginManifest.version, "package and plugin versions must match");
+const expectedVersion = packageManifest.version;
 
 try {
   const marketplaceResult = await runCodex(["plugin", "marketplace", "add", repository, "--json"]);
@@ -18,7 +26,7 @@ try {
 
   const installResult = await runCodex(["plugin", "add", "framekit@framekit", "--json"]);
   assert.equal(installResult.pluginId, "framekit@framekit");
-  assert.equal(installResult.version, "0.1.0");
+  assert.equal(installResult.version, expectedVersion);
 
   const servers = await runCodex(["mcp", "list", "--json"]);
   assert.ok(Array.isArray(servers));
@@ -40,10 +48,23 @@ try {
 }
 
 async function runCodex(args) {
-  const { stdout } = await exec(codex, args, {
-    cwd: repository,
-    env: environment,
-    maxBuffer: 10 * 1024 * 1024,
-  });
-  return JSON.parse(stdout);
+  try {
+    const { stdout } = await exec(codex, args, {
+      cwd: repository,
+      env: environment,
+      maxBuffer: 10 * 1024 * 1024,
+      timeout: CODEX_TIMEOUT_MS,
+    });
+    return JSON.parse(stdout);
+  } catch (error) {
+    if (
+      error && typeof error === "object" &&
+      (("killed" in error && error.killed) || ("code" in error && error.code === "ETIMEDOUT"))
+    ) {
+      throw new Error(`Codex command timed out after ${CODEX_TIMEOUT_MS}ms: codex ${args.join(" ")}`, {
+        cause: error,
+      });
+    }
+    throw error;
+  }
 }

--- a/scripts/codex-plugin-smoke.mjs
+++ b/scripts/codex-plugin-smoke.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const exec = promisify(execFile);
+const repository = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const codex = process.env.CODEX_BIN ?? "codex";
+const codexHome = await mkdtemp(join(os.tmpdir(), "framekit-codex-plugin-"));
+const environment = { ...process.env, CODEX_HOME: codexHome };
+
+try {
+  const marketplaceResult = await runCodex(["plugin", "marketplace", "add", repository, "--json"]);
+  assert.equal(marketplaceResult.marketplaceName, "framekit");
+
+  const installResult = await runCodex(["plugin", "add", "framekit@framekit", "--json"]);
+  assert.equal(installResult.pluginId, "framekit@framekit");
+  assert.equal(installResult.version, "0.1.0");
+
+  const servers = await runCodex(["mcp", "list", "--json"]);
+  assert.ok(Array.isArray(servers));
+  const framekit = servers.find((server) => server.name === "framekit");
+  assert.ok(framekit, "installed plugin must expose the Framekit MCP server");
+  assert.equal(framekit.enabled, true);
+  assert.deepEqual(framekit.transport, {
+    type: "stdio",
+    command: "npx",
+    args: ["-y", "framekit", "mcp", "--editor", "final-cut-live", "--headless"],
+    env: null,
+    env_vars: [],
+    cwd: null,
+  });
+
+  process.stdout.write("Framekit Codex plugin smoke test passed\n");
+} finally {
+  await rm(codexHome, { recursive: true, force: true });
+}
+
+async function runCodex(args) {
+  const { stdout } = await exec(codex, args, {
+    cwd: repository,
+    env: environment,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  return JSON.parse(stdout);
+}

--- a/scripts/codex-plugin-smoke.mjs
+++ b/scripts/codex-plugin-smoke.mjs
@@ -28,7 +28,7 @@ try {
   assert.deepEqual(framekit.transport, {
     type: "stdio",
     command: "npx",
-    args: ["-y", "framekit", "mcp", "--editor", "final-cut-live", "--headless"],
+    args: ["-y", "@morshoto/framekit", "mcp", "--editor", "final-cut-live", "--headless"],
     env: null,
     env_vars: [],
     cwd: null,

--- a/tests/integration/codex-plugin.test.ts
+++ b/tests/integration/codex-plugin.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repository = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+async function readJson(relativePath: string): Promise<unknown> {
+  return JSON.parse(await readFile(resolve(repository, relativePath), "utf8"));
+}
+
+test("Framekit plugin registers the published headless Final Cut MCP command", async () => {
+  const manifest = await readJson("plugins/framekit/.codex-plugin/plugin.json") as {
+    name?: string;
+    version?: string;
+    skills?: string;
+    mcpServers?: string;
+    interface?: { displayName?: string; category?: string; capabilities?: string[] };
+  };
+  assert.equal(manifest.name, "framekit");
+  assert.match(manifest.version ?? "", /^\d+\.\d+\.\d+$/);
+  assert.equal(manifest.skills, "./skills/");
+  assert.equal(manifest.mcpServers, "./.mcp.json");
+  assert.equal(manifest.interface?.displayName, "Framekit");
+  assert.equal(manifest.interface?.category, "Developer Tools");
+  assert.deepEqual(manifest.interface?.capabilities, ["Interactive"]);
+
+  const mcp = await readJson("plugins/framekit/.mcp.json") as {
+    mcpServers?: Record<string, { command?: string; args?: string[]; env?: unknown }>;
+  };
+  assert.deepEqual(mcp.mcpServers?.framekit, {
+    command: "npx",
+    args: ["-y", "framekit", "mcp", "--editor", "final-cut-live", "--headless"],
+  });
+});
+
+test("Framekit is discoverable from the repository marketplace", async () => {
+  const marketplace = await readJson(".agents/plugins/marketplace.json") as {
+    name?: string;
+    interface?: { displayName?: string };
+    plugins?: Array<unknown>;
+  };
+  assert.equal(marketplace.name, "framekit");
+  assert.equal(marketplace.interface?.displayName, "Framekit");
+  assert.deepEqual(marketplace.plugins, [
+    {
+      name: "framekit",
+      source: { source: "local", path: "./plugins/framekit" },
+      policy: { installation: "AVAILABLE", authentication: "ON_INSTALL" },
+      category: "Developer Tools",
+    },
+  ]);
+});
+
+test("Framekit plugin guidance preserves live capability and safety boundaries", async () => {
+  const skill = await readFile(resolve(repository, "plugins/framekit/skills/framekit/SKILL.md"), "utf8");
+  for (const expected of [
+    "connection.status",
+    "editor.live.inspect",
+    "--headless",
+    "CAPABILITY_UNAVAILABLE",
+    "preview",
+    "undo",
+    "Accessibility",
+    "Automation",
+  ]) {
+    assert.match(skill, new RegExp(expected.replace(".", "\\."), "i"));
+  }
+});

--- a/tests/integration/codex-plugin.test.ts
+++ b/tests/integration/codex-plugin.test.ts
@@ -77,3 +77,27 @@ test("CI runs the clean Codex plugin installation smoke test", async () => {
   assert.match(workflow, /npm install --global @openai\/codex/);
   assert.match(workflow, /pnpm run test:codex-plugin/);
 });
+
+test("user documentation leads with plugin installation and explains first-run boundaries", async () => {
+  const readme = await readFile(resolve(repository, "README.md"), "utf8");
+  const gettingStarted = await readFile(resolve(repository, "docs/getting-started.md"), "utf8");
+  const installation = await readFile(resolve(repository, "docs/final-cut/installation.md"), "utf8");
+
+  for (const content of [readme, gettingStarted]) {
+    assert.match(content, /codex plugin marketplace add morshoto\/framekit/);
+    assert.match(content, /\/plugins/);
+    assert.match(content, /new\s+Codex session/i);
+    assert.doesNotMatch(content, /codex mcp add framekit/);
+  }
+
+  for (const expected of [
+    "Workflow Extension",
+    "Accessibility",
+    "Automation",
+    "headless",
+    "connection.status",
+    "capability",
+  ]) {
+    assert.match(installation, new RegExp(expected.replace(".", "\\."), "i"));
+  }
+});

--- a/tests/integration/codex-plugin.test.ts
+++ b/tests/integration/codex-plugin.test.ts
@@ -101,3 +101,16 @@ test("user documentation leads with plugin installation and explains first-run b
     assert.match(installation, new RegExp(expected.replace(".", "\\."), "i"));
   }
 });
+
+test("tagpr releases publish the package consumed by the plugin", async () => {
+  const tagpr = await readFile(resolve(repository, ".tagpr"), "utf8");
+  assert.match(tagpr, /versionFile = package\.json,plugins\/framekit\/\.codex-plugin\/plugin\.json/);
+
+  const workflow = await readFile(resolve(repository, ".github/workflows/release.yml"), "utf8");
+  assert.match(workflow, /publish-npm:/);
+  assert.match(workflow, /needs:\s+tagpr/);
+  assert.match(workflow, /needs\.tagpr\.outputs\.tagpr-tag != ''/);
+  assert.match(workflow, /id-token:\s+write/);
+  assert.match(workflow, /npm publish --provenance --access public/);
+  assert.match(workflow, /NODE_AUTH_TOKEN:\s+\$\{\{ secrets\.NPM_TOKEN \}\}/);
+});

--- a/tests/integration/codex-plugin.test.ts
+++ b/tests/integration/codex-plugin.test.ts
@@ -31,7 +31,7 @@ test("Framekit plugin registers the published headless Final Cut MCP command", a
   };
   assert.deepEqual(mcp.mcpServers?.framekit, {
     command: "npx",
-    args: ["-y", "framekit", "mcp", "--editor", "final-cut-live", "--headless"],
+    args: ["-y", "@morshoto/framekit", "mcp", "--editor", "final-cut-live", "--headless"],
   });
 });
 

--- a/tests/integration/codex-plugin.test.ts
+++ b/tests/integration/codex-plugin.test.ts
@@ -67,6 +67,8 @@ test("Framekit plugin guidance preserves live capability and safety boundaries",
   ]) {
     assert.match(skill, new RegExp(expected.replace(".", "\\."), "i"));
   }
+  assert.match(skill, /headed native-write setup/i);
+  assert.match(skill, /not prerequisites?\s+for headless read-only access/i);
 });
 
 test("CI runs the clean Codex plugin installation smoke test", async () => {
@@ -74,8 +76,16 @@ test("CI runs the clean Codex plugin installation smoke test", async () => {
   assert.equal(packageManifest.scripts?.["test:codex-plugin"], "node scripts/codex-plugin-smoke.mjs");
 
   const workflow = await readFile(resolve(repository, ".github/workflows/typescript.yml"), "utf8");
-  assert.match(workflow, /npm install --global @openai\/codex/);
+  assert.match(workflow, /npm install --global @openai\/codex@0\.144\.1/);
   assert.match(workflow, /pnpm run test:codex-plugin/);
+
+  const smoke = await readFile(resolve(repository, "scripts/codex-plugin-smoke.mjs"), "utf8");
+  assert.match(smoke, /package\.json/);
+  assert.match(smoke, /plugins\/framekit\/\.codex-plugin\/plugin\.json/);
+  assert.match(smoke, /installResult\.version, expectedVersion/);
+  assert.match(smoke, /timeout: CODEX_TIMEOUT_MS/);
+  assert.match(smoke, /Codex command timed out after/);
+  assert.doesNotMatch(smoke, /installResult\.version, "0\.1\.0"/);
 });
 
 test("user documentation leads with plugin installation and explains first-run boundaries", async () => {
@@ -100,6 +110,8 @@ test("user documentation leads with plugin installation and explains first-run b
   ]) {
     assert.match(installation, new RegExp(expected.replace(".", "\\."), "i"));
   }
+  assert.match(installation, /npx -y @morshoto\/framekit doctor finalcut/);
+  assert.match(gettingStarted, /permissions are required only for an explicit\s+headed native-write setup/i);
 });
 
 test("tagpr releases publish the package consumed by the plugin", async () => {
@@ -108,6 +120,7 @@ test("tagpr releases publish the package consumed by the plugin", async () => {
 
   const workflow = await readFile(resolve(repository, ".github/workflows/release.yml"), "utf8");
   assert.match(workflow, /publish-npm:/);
+  assert.match(workflow, /publish-npm:[\s\S]*?actions\/checkout@v4\s+with:\s+persist-credentials:\s+false/);
   assert.match(workflow, /needs:\s+tagpr/);
   assert.match(workflow, /needs\.tagpr\.outputs\.tagpr-tag != ''/);
   assert.match(workflow, /id-token:\s+write/);

--- a/tests/integration/codex-plugin.test.ts
+++ b/tests/integration/codex-plugin.test.ts
@@ -68,3 +68,12 @@ test("Framekit plugin guidance preserves live capability and safety boundaries",
     assert.match(skill, new RegExp(expected.replace(".", "\\."), "i"));
   }
 });
+
+test("CI runs the clean Codex plugin installation smoke test", async () => {
+  const packageManifest = await readJson("package.json") as { scripts?: Record<string, string> };
+  assert.equal(packageManifest.scripts?.["test:codex-plugin"], "node scripts/codex-plugin-smoke.mjs");
+
+  const workflow = await readFile(resolve(repository, ".github/workflows/typescript.yml"), "utf8");
+  assert.match(workflow, /npm install --global @openai\/codex/);
+  assert.match(workflow, /pnpm run test:codex-plugin/);
+});

--- a/tests/integration/package-distribution.test.ts
+++ b/tests/integration/package-distribution.test.ts
@@ -14,12 +14,14 @@ const repository = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 
 test("published package contains the runnable Framekit CLI and MCP sources", async () => {
   const manifest = JSON.parse(await readFile(resolve(repository, "package.json"), "utf8")) as {
+    name?: string;
     private?: boolean;
     bin?: Record<string, string>;
     dependencies?: Record<string, string>;
     files?: string[];
   };
 
+  assert.equal(manifest.name, "@morshoto/framekit");
   assert.equal(manifest.private, false);
   assert.equal(manifest.bin?.framekit, "./bin/framekit.mjs");
   assert.equal(manifest.dependencies?.tsx, undefined, "published CLI must not depend on the development loader");

--- a/tests/integration/package-distribution.test.ts
+++ b/tests/integration/package-distribution.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import { dirname, join, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const exec = promisify(execFile);
+const repository = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+test("published package contains the runnable Framekit CLI and MCP sources", async () => {
+  const manifest = JSON.parse(await readFile(resolve(repository, "package.json"), "utf8")) as {
+    private?: boolean;
+    bin?: Record<string, string>;
+    dependencies?: Record<string, string>;
+    files?: string[];
+  };
+
+  assert.equal(manifest.private, false);
+  assert.equal(manifest.bin?.framekit, "./bin/framekit.mjs");
+  assert.equal(manifest.dependencies?.tsx, undefined, "published CLI must not depend on the development loader");
+  assert.deepEqual(manifest.files, ["bin", "dist-package"]);
+
+  const { stdout } = await exec("npm", ["pack", "--dry-run", "--json"], { cwd: repository });
+  const [packed] = JSON.parse(stdout) as Array<{ files: Array<{ path: string }> }>;
+  const paths = packed.files.map((file) => file.path);
+  for (const requiredPath of [
+    "bin/framekit.mjs",
+    "dist-package/apps/cli/src/main.js",
+    "dist-package/apps/mcp-server/src/main.js",
+    "dist-package/packages/runtime/src/index.js",
+    "dist-package/adapters/final-cut/typescript/src/index.js",
+  ]) {
+    assert.ok(paths.includes(requiredPath), `${requiredPath} must be included in the npm package`);
+  }
+  assert.equal(paths.some((path) => path.startsWith("tests/")), false);
+  assert.equal(paths.some((path) => path.startsWith("adapters/final-cut/swift-bridge/")), false);
+});
+
+test("clean install of the packed package starts the headless Final Cut MCP server", { timeout: 120_000 }, async () => {
+  const directory = await mkdtemp(join(os.tmpdir(), "framekit-package-smoke-"));
+  let client: Client | undefined;
+  let transport: StdioClientTransport | undefined;
+
+  try {
+    const { stdout } = await exec("npm", ["pack", "--json", "--pack-destination", directory], {
+      cwd: repository,
+    });
+    const [packed] = JSON.parse(stdout) as Array<{ filename: string }>;
+    const archive = join(directory, packed.filename);
+    await exec("npm", ["install", "--ignore-scripts", archive], { cwd: directory });
+
+    const executable = join(directory, "node_modules", ".bin", "framekit");
+    const help = await exec(executable, ["help"], { cwd: directory });
+    assert.match(help.stdout, /framekit mcp --editor final-cut-live \[--headless\]/);
+
+    transport = new StdioClientTransport({
+      command: executable,
+      args: ["mcp", "--editor", "final-cut-live", "--headless"],
+      cwd: directory,
+      stderr: "pipe",
+    });
+    client = new Client({ name: "framekit-package-smoke", version: "0.1.0" });
+    await client.connect(transport);
+    const tools = await client.listTools();
+    assert.ok(tools.tools.some((tool) => tool.name === "connection.status"));
+    assert.ok(tools.tools.some((tool) => tool.name === "editor.live.inspect"));
+  } finally {
+    await client?.close();
+    await transport?.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/tsconfig.package.json
+++ b/tsconfig.package.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist-package",
+    "rootDir": "."
+  },
+  "include": [
+    "adapters/final-cut/typescript/src/**/*.ts",
+    "apps/cli/src/**/*.ts",
+    "apps/mcp-server/src/**/*.ts",
+    "packages/runtime/src/**/*.ts",
+    "packages/testkit/src/**/*.ts"
+  ],
+  "exclude": ["node_modules", "dist", "dist-package", "tests"]
+}


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a draft.
- [x] Github issue: Closes: #23

## Summary

- publish a consumer-safe `@morshoto/framekit` npm package with a compiled CLI/MCP artifact
- add the Framekit Codex plugin, repository marketplace metadata, and bundled live-capability guidance
- validate marketplace installation and `codex mcp list` visibility in an isolated Codex home
- publish the npm package from tagpr releases with provenance and synchronized package/plugin versions
- document `/plugins` installation, Workflow Extension prerequisites, and fail-closed headless boundaries

The issue proposed the unscoped `framekit` package, but that npm name is owned by an unrelated publisher. The plugin therefore invokes `npx -y @morshoto/framekit mcp --editor final-cut-live --headless`. The release secret `NPM_TOKEN` must have publish access to the `@morshoto` scope.

## Validation

```bash
pnpm install --frozen-lockfile
pnpm run build
pnpm run test
pnpm run check:boundaries
pnpm run test:codex-plugin
npm pack --dry-run --json
pnpm run xcode:check
xcodebuild -project adapters/final-cut/swift-bridge/FinalCutWorkflowExtension/FramekitFinalCutWorkflow.xcodeproj -list
```

The plugin manifest also passed the plugin-creator canonical validator. All commands passed, and the full suite reports 129 passing tests.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Public MCP behavior or package interfaces are documented if changed.
- [x] Existing adapters and test fixtures remain compatible, or the migration is explained above.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [x] Documentation reflects changed commands, paths, and environment variables.

The installed plugin remains headless: it probes an existing Workflow Extension bridge and does not enable native UI writes, launch Final Cut, or grant macOS permissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Codex marketplace plugin for Framekit.
  * Added published package support for headless Final Cut Pro workflows.
  * Added guided skills, prompts, and safety boundaries for live session work.

* **Documentation**
  * Updated setup instructions for marketplace/plugin installation.
  * Clarified connection checks, permissions, startup flow, and supported capabilities.

* **Bug Fixes**
  * Improved CLI behavior across packaged and development environments.

* **Tests**
  * Added plugin, package distribution, installation, and runtime smoke tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->