### PR TITLE
fix: harden canonical live Final Cut provider

### DIFF
--- a/adapters/final-cut/typescript/src/live.ts
+++ b/adapters/final-cut/typescript/src/live.ts
@@ -191,6 +191,7 @@ export class FinalCutLiveAdapter implements LiveEditorStatePort {
   public async listProjects(): Promise<ProjectCatalog> {
     const response = await this.request({ method: "projects" });
     if (!response.catalog) throw new Error("FINAL_CUT_LIVE_PROTOCOL: project catalog response was empty");
+    validateProjectCatalog(response.catalog);
     return response.catalog;
   }
 
@@ -201,6 +202,8 @@ export class FinalCutLiveAdapter implements LiveEditorStatePort {
       sequenceId: selection.sequenceId,
     });
     if (!response.catalog) throw new Error("FINAL_CUT_LIVE_PROTOCOL: project selection response was empty");
+    validateProjectCatalog(response.catalog);
+    validateProjectSelection(response.catalog, selection);
     return response.catalog;
   }
 
@@ -274,6 +277,61 @@ function validateSnapshotTarget(snapshot: ProjectSnapshot, catalog: ProjectCatal
   const project = catalog.projects.find(({ id }) => id === snapshot.projectId);
   if (!project?.sequences.some(({ id }) => id === snapshot.timeline.id)) {
     protocolError("active canonical snapshot target is absent from the project catalog");
+  }
+}
+
+function validateProjectCatalog(catalog: ProjectCatalog): void {
+  if (!Array.isArray(catalog.projects)) protocolError("project catalog projects must be an array");
+  const projectIds = new Set<string>();
+  for (const project of catalog.projects) {
+    requireNonEmpty(project.id, "project id");
+    requireNonEmpty(project.name, `project ${project.id} name`);
+    if (projectIds.has(project.id)) protocolError(`duplicate project id ${project.id}`);
+    projectIds.add(project.id);
+    if (!Array.isArray(project.sequences)) protocolError(`project ${project.id} sequences must be an array`);
+    const sequenceIds = new Set<string>();
+    for (const sequence of project.sequences) {
+      requireNonEmpty(sequence.id, `sequence in project ${project.id} id`);
+      requireNonEmpty(sequence.name, `sequence ${sequence.id} name`);
+      if (sequenceIds.has(sequence.id)) protocolError(`duplicate sequence id ${sequence.id} in project ${project.id}`);
+      sequenceIds.add(sequence.id);
+    }
+  }
+  if (catalog.activeProjectId !== undefined) {
+    requireNonEmpty(catalog.activeProjectId, "active project id");
+    if (!projectIds.has(catalog.activeProjectId)) {
+      protocolError(`active project ${catalog.activeProjectId} is absent from the project catalog`);
+    }
+  }
+  if (catalog.activeSequenceId !== undefined) {
+    requireNonEmpty(catalog.activeSequenceId, "active sequence id");
+    const activeProject = catalog.projects.find(({ id }) => id === catalog.activeProjectId);
+    if (!activeProject?.sequences.some(({ id }) => id === catalog.activeSequenceId)) {
+      protocolError(`active sequence ${catalog.activeSequenceId} is absent from the active project catalog`);
+    }
+  }
+}
+
+function validateProjectSelection(catalog: ProjectCatalog, selection: ProjectSelection): void {
+  if (catalog.activeProjectId !== selection.projectId) {
+    throw new Error(
+      `TARGET_MISMATCH: live project selection did not activate requested target ${selection.projectId}/${selection.sequenceId ?? "unknown"}`,
+    );
+  }
+  const project = catalog.projects.find(({ id }) => id === selection.projectId);
+  if (!project) {
+    throw new Error(`TARGET_MISMATCH: selected project ${selection.projectId} is absent from the project catalog`);
+  }
+  if (selection.sequenceId !== undefined) {
+    if (catalog.activeSequenceId !== selection.sequenceId) {
+      throw new Error(
+        `TARGET_MISMATCH: live project selection did not activate requested target ${selection.projectId}/${selection.sequenceId}`,
+      );
+    }
+    return;
+  }
+  if (project.sequences.length !== 1 || catalog.activeSequenceId !== project.sequences[0]?.id) {
+    throw new Error(`AMBIGUOUS_PROJECT_TARGET: sequenceId is required for project ${selection.projectId}`);
   }
 }
 

