### PR TITLE
docs: add deep wiki navigation without deleting content

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,31 @@
 
 This directory is the shareable knowledge base for Framekit.
 
+It is also Framekit's deep wiki: a place where users, integrators,
+contributors, and curious readers can understand what the project does, how it
+is built, and what has actually been validated.
+
+## Start here
+
+Choose the path that matches your question:
+
+- [Getting started](./getting-started/README.md) if you are new to Framekit.
+- [Guides](./guides/README.md) if you want to complete a task.
+- [Concepts](./concepts/README.md) if you want the ideas and product model.
+- [Integrations](./integrations/README.md) if you are connecting an editor or
+  an agent.
+- [Reference](./reference/README.md) if you need exact tools, protocols, or
+  compatibility details.
+- [Architecture](./architecture/README.md) if you want to understand the
+  implementation boundaries.
+- [Project](./project/README.md) for requirements, design documents, and ADRs.
+- [Validation](./validation/README.md) for evidence, test scope, and known
+  limitations.
+
+These index pages organize the knowledge base without replacing the existing
+documents. Content migration is incremental, and the established document
+paths remain available while links and readers move to the new structure.
+
 Repository-local GitHub agent playbooks are documented in
 [`../.agents/README.md`](../.agents/README.md).
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,16 @@
+# Architecture
+
+The architecture section explains how Framekit keeps editor-independent
+contracts separate from MCP transport and editor adapters.
+
+- [Architecture overview](../ARCHITECTURE.md)
+- [Runtime boundaries](./runtime-boundaries.md)
+- [Backend selection](./backend-selection.md)
+- [Capability model](./capability-model.md)
+- [Skill requirements](./skill-requirements.md)
+- [Skill runtime](./skill-runtime.md)
+- [Filler detection and safe cuts](./filler-detection-safe-cuts.md)
+- [Rough-cut construction](./rough-cut-construction.md)
+
+This index is a map over the existing architecture documents; it does not
+replace or shorten them.

