### PR TITLE
chore: set up Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:best-practices"],
+  "timezone": "Asia/Tokyo",
+  "schedule": ["before 9am on monday"],
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "packageRules": [
+    {
+      "description": "Group non-major development dependency updates",
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "dev dependencies"
+    },
+    {
+      "description": "Group GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "groupName": "github actions"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add Renovate configuration using `config:best-practices`
- run dependency updates weekly on Monday mornings (Asia/Tokyo)
- cap concurrent and hourly Renovate PR creation
- group non-major npm dev dependency updates
- group GitHub Actions updates
- keep automerge disabled by default

## Notes

After merging this PR, Renovate still needs repository access via the Renovate GitHub App (or a self-hosted Renovate runner) before update PRs will begin appearing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated dependency update management.
  * Updates are scheduled during off-peak hours to reduce disruption.
  * Related updates may be grouped together for easier review.
  * Limits were added to help keep update activity manageable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->