--- a/adapters/final-cut/typescript/src/live.ts
+++ b/adapters/final-cut/typescript/src/live.ts
@@ -292,6 +292,7 @@ function validateProjectCatalog(catalog: ProjectCatalog): void {
   if (!Array.isArray(catalog.projects)) protocolError("project catalog projects must be an array");
   const projectIds = new Set<string>();
   for (const project of catalog.projects) {
+    requireRecord(project, "project");
     requireNonEmpty(project.id, "project id");
     requireNonEmpty(project.name, `project ${project.id} name`);
     if (projectIds.has(project.id)) protocolError(`duplicate project id ${project.id}`);
@@ -299,6 +300,7 @@ function validateProjectCatalog(catalog: ProjectCatalog): void {
     if (!Array.isArray(project.sequences)) protocolError(`project ${project.id} sequences must be an array`);
     const sequenceIds = new Set<string>();
     for (const sequence of project.sequences) {
+      requireRecord(sequence, `sequence in project ${project.id}`);
       requireNonEmpty(sequence.id, `sequence in project ${project.id} id`);
       requireNonEmpty(sequence.name, `sequence ${sequence.id} name`);
       if (sequenceIds.has(sequence.id)) protocolError(`duplicate sequence id ${sequence.id} in project ${project.id}`);
@@ -356,6 +358,12 @@ function uniqueIds<T>(values: T[], identify: (value: T) => string, kind: string)
 
 function requireArray(value: unknown, field: string): asserts value is unknown[] {
   if (!Array.isArray(value)) protocolError(`${field} must be an array`);
+}
+
+function requireRecord(value: unknown, field: string): asserts value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    protocolError(`${field} must be an object`);
+  }
 }
 
 function requireNonEmpty(value: unknown, field: string): asserts value is string {

--- a/adapters/final-cut/typescript/src/live.ts
+++ b/adapters/final-cut/typescript/src/live.ts
@@ -156,13 +156,13 @@ export class FinalCutLiveAdapter implements LiveEditorStatePort {
   }
 
   public async apply(operation: EditOperation, expectedRevision: ContextRevision): Promise<ContextRevision> {
+    validateRevision(expectedRevision, "expected revision");
     const capabilities = await this.getCapabilities();
     if (capabilities.editor.canonicalTimelineMode !== "canonical-write") {
       throw new Error("CAPABILITY_UNAVAILABLE: live Final Cut canonical mutation");
     }
     const response = await this.request({ method: "apply", operation, expectedRevision });
     if (!response.revision) throw new Error("FINAL_CUT_LIVE_PROTOCOL: apply response revision was empty");
-    validateRevision(expectedRevision, "expected revision");
     validateRevision(response.revision, "apply response revision");
     if (
       response.revision.sequence <= expectedRevision.sequence
@@ -204,6 +204,10 @@ export class FinalCutLiveAdapter implements LiveEditorStatePort {
   }
 
   public async selectProject(selection: ProjectSelection): Promise<ProjectCatalog> {
+    requireNonEmpty(selection.projectId, "selected project id");
+    if (selection.sequenceId !== undefined) {
+      requireNonEmpty(selection.sequenceId, "selected sequence id");
+    }
     const response = await this.request({
       method: "select-project",
       projectId: selection.projectId,

--- a/adapters/final-cut/typescript/src/live.ts
+++ b/adapters/final-cut/typescript/src/live.ts
@@ -162,6 +162,14 @@ export class FinalCutLiveAdapter implements LiveEditorStatePort {
     }
     const response = await this.request({ method: "apply", operation, expectedRevision });
     if (!response.revision) throw new Error("FINAL_CUT_LIVE_PROTOCOL: apply response revision was empty");
+    validateRevision(expectedRevision, "expected revision");
+    validateRevision(response.revision, "apply response revision");
+    if (
+      response.revision.sequence <= expectedRevision.sequence
+      || response.revision.id === expectedRevision.id
+    ) {
+      protocolError("apply response revision must advance expected revision");
+    }
     return response.revision;
   }
 
@@ -241,11 +249,7 @@ function validateCanonicalSnapshot(snapshot: ProjectSnapshot): void {
   requireArray(snapshot.timeline?.markers, "timeline markers");
   requireArray(snapshot.timeline?.captions, "timeline captions");
   requireArray(snapshot.media, "media references");
-  requireNonEmpty(snapshot.revision?.id, "revision id");
-  if (!Number.isInteger(snapshot.revision?.sequence) || snapshot.revision.sequence < 0) {
-    protocolError("revision sequence must be a non-negative integer");
-  }
-  requireNonEmpty(snapshot.revision?.timestamp, "revision timestamp");
+  validateRevision(snapshot.revision, "revision");
 
   const mediaIds = uniqueIds(snapshot.media, ({ mediaId }) => mediaId, "media");
   uniqueIds(snapshot.timeline.markers, ({ id }) => id, "marker");
@@ -358,6 +362,14 @@ function requireFiniteNonNegative(value: unknown, field: string): asserts value 
   if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
     protocolError(`${field} must be finite and non-negative`);
   }
+}
+
+function validateRevision(revision: ContextRevision | undefined, field: string): asserts revision is ContextRevision {
+  requireNonEmpty(revision?.id, `${field} id`);
+  if (!Number.isInteger(revision?.sequence) || revision.sequence < 0) {
+    protocolError(`${field} sequence must be a non-negative integer`);
+  }
+  requireNonEmpty(revision?.timestamp, `${field} timestamp`);
 }
 
 function requireRational(value: unknown, field: string): void {

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -9,7 +9,14 @@ authoritative at runtime; unsupported operations must fail with an explicit
 | In-memory fixture | deterministic test fixture | yes | yes | yes | yes | fixture providers | fixture provider | fixture provider | fixture assets |
 | Final Cut document | FCPXML file interchange | yes, with project and sequence UIDs | artifact only | yes | yes | external provider required | no | no | no |
 | Final Cut session | document + Workflow Extension | document provider | artifact only | document provider | document provider | configured local provider | configured local provider | unavailable until configured | Motion-template registry |
-| Final Cut live | Workflow Extension live IPC | active project/sequence metadata only; catalog/selection unavailable | no | no | no | no | no | no | no |
+| Final Cut live (bundled Workflow Extension) | Workflow Extension live IPC | active project/sequence metadata only; catalog/selection unavailable | no | no | no | no | no | no | no |
+| Final Cut live (canonical-capable bridge) | guarded live IPC provider contract | complete snapshot with explicit targets | yes, when canonical-write is advertised | yes | yes | provider-specific | provider-specific | provider-specific | provider-specific |
+
+The canonical-capable live row describes an optional provider contract, not a
+claim about the bundled Workflow Extension. The bundled bridge remains
+metadata-only until a real Final Cut bridge can enumerate and mutate the open
+timeline and pass the headed evidence gate documented in
+[`docs/tests/final-cut-live-e2e.md`](tests/final-cut-live-e2e.md).
 
 ## Verified local environment
 

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -28,13 +28,13 @@
 | `editor.native.trim-to-duration.execute` | Execute a previewed trim-to-duration operation | Requires unchanged sequence revision and duration |
 | `context.inspect` | Queryable agent editing context | Backend-dependent |
 | `context.changes` | Incremental timeline, live-state, and asset changes | Backend-dependent; fails closed when unavailable |
-| `project.inspect` | Canonical project snapshot | Fixture/FCPXML-backed Final Cut session |
-| `project.list` | Stable project and sequence catalog plus active IDs | Deterministic fixture and FCPXML-backed session; live-only Final Cut is unavailable |
-| `project.select` | Select a project and explicit sequence when needed | Deterministic fixture and FCPXML-backed session; ambiguous targets fail closed |
-| `timeline.inspect` | Canonical timeline snapshot | FCPXML-backed Final Cut session; not live-only |
+| `project.inspect` | Canonical project snapshot | Fixture/FCPXML-backed session or a canonical-capable live Final Cut bridge |
+| `project.list` | Stable project and sequence catalog plus active IDs | Deterministic fixture, FCPXML-backed session, or a canonical-capable live bridge |
+| `project.select` | Select a project and explicit sequence when needed | Deterministic fixture, FCPXML-backed session, or a canonical-capable live bridge; ambiguous targets fail closed |
+| `timeline.inspect` | Canonical timeline snapshot | Fixture/FCPXML-backed session or a canonical-capable live Final Cut bridge |
 | `timeline.frame.capture` | Image at an exact rational timeline position, with timecode and timeline metadata; optional visual analysis | Deterministic fixture; other backends fail with `CAPABILITY_UNAVAILABLE` until a capture provider is configured |
-| `timeline.changes` | Canonical timeline diff | Fixture/FCPXML-backed Final Cut session |
-| `timeline.edit` | Supported Phase 0 edits | Fixture/FCPXML artifact path |
+| `timeline.changes` | Canonical timeline diff | Fixture/FCPXML-backed session or a canonical-capable live Final Cut bridge |
+| `timeline.edit` | Supported Phase 0 edits | Fixture/FCPXML artifact path or a canonical-capable live Final Cut bridge |
 | `timeline.edit.preview` | Validate an ordered Basic Editing MVP workflow and return a short-lived token plus expected diff | Deterministic fixture; non-mutating and capability-gated |
 | `timeline.edit.execute` | Execute one composite preview exactly once, verify it, and return the transaction | Deterministic fixture; stale, expired, reused, or unsupported previews fail before mutation |
 | `timeline.publish.new-project` | Import a verified FCPXML artifact as a new project | Requires verified `transactionId`, FCPXML path, and native writes; never replaces the active project |
@@ -45,9 +45,9 @@
 | `visual.analyze` | Scenes, subjects, motion, and keyframes | Fixture or configured local JSON provider |
 | `media.understand` | Combined speech, audio, and visual understanding | Configured providers required for Final Cut |
 | `editor.assets` | Search native editor assets by text, kind, or vendor | Fixture or Motion-template registry |
-| `edit.diff` | Transaction diff | Fixture/FCPXML transaction path |
-| `edit.verify` | Verification results | Fixture/FCPXML transaction path |
-| `edit.undo` | Restore a transaction | Fixture/FCPXML transaction path |
+| `edit.diff` | Transaction diff | Fixture/FCPXML transaction path or a canonical-capable live Final Cut bridge |
+| `edit.verify` | Verification results | Fixture/FCPXML transaction path or a canonical-capable live Final Cut bridge |
+| `edit.undo` | Restore a transaction | Fixture/FCPXML transaction path or a canonical-capable live Final Cut bridge |
 
 ## Live Final Cut tools
 
@@ -56,19 +56,27 @@
 | `editor.live.inspect` | none | Active project, sequence, playhead, range, and revision |
 | `editor.live.changes` | `sequence`, optional `waitMs` | Events after the requested revision |
 
-Live Final Cut state is not presented as a complete canonical timeline. When
-`FRAMEKIT_FCPXML_PATH` is configured, canonical tools use that artifact while
-`editor.live.*` continues to report the actual open Final Cut state.
+The bundled Workflow Extension is metadata-only, so its `editor.live.*` state is
+not presented as a complete canonical timeline. A separate bridge may expose
+canonical tools only after it advertises `canonical-read` or `canonical-write`
+and passes the adapter’s snapshot, identity, target, and revision validation.
+When `FRAMEKIT_FCPXML_PATH` is configured, canonical tools use that artifact
+while `editor.live.*` continues to report the actual open Final Cut state; the
+artifact provider does not inherit canonical-write capability from the live
+state provider.
 
 `project.list` and `project.select` use stable IDs supplied by the selected
 backend. The current Workflow Extension exposes only the active project and
 sequence metadata, not a project browser or project-selection API, so a
-live-only session rejects these tools with `CAPABILITY_UNAVAILABLE`. An
-FCPXML-backed session can inspect and select its single managed project;
-selection never silently changes the open Final Cut project. Its project and
-sequence nodes must both provide non-empty `uid` attributes; otherwise project
-inspection and catalog operations fail with `FCPXML_PROJECT_IDENTITY_UNAVAILABLE`
-or `FCPXML_SEQUENCE_IDENTITY_UNAVAILABLE` instead of deriving IDs from mutable
+metadata-only live session rejects these tools with
+`CAPABILITY_UNAVAILABLE`. A canonical-capable live bridge must return unique
+project and sequence IDs and prove that an explicit selection became active;
+ambiguous or mismatched responses fail closed. An FCPXML-backed session can
+inspect and select its single managed project; selection never silently changes
+the open Final Cut project. Its project and sequence nodes must both provide
+non-empty `uid` attributes; otherwise project inspection and catalog operations
+fail with `FCPXML_PROJECT_IDENTITY_UNAVAILABLE` or
+`FCPXML_SEQUENCE_IDENTITY_UNAVAILABLE` instead of deriving IDs from mutable
 names.
 
 `media.search` remains canonical snapshot search. Live Browser import and search

--- a/tests/integration/canonical-live.test.ts
+++ b/tests/integration/canonical-live.test.ts
@@ -229,6 +229,63 @@ test("canonical-read live sessions expose complete snapshots with explicit stabl
   assert.ok(requests.some(({ method }) => method === "snapshot"));
 });
 
+test("live project selection fails closed on ambiguous or mismatched targets", async () => {
+  const adapter = new FinalCutLiveAdapter({
+    request: async (request: FinalCutLiveRequest): Promise<FinalCutLiveResponse> => ({
+      version: 1,
+      id: request.id,
+      ok: true,
+      result: {
+        identity: { name: "Final Cut Pro", version: "test", backend: "canonical-live-ipc" },
+        capabilities: canonicalReadCapabilities,
+        catalog: {
+          projects: [{
+            id: canonicalSnapshot.projectId,
+            name: canonicalSnapshot.projectName,
+            sequences: [
+              { id: canonicalSnapshot.timeline.id, name: canonicalSnapshot.timeline.name },
+              { id: "final-cut:sequence:social", name: "Social" },
+            ],
+          }],
+          activeProjectId: canonicalSnapshot.projectId,
+          activeSequenceId: canonicalSnapshot.timeline.id,
+        },
+      },
+    }),
+  });
+
+  await assert.rejects(
+    adapter.selectProject({ projectId: canonicalSnapshot.projectId }),
+    /AMBIGUOUS_PROJECT_TARGET: sequenceId is required/,
+  );
+  await assert.rejects(
+    adapter.selectProject({ projectId: canonicalSnapshot.projectId, sequenceId: "final-cut:sequence:social" }),
+    /TARGET_MISMATCH: live project selection did not activate requested target/,
+  );
+});
+
+test("live project catalogs fail closed on duplicate project identities", async () => {
+  const adapter = new FinalCutLiveAdapter({
+    request: async (request: FinalCutLiveRequest): Promise<FinalCutLiveResponse> => ({
+      version: 1,
+      id: request.id,
+      ok: true,
+      result: {
+        identity: { name: "Final Cut Pro", version: "test", backend: "canonical-live-ipc" },
+        capabilities: canonicalReadCapabilities,
+        catalog: {
+          projects: [
+            { id: "duplicate-project", name: "One", sequences: [] },
+            { id: "duplicate-project", name: "Two", sequences: [] },
+          ],
+        },
+      },
+    }),
+  });
+
+  await assert.rejects(adapter.listProjects(), /FINAL_CUT_LIVE_PROTOCOL: duplicate project id duplicate-project/);
+});
+
 const canonicalWriteCapabilities: RuntimeCapabilities = {
   ...canonicalReadCapabilities,
   editor: {

--- a/tests/integration/canonical-live.test.ts
+++ b/tests/integration/canonical-live.test.ts
@@ -14,7 +14,7 @@ import {
   type FinalCutLiveRequest,
   type FinalCutLiveResponse,
 } from "@framekit/final-cut";
-import type { EditOperation, ProjectSnapshot, RuntimeCapabilities } from "@framekit/runtime";
+import type { EditOperation, ProjectCatalog, ProjectSnapshot, RuntimeCapabilities } from "@framekit/runtime";
 import { createMcpServer } from "../../apps/mcp-server/src/server.js";
 
 const execFile = promisify(execFileCallback);
@@ -284,6 +284,43 @@ test("live project catalogs fail closed on duplicate project identities", async 
   });
 
   await assert.rejects(adapter.listProjects(), /FINAL_CUT_LIVE_PROTOCOL: duplicate project id duplicate-project/);
+});
+
+test("live project catalogs reject non-object project and sequence entries", async () => {
+  const malformedProjectAdapter = new FinalCutLiveAdapter({
+    request: async (request: FinalCutLiveRequest): Promise<FinalCutLiveResponse> => ({
+      version: 1,
+      id: request.id,
+      ok: true,
+      result: {
+        identity: { name: "Final Cut Pro", version: "test", backend: "canonical-live-ipc" },
+        capabilities: canonicalReadCapabilities,
+        catalog: { projects: [null] } as unknown as ProjectCatalog,
+      },
+    }),
+  });
+
+  await assert.rejects(malformedProjectAdapter.listProjects(), /FINAL_CUT_LIVE_PROTOCOL: project must be an object/);
+
+  const malformedSequenceAdapter = new FinalCutLiveAdapter({
+    request: async (request: FinalCutLiveRequest): Promise<FinalCutLiveResponse> => ({
+      version: 1,
+      id: request.id,
+      ok: true,
+      result: {
+        identity: { name: "Final Cut Pro", version: "test", backend: "canonical-live-ipc" },
+        capabilities: canonicalReadCapabilities,
+        catalog: {
+          projects: [{ id: "project-1", name: "Project", sequences: [null] }],
+        } as unknown as ProjectCatalog,
+      },
+    }),
+  });
+
+  await assert.rejects(
+    malformedSequenceAdapter.listProjects(),
+    /FINAL_CUT_LIVE_PROTOCOL: sequence in project project-1 must be an object/,
+  );
 });
 
 const canonicalWriteCapabilities: RuntimeCapabilities = {

--- a/tests/integration/canonical-live.test.ts
+++ b/tests/integration/canonical-live.test.ts
@@ -296,6 +296,29 @@ const canonicalWriteCapabilities: RuntimeCapabilities = {
   },
 };
 
+test("live canonical apply rejects a non-advancing resulting revision", async () => {
+  const adapter = new FinalCutLiveAdapter({
+    request: async (request: FinalCutLiveRequest): Promise<FinalCutLiveResponse> => ({
+      version: 1,
+      id: request.id,
+      ok: true,
+      result: {
+        identity: { name: "Final Cut Pro", version: "test", backend: "canonical-live-ipc" },
+        capabilities: canonicalWriteCapabilities,
+        revision: canonicalSnapshot.revision,
+      },
+    }),
+  });
+
+  await assert.rejects(
+    adapter.apply(
+      { type: "rename-clip", clipId: "final-cut:occurrence:one", name: "Invalid revision" },
+      canonicalSnapshot.revision,
+    ),
+    /FINAL_CUT_LIVE_PROTOCOL: apply response revision must advance expected revision/,
+  );
+});
+
 class MutableCanonicalLiveTransport {
   public snapshot = structuredClone(canonicalSnapshot);
   public applyCalls = 0;

--- a/tests/integration/canonical-live.test.ts
+++ b/tests/integration/canonical-live.test.ts
@@ -319,6 +319,67 @@ test("live canonical apply rejects a non-advancing resulting revision", async ()
   );
 });
 
+test("live canonical apply rejects an unchanged revision id even when sequence advances", async () => {
+  const adapter = new FinalCutLiveAdapter({
+    request: async (request: FinalCutLiveRequest): Promise<FinalCutLiveResponse> => ({
+      version: 1,
+      id: request.id,
+      ok: true,
+      result: {
+        identity: { name: "Final Cut Pro", version: "test", backend: "canonical-live-ipc" },
+        capabilities: canonicalWriteCapabilities,
+        revision: {
+          ...canonicalSnapshot.revision,
+          sequence: canonicalSnapshot.revision.sequence + 1,
+        },
+      },
+    }),
+  });
+
+  await assert.rejects(
+    adapter.apply(
+      { type: "rename-clip", clipId: "final-cut:occurrence:one", name: "Reused revision id" },
+      canonicalSnapshot.revision,
+    ),
+    /FINAL_CUT_LIVE_PROTOCOL: apply response revision must advance expected revision/,
+  );
+});
+
+test("live adapter rejects invalid mutation and selection inputs before transport", async () => {
+  const requests: FinalCutLiveRequest[] = [];
+  const adapter = new FinalCutLiveAdapter({
+    request: async (request: FinalCutLiveRequest): Promise<FinalCutLiveResponse> => {
+      requests.push(request);
+      return {
+        version: 1,
+        id: request.id,
+        ok: true,
+        result: {
+          identity: { name: "Final Cut Pro", version: "test", backend: "canonical-live-ipc" },
+          capabilities: canonicalWriteCapabilities,
+        },
+      };
+    },
+  });
+
+  await assert.rejects(
+    adapter.apply(
+      { type: "rename-clip", clipId: "final-cut:occurrence:one", name: "Invalid input" },
+      { ...canonicalSnapshot.revision, timestamp: "" },
+    ),
+    /FINAL_CUT_LIVE_PROTOCOL: expected revision timestamp must be a non-empty string/,
+  );
+  await assert.rejects(
+    adapter.selectProject({ projectId: "" }),
+    /FINAL_CUT_LIVE_PROTOCOL: selected project id must be a non-empty string/,
+  );
+  await assert.rejects(
+    adapter.selectProject({ projectId: "project-1", sequenceId: " " }),
+    /FINAL_CUT_LIVE_PROTOCOL: selected sequence id must be a non-empty string/,
+  );
+  assert.deepEqual(requests, []);
+});
+
 class MutableCanonicalLiveTransport {
   public snapshot = structuredClone(canonicalSnapshot);
   public applyCalls = 0;

--- a/tests/integration/canonical-live.test.ts
+++ b/tests/integration/canonical-live.test.ts
@@ -323,6 +323,37 @@ test("live project catalogs reject non-object project and sequence entries", asy
   );
 });
 
+test("live project catalogs fail closed on duplicate sequence identities", async () => {
+  const adapter = new FinalCutLiveAdapter({
+    request: async (request: FinalCutLiveRequest): Promise<FinalCutLiveResponse> => ({
+      version: 1,
+      id: request.id,
+      ok: true,
+      result: {
+        identity: { name: "Final Cut Pro", version: "test", backend: "canonical-live-ipc" },
+        capabilities: canonicalReadCapabilities,
+        catalog: {
+          projects: [
+            {
+              id: "project-1",
+              name: "Project",
+              sequences: [
+                { id: "duplicate-sequence", name: "One" },
+                { id: "duplicate-sequence", name: "Two" },
+              ],
+            },
+          ],
+        },
+      },
+    }),
+  });
+
+  await assert.rejects(
+    adapter.listProjects(),
+    /FINAL_CUT_LIVE_PROTOCOL: duplicate sequence id duplicate-sequence in project project-1/,
+  );
+});
+
 const canonicalWriteCapabilities: RuntimeCapabilities = {
   ...canonicalReadCapabilities,
   editor: {


### PR DESCRIPTION
## Summary

Follow-up to #52; refs #32.

- validate live project catalogs and reject duplicate identities
- require explicit live project/sequence selection to become active
- reject non-advancing canonical apply revisions
- align MCP and compatibility documentation with canonical-capable live routing

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm run test` — 166 passed
- `pnpm run check:boundaries`
- `pnpm run xcode:check`
- `xcodebuild -project adapters/final-cut/swift-bridge/FinalCutWorkflowExtension/FramekitFinalCutWorkflow.xcodeproj -list`

## Limitation

The bundled Workflow Extension remains metadata-only because the checked-in Final Cut host shim does not expose complete timeline enumeration or canonical mutation. This PR does not claim that issue #32's headed canonical evidence gate is complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for live project selection, catalogs, snapshots, revisions, and canonical timeline writes.
  * Prevented ambiguous, mismatched, duplicate, stale, or non-advancing project and timeline operations.
  * Added clearer failure handling when project or timeline information is unavailable.
  * Invalid requests are rejected before transmission.

* **Documentation**
  * Clarified capabilities and limitations of bundled and canonical-capable live Final Cut bridges.
  * Documented supported tools, bridge requirements, and FCPXML identity requirements.

* **Tests**
  * Added coverage for invalid selections, duplicate projects and sequences, malformed catalogs, and revision handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->