--- a/docs/concepts/README.md
+++ b/docs/concepts/README.md
@@ -1,0 +1,17 @@
+# Concepts
+
+Conceptual explanations for understanding Framekit before using a particular
+tool or integration.
+
+- [Architecture overview](../ARCHITECTURE.md): the major runtime and adapter
+  boundaries.
+- [Architecture details](../architecture/runtime-boundaries.md): dependency
+  direction and responsibility boundaries.
+- [Capability model](../architecture/capability-model.md): supported,
+  unavailable, and fail-closed operations.
+- [Product requirements](../PRD.md): product goals and roadmap context.
+- [Software design](../SDD.md): system-level design contracts.
+- [Compatibility](../COMPATIBILITY.md): verified editor and toolchain scope.
+
+Concept pages should explain the model in plain language and link to the
+reference pages where exact contracts live.

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,0 +1,14 @@
+# Getting started
+
+This section is the entry point for people who are discovering Framekit.
+
+- [Existing getting-started guide](../getting-started.md): installation,
+  MCP setup, and the first connection path.
+- [Final Cut installation](../final-cut/installation.md): Workflow Extension,
+  permissions, and capability boundaries.
+- [MCP documentation](../mcp/README.md): the agent-facing protocol and tools.
+- [Clean MCP client validation](../tests/clean-mcp-clients.md): reproducible
+  first-run checks for supported clients.
+
+The original documents remain canonical while this audience-oriented index is
+expanded.

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,0 +1,15 @@
+# Guides
+
+Task-oriented entry points for using and operating Framekit.
+
+- [Basic Final Cut Editing MVP](../final-cut/basic-editing-mvp.md): the
+  end-to-end editing workflow and its validation contract.
+- [MCP tools](../mcp/tools.md): tool-level workflows and request semantics.
+- [Rough-cut duration policy](../rough-cut/duration-policy.md): planning edits
+  when the requested duration is a soft constraint.
+- [Final Cut troubleshooting](../final-cut/troubleshooting.md): operational
+  recovery and diagnostics.
+- [Release operations](../releasing.md): publishing and release verification.
+
+New task guides should link to the deeper reference and validation material
+that supports their claims.

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -1,0 +1,15 @@
+# Integrations
+
+How Framekit connects to editors, agents, and local tools.
+
+- [Final Cut integration](./final-cut/README.md): native connection,
+  installation, and capability boundaries.
+- [MCP documentation](../mcp/README.md): the protocol exposed to agent
+  clients.
+- [Clean MCP client validation](../tests/clean-mcp-clients.md): reproducible
+  checks for client installation and first-run behavior.
+- [Codex plugin documentation](../../README.md#connect-codex-to-final-cut): the
+  plugin entry point when using Codex.
+
+Integration pages must distinguish deterministic fixture behavior, artifact
+behavior, and headed native Final Cut evidence.

--- a/docs/integrations/agents/README.md
+++ b/docs/integrations/agents/README.md
@@ -1,0 +1,15 @@
+# Agent integrations
+
+Framekit exposes its editing runtime through MCP so that agent clients can
+inspect capabilities, plan work, and verify outcomes.
+
+- [Codex setup](../../../README.md#connect-codex-to-final-cut): install the
+  Framekit plugin and start a new session.
+- [MCP reference](../../reference/mcp/README.md): protocol, tools, and errors.
+- [Clean client validation](../../tests/clean-mcp-clients.md): reproducible
+  checks for supported agent clients.
+- [Skill authoring](../../mcp/skill-authoring.md): the versioned Skill
+  contract and lifecycle boundaries.
+
+Client-specific pages can be added here as their installation and evidence
+contracts become stable.

--- a/docs/integrations/final-cut/README.md
+++ b/docs/integrations/final-cut/README.md
@@ -1,0 +1,16 @@
+# Final Cut integration
+
+Framekit's Final Cut integration combines an editor-independent runtime with
+Final Cut-specific adapters and a local Workflow Extension bridge.
+
+- [Installation](../../final-cut/installation.md): setup, permissions, and
+  first connection checks.
+- [Final Cut operations](../../final-cut/README.md): integration overview.
+- [Workflow Extension IPC](../../final-cut/ipc.md): the local bridge contract.
+- [Troubleshooting](../../final-cut/troubleshooting.md): recovery and
+  diagnostics.
+- [Live validation](../../tests/final-cut-live-e2e.md): the headed evidence
+  boundary.
+
+Metadata, FCPXML, deterministic fixtures, and headed native Final Cut proof
+are separate evidence classes; each guide should say which one it uses.

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -1,0 +1,13 @@
+# Project
+
+Durable project context for contributors and maintainers.
+
+- [Product requirements](../PRD.md)
+- [Software design](../SDD.md)
+- [Architecture overview](../ARCHITECTURE.md)
+- [Architecture decision records](./adr/README.md)
+- [Release notes](../release-notes-v0.0.3.md)
+- [Release checklist](../release-v0.0.2-checklist.md)
+
+Project documents describe intent and decisions. Validation documents record
+what was actually demonstrated at a particular point in time.

--- a/docs/project/adr/README.md
+++ b/docs/project/adr/README.md
@@ -1,0 +1,14 @@
+# Architecture decision records
+
+The original ADR documents remain under [`../../adr/`](../../adr/). This page
+provides a stable project-oriented entry point while the documentation tree is
+being organized.
+
+- [ADR 0001: Workflow Extension IPC](../../adr/0001-workflow-extension-ipc.md)
+- [ADR 0002: Fail-closed live capabilities](../../adr/0002-fail-closed-live-capabilities.md)
+- [ADR 0003: Rational time](../../adr/0003-rational-time.md)
+- [ADR 0004: Automatic Final Cut connection](../../adr/0004-automatic-final-cut-connection.md)
+- [ADR 0005: Native selection writes](../../adr/0005-native-selection-writes.md)
+- [ADR 0006: Live browser blade and project publish](../../adr/0006-live-browser-blade-and-project-publish.md)
+- [ADR 0007: Native range and duration writes](../../adr/0007-native-range-and-duration-writes.md)
+- [ADR 0008: Skill contract](../../adr/0008-skill-contract.md)

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,0 +1,16 @@
+# Reference
+
+Exact contracts and operational details for users who already understand the
+basic Framekit workflow.
+
+- [MCP reference](./mcp/README.md): protocol, tools, capabilities, and errors.
+- [Compatibility](../COMPATIBILITY.md): verified support matrix.
+- [Configuration and environment](../getting-started.md): current setup
+  instructions and runtime configuration.
+- [Release operations](../releasing.md): exact publishing and verification
+  commands.
+- [Validation evidence](../validation/README.md): scope and limitations of
+  reported behavior.
+
+Reference pages should prefer exact names, schemas, commands, and explicit
+unsupported behavior over aspirational descriptions.

--- a/docs/reference/mcp/README.md
+++ b/docs/reference/mcp/README.md
@@ -1,0 +1,15 @@
+# MCP reference
+
+The MCP surface exposed by Framekit is documented in the existing reference
+pages:
+
+- [Protocol](../../mcp/protocol.md)
+- [Tools](../../mcp/tools.md)
+- [Capabilities and errors](../../mcp/capabilities-and-errors.md)
+- [Final Cut live behavior](../../mcp/final-cut-live.md)
+- [Generic Skills](../../mcp/skills.md)
+- [Skill authoring](../../mcp/skill-authoring.md)
+
+When a capability is unavailable, the reference should describe the explicit
+failure and the evidence boundary instead of implying that a fallback is a
+native edit.

--- a/docs/validation/README.md
+++ b/docs/validation/README.md
@@ -1,0 +1,16 @@
+# Validation
+
+Validation pages explain what Framekit has demonstrated, under which
+conditions, and where the evidence stops.
+
+- [Test index](../tests/README.md)
+- [Test matrix](../tests/test-matrix.md)
+- [MCP evaluation](../tests/mcp-evaluation.md)
+- [Final Cut live validation](../tests/final-cut-live-e2e.md)
+- [Release gate](../tests/release-gate.md)
+- [Skill conformance](../tests/skill-conformance.md)
+- [Evidence directory](../tests/evidence/)
+
+Every validation report should identify its goal, result, environment, scope,
+and limitations. Deterministic fixtures and metadata-only evidence do not by
+themselves prove headed native Final Cut behavior.


### PR DESCRIPTION
## Summary

- add a Framekit documentation landing page for the deep wiki
- add audience-oriented indexes for getting started, guides, concepts, integrations, reference, architecture, project, and validation
- keep all existing documentation files and canonical paths intact

## Scope

This is the non-destructive first step toward a Framekit landing page and deep wiki. The new index pages organize the existing knowledge base; they do not replace, empty, or delete the established documents. Content migration can happen incrementally in follow-up changes.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm run test` — 466 passed
- `pnpm run check:boundaries`
- diff against current `main` contains no deleted paths

## Follow-up

Future documentation work can move or expand content only with explicit links, preserved evidence boundaries, and compatible references from the existing paths.