### PR TITLE
[Improvement] Add sanitized headed evidence for native Final Cut mutation

### DIFF
--- a/docs/tests/final-cut-live-e2e.md
+++ b/docs/tests/final-cut-live-e2e.md
@@ -123,14 +123,21 @@ pnpm run test:final-cut-canonical-headed \
 ```
 
 The runner disables FCPXML composition, verifies the exact project and
-occurrence before mutation, renames that occurrence, records the capability
-payload plus complete before/after state and deterministic diff, and performs
-compensating undo. It succeeds only when the restored canonical digest matches
-the pre-edit digest. If the bridge is metadata-only or canonical-read, it fails
-before calling `timeline.edit`. Review the JSON for the Framekit version, Final
-Cut identity/version, target IDs, capability payload, and matching digests
-before attaching it to a release or pull request. Do not commit evidence that
-contains private media paths.
+occurrence before mutation, renames that occurrence, and performs compensating
+undo. It emits a sanitized evidence document using an allowlisted summary
+rather than the raw snapshots returned by the MCP tools. The document records
+the Framekit version, full Git commit, runtime environment, Final Cut
+identity/version, capability payload, required tool results, target IDs,
+verified revision/diff summaries, and matching pre-edit/restored digests. It
+proves that the open canonical timeline changed through the verified target
+diff and advancing revision, then proves restoration through the matching
+canonical digest. If the bridge is metadata-only or canonical-read, it fails
+before calling `timeline.edit`.
+
+Before attaching the JSON to a release or pull request, review that it contains
+no private media paths, raw snapshots, transaction identifiers, credentials,
+or diagnostics. The runner and sanitizer both fail closed when the mutation,
+undo, required tool sequence, or full commit provenance is incomplete.
 
 ## Optional native UI validation
 

--- a/scripts/final-cut-canonical-headed-e2e.mjs
+++ b/scripts/final-cut-canonical-headed-e2e.mjs
@@ -1,10 +1,16 @@
 import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import os from "node:os";
+import { execFile as execFileCallback } from "node:child_process";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
+import { promisify } from "node:util";
+import { sanitizeCanonicalEvidence } from "./final-cut-evidence.mjs";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const execFile = promisify(execFileCallback);
 const expectedProject = process.env.FRAMEKIT_FINAL_CUT_E2E_PROJECT;
 const clipId = process.env.FRAMEKIT_FINAL_CUT_E2E_CLIP_ID;
 
@@ -59,19 +65,21 @@ try {
     throw new Error("FINAL_CUT_E2E_ROLLBACK_DIGEST_MISMATCH: undo did not restore the pre-edit canonical digest");
   }
 
-  process.stdout.write(`${JSON.stringify({
+  const evidence = sanitizeCanonicalEvidence({
     passed: true,
     recordedAt: new Date().toISOString(),
     editor: editor.identity,
     capabilities: editor.capabilities,
     project: { id: before.projectId, name: before.projectName, sequenceId: before.timeline.id },
     target: { occurrenceId: target.id, mediaId: target.mediaId },
+    editStatus: transaction.status,
     before,
     after: transaction.after,
     diff: transaction.diff,
     restored,
     digests: { before: beforeDigest, restored: restoredDigest },
-  }, null, 2)}\n`);
+  }, await evidenceEnvironment());
+  process.stdout.write(`${JSON.stringify(evidence, null, 2)}\n`);
 } catch (error) {
   if (transactionId) {
     try {
@@ -117,4 +125,23 @@ function stableJson(value) {
 
 function compareText(left, right) {
   return left < right ? -1 : left > right ? 1 : 0;
+}
+
+async function evidenceEnvironment() {
+  const packageJson = JSON.parse(await readFile(join(root, "package.json"), "utf8"));
+  let gitCommit;
+  try {
+    gitCommit = (await execFile("git", ["rev-parse", "HEAD"], { cwd: root })).stdout.trim();
+  } catch (error) {
+    throw new Error(`FINAL_CUT_E2E_COMMIT_UNAVAILABLE: ${String(error)}`);
+  }
+  if (!gitCommit) throw new Error("FINAL_CUT_E2E_COMMIT_UNAVAILABLE: git returned an empty commit");
+  return {
+    framekitVersion: packageJson.version,
+    gitCommit,
+    nodeVersion: process.version,
+    platform: process.platform,
+    architecture: process.arch,
+    osVersion: os.version(),
+  };
 }

--- a/scripts/final-cut-canonical-headed-e2e.mjs
+++ b/scripts/final-cut-canonical-headed-e2e.mjs
@@ -35,11 +35,13 @@ let transactionId;
 try {
   await client.connect(transport);
   const editor = await callJson("editor.inspect");
+  const toolResults = [{ name: "editor.inspect", status: "passed" }];
   if (editor.capabilities?.editor?.canonicalTimelineMode !== "canonical-write") {
     throw new Error(`CAPABILITY_UNAVAILABLE: live bridge reported ${editor.capabilities?.editor?.canonicalTimelineMode ?? "unknown"}; canonical-write is required`);
   }
 
   const before = await callJson("project.inspect");
+  toolResults.push({ name: "project.inspect", status: "passed" });
   if (before.projectName !== expectedProject) {
     throw new Error(`FINAL_CUT_E2E_PROJECT_MISMATCH: expected ${expectedProject}, observed ${before.projectName ?? "unknown"}`);
   }
@@ -53,12 +55,14 @@ try {
     name: `${target.name} [Framekit E2E]`,
     baseRevision: before.revision,
   });
+  toolResults.push({ name: "timeline.edit", status: transaction.status });
   transactionId = transaction.id;
   if (transaction.status !== "VERIFIED" || transaction.diff?.modified?.[0]?.itemId !== clipId) {
     throw new Error("FINAL_CUT_E2E_EDIT_VERIFICATION_FAILED: live edit did not return the expected verified diff");
   }
 
   const restored = await callJson("edit.undo", { transactionId });
+  toolResults.push({ name: "edit.undo", status: "passed" });
   transactionId = undefined;
   const restoredDigest = canonicalDigest(restored);
   if (restoredDigest !== beforeDigest) {
@@ -72,6 +76,7 @@ try {
     capabilities: editor.capabilities,
     project: { id: before.projectId, name: before.projectName, sequenceId: before.timeline.id },
     target: { occurrenceId: target.id, mediaId: target.mediaId },
+    toolResults,
     editStatus: transaction.status,
     before,
     after: transaction.after,

--- a/scripts/final-cut-canonical-headed-e2e.mjs
+++ b/scripts/final-cut-canonical-headed-e2e.mjs
@@ -143,10 +143,21 @@ async function evidenceEnvironment() {
   if (!gitCommit) throw new Error("FINAL_CUT_E2E_COMMIT_UNAVAILABLE: git returned an empty commit");
   return {
     framekitVersion: packageJson.version,
+    finalCutVersion: await finalCutVersion(),
     gitCommit,
     nodeVersion: process.version,
     platform: process.platform,
     architecture: process.arch,
     osVersion: os.version(),
   };
+}
+
+async function finalCutVersion() {
+  try {
+    const version = (await execFile("osascript", ["-e", 'tell application "Final Cut Pro" to get version'])).stdout.trim();
+    if (version) return version;
+  } catch (error) {
+    throw new Error(`FINAL_CUT_E2E_FINAL_CUT_VERSION_UNAVAILABLE: ${String(error)}`);
+  }
+  throw new Error("FINAL_CUT_E2E_FINAL_CUT_VERSION_UNAVAILABLE: Final Cut Pro returned an empty version");
 }

--- a/scripts/final-cut-evidence.d.mts
+++ b/scripts/final-cut-evidence.d.mts
@@ -1,5 +1,6 @@
 export function sanitizeCanonicalEvidence(run: unknown, environment: {
   framekitVersion: string;
+  finalCutVersion: string;
   gitCommit: string;
   nodeVersion: string;
   platform: string;

--- a/scripts/final-cut-evidence.d.mts
+++ b/scripts/final-cut-evidence.d.mts
@@ -1,0 +1,8 @@
+export function sanitizeCanonicalEvidence(run: unknown, environment: {
+  framekitVersion: string;
+  gitCommit: string;
+  nodeVersion: string;
+  platform: string;
+  architecture: string;
+  osVersion: string;
+}): unknown;

--- a/scripts/final-cut-evidence.mjs
+++ b/scripts/final-cut-evidence.mjs
@@ -40,6 +40,10 @@ export function sanitizeCanonicalEvidence(run, environment) {
   assert(run.before && run.after && run.restored && run.diff, "canonical snapshots or diff are missing");
   assert(run.digests?.before && run.digests?.restored, "canonical digests are missing");
   assert(run.digests.before === run.digests.restored, "restored digest does not match the pre-edit digest");
+  const beforeRevision = summarizeRevision(run.before.revision);
+  const afterRevision = summarizeRevision(run.after.revision);
+  const restoredRevision = summarizeRevision(run.restored.revision);
+  assert(afterRevision.sequence > beforeRevision.sequence, "canonical mutation revision did not advance");
 
   const beforeTarget = findTarget(run.before, run.target.occurrenceId);
   const afterTarget = findTarget(run.after, run.target.occurrenceId);
@@ -73,14 +77,14 @@ export function sanitizeCanonicalEvidence(run, environment) {
       operation: "rename-clip",
       status: run.editStatus,
       timelineChanged: true,
-      beforeRevision: summarizeRevision(run.before.revision),
-      afterRevision: summarizeRevision(run.after.revision),
+      beforeRevision,
+      afterRevision,
       diff: {
         addedCount: countChanges(run.diff.added),
         removedCount: countChanges(run.diff.removed),
         modifiedCount: modifiedItemIds.length,
         modifiedItemIds,
-        durationDelta: run.diff.durationDelta,
+        durationDelta: requireFiniteNumber(run.diff.durationDelta, "duration delta"),
         affectedRangeCount: countChanges(run.diff.affectedRanges),
       },
     },
@@ -90,7 +94,7 @@ export function sanitizeCanonicalEvidence(run, environment) {
       restored: true,
       beforeDigest: run.digests.before,
       restoredDigest: run.digests.restored,
-      restoredRevision: summarizeRevision(run.restored.revision),
+      restoredRevision,
     },
     sanitization: {
       strategy: "allowlisted-summary",
@@ -161,7 +165,7 @@ function summarizeRevision(revision) {
   assert(revision, "revision is missing");
   return {
     id: requireString(revision.id, "revision id"),
-    sequence: revision.sequence,
+    sequence: requireNonNegativeInteger(revision.sequence, "revision sequence"),
     timestamp: requireString(revision.timestamp, "revision timestamp"),
   };
 }
@@ -176,6 +180,16 @@ function countChanges(changes) {
 
 function requireString(value, label) {
   assert(isNonEmptyString(value), `${label} is missing`);
+  return value;
+}
+
+function requireFiniteNumber(value, label) {
+  assert(typeof value === "number" && Number.isFinite(value), `${label} must be a finite number`);
+  return value;
+}
+
+function requireNonNegativeInteger(value, label) {
+  assert(Number.isInteger(value) && value >= 0, `${label} must be a non-negative integer`);
   return value;
 }
 

--- a/scripts/final-cut-evidence.mjs
+++ b/scripts/final-cut-evidence.mjs
@@ -35,6 +35,7 @@ export function sanitizeCanonicalEvidence(run, environment) {
   assert(run.editStatus === "VERIFIED", "headed mutation was not verified");
   assert(run.editor, "editor identity is missing");
   assert(run.capabilities, "capability payload is missing");
+  assert(run.capabilities.editor?.canonicalTimelineMode === "canonical-write", "canonical-write capability is required");
   assert(run.project && run.target, "project or target identity is missing");
   assert(run.before && run.after && run.restored && run.diff, "canonical snapshots or diff are missing");
   assert(run.digests?.before && run.digests?.restored, "canonical digests are missing");

--- a/scripts/final-cut-evidence.mjs
+++ b/scripts/final-cut-evidence.mjs
@@ -23,6 +23,12 @@ const editorCapabilityKeys = [
 ];
 
 const analyzerCapabilityKeys = ["speechTranscribe", "speechVad", "audioLoudness", "visualTrack"];
+const requiredToolResults = [
+  ["editor.inspect", "passed"],
+  ["project.inspect", "passed"],
+  ["timeline.edit", "VERIFIED"],
+  ["edit.undo", "passed"],
+];
 
 export function sanitizeCanonicalEvidence(run, environment) {
   assert(run?.passed === true, "headed run did not pass");
@@ -61,6 +67,7 @@ export function sanitizeCanonicalEvidence(run, environment) {
       occurrenceId: requireString(run.target.occurrenceId, "occurrence id"),
       ...(isNonEmptyString(run.target.mediaId) ? { mediaId: run.target.mediaId } : {}),
     },
+    toolResults: sanitizeToolResults(run.toolResults),
     mutation: {
       operation: "rename-clip",
       status: run.editStatus,
@@ -92,9 +99,11 @@ export function sanitizeCanonicalEvidence(run, environment) {
 }
 
 function sanitizeEnvironment(environment) {
+  const gitCommit = requireString(environment?.gitCommit, "Git commit");
+  assert(/^[0-9a-f]{40}$/i.test(gitCommit), "Git commit must be a full SHA-1");
   return {
     framekitVersion: requireString(environment?.framekitVersion, "Framekit version"),
-    gitCommit: requireString(environment?.gitCommit, "Git commit"),
+    gitCommit,
     nodeVersion: requireString(environment?.nodeVersion, "Node version"),
     platform: requireString(environment?.platform, "platform"),
     architecture: requireString(environment?.architecture, "architecture"),
@@ -115,6 +124,18 @@ function sanitizeCapabilities(capabilities) {
     editor: pickKnown(capabilities.editor, editorCapabilityKeys),
     analyzers: pickKnown(capabilities.analyzers, analyzerCapabilityKeys),
   };
+}
+
+function sanitizeToolResults(toolResults) {
+  assert(Array.isArray(toolResults), "tool results are missing");
+  assert(toolResults.length === requiredToolResults.length, "required tool results are incomplete");
+  return toolResults.map((result, index) => {
+    const [expectedName, expectedStatus] = requiredToolResults[index];
+    const name = requireString(result?.name, "tool name");
+    const status = requireString(result?.status, `tool ${name} status`);
+    assert(name === expectedName && status === expectedStatus, `tool result ${index + 1} does not match the required headed workflow`);
+    return { name, status };
+  });
 }
 
 function pickKnown(value, keys) {

--- a/scripts/final-cut-evidence.mjs
+++ b/scripts/final-cut-evidence.mjs
@@ -1,0 +1,156 @@
+const editorCapabilityKeys = [
+  "canonicalTimelineMode",
+  "projectRead",
+  "timelineSnapshotRead",
+  "timelineWrite",
+  "timelineArtifactWrite",
+  "readAfterWrite",
+  "incrementalChanges",
+  "rollback",
+  "assetDiscovery",
+  "liveStateRead",
+  "playheadWrite",
+  "frameCapture",
+  "playbackControl",
+  "timelinePublishNewProject",
+  "projectCatalogRead",
+  "projectSelection",
+  "compositeTransactions",
+  "videoExport",
+  "mediaImport",
+  "mediaPlacement",
+  "titlePlacement",
+];
+
+const analyzerCapabilityKeys = ["speechTranscribe", "speechVad", "audioLoudness", "visualTrack"];
+
+export function sanitizeCanonicalEvidence(run, environment) {
+  assert(run?.passed === true, "headed run did not pass");
+  assert(run.editStatus === "VERIFIED", "headed mutation was not verified");
+  assert(run.editor, "editor identity is missing");
+  assert(run.capabilities, "capability payload is missing");
+  assert(run.project && run.target, "project or target identity is missing");
+  assert(run.before && run.after && run.restored && run.diff, "canonical snapshots or diff are missing");
+  assert(run.digests?.before && run.digests?.restored, "canonical digests are missing");
+  assert(run.digests.before === run.digests.restored, "restored digest does not match the pre-edit digest");
+
+  const beforeTarget = findTarget(run.before, run.target.occurrenceId);
+  const afterTarget = findTarget(run.after, run.target.occurrenceId);
+  const restoredTarget = findTarget(run.restored, run.target.occurrenceId);
+  assert(beforeTarget && afterTarget && restoredTarget, "target occurrence is missing from a canonical snapshot");
+  assert(beforeTarget.name !== afterTarget.name, "canonical mutation did not change the target occurrence");
+  assert(beforeTarget.name === restoredTarget.name, "restored target occurrence does not match the pre-edit state");
+
+  const modifiedItemIds = (run.diff.modified ?? []).map((change) => change?.itemId).filter(isNonEmptyString);
+  assert(modifiedItemIds.includes(run.target.occurrenceId), "canonical diff does not identify the target occurrence");
+
+  return {
+    schemaVersion: 1,
+    evidenceType: "headed-native-canonical-mutation",
+    passed: true,
+    recordedAt: requireString(run.recordedAt, "recordedAt"),
+    environment: sanitizeEnvironment(environment),
+    editor: sanitizeIdentity(run.editor),
+    capabilities: sanitizeCapabilities(run.capabilities),
+    project: {
+      id: requireString(run.project.id, "project id"),
+      name: requireString(run.project.name, "project name"),
+      sequenceId: requireString(run.project.sequenceId, "sequence id"),
+    },
+    target: {
+      occurrenceId: requireString(run.target.occurrenceId, "occurrence id"),
+      ...(isNonEmptyString(run.target.mediaId) ? { mediaId: run.target.mediaId } : {}),
+    },
+    mutation: {
+      operation: "rename-clip",
+      status: run.editStatus,
+      timelineChanged: true,
+      beforeRevision: summarizeRevision(run.before.revision),
+      afterRevision: summarizeRevision(run.after.revision),
+      diff: {
+        addedCount: countChanges(run.diff.added),
+        removedCount: countChanges(run.diff.removed),
+        modifiedCount: modifiedItemIds.length,
+        modifiedItemIds,
+        durationDelta: run.diff.durationDelta,
+        affectedRangeCount: countChanges(run.diff.affectedRanges),
+      },
+    },
+    restoration: {
+      operation: "edit.undo",
+      status: "VERIFIED",
+      restored: true,
+      beforeDigest: run.digests.before,
+      restoredDigest: run.digests.restored,
+      restoredRevision: summarizeRevision(run.restored.revision),
+    },
+    sanitization: {
+      strategy: "allowlisted-summary",
+      omitted: ["media sources", "raw snapshots", "transaction identifiers", "diagnostics"],
+    },
+  };
+}
+
+function sanitizeEnvironment(environment) {
+  return {
+    framekitVersion: requireString(environment?.framekitVersion, "Framekit version"),
+    gitCommit: requireString(environment?.gitCommit, "Git commit"),
+    nodeVersion: requireString(environment?.nodeVersion, "Node version"),
+    platform: requireString(environment?.platform, "platform"),
+    architecture: requireString(environment?.architecture, "architecture"),
+    osVersion: requireString(environment?.osVersion, "OS version"),
+  };
+}
+
+function sanitizeIdentity(identity) {
+  return {
+    name: requireString(identity.name, "editor name"),
+    version: requireString(identity.version, "editor version"),
+    backend: requireString(identity.backend, "editor backend"),
+  };
+}
+
+function sanitizeCapabilities(capabilities) {
+  return {
+    editor: pickKnown(capabilities.editor, editorCapabilityKeys),
+    analyzers: pickKnown(capabilities.analyzers, analyzerCapabilityKeys),
+  };
+}
+
+function pickKnown(value, keys) {
+  const result = {};
+  for (const key of keys) {
+    if (value?.[key] !== undefined) result[key] = value[key];
+  }
+  return result;
+}
+
+function summarizeRevision(revision) {
+  assert(revision, "revision is missing");
+  return {
+    id: requireString(revision.id, "revision id"),
+    sequence: revision.sequence,
+    timestamp: requireString(revision.timestamp, "revision timestamp"),
+  };
+}
+
+function findTarget(snapshot, occurrenceId) {
+  return snapshot.timeline?.clips?.find((clip) => clip?.id === occurrenceId);
+}
+
+function countChanges(changes) {
+  return Array.isArray(changes) ? changes.length : 0;
+}
+
+function requireString(value, label) {
+  assert(isNonEmptyString(value), `${label} is missing`);
+  return value;
+}
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(`FINAL_CUT_E2E_EVIDENCE_INCOMPLETE: ${message}`);
+}

--- a/scripts/final-cut-evidence.mjs
+++ b/scripts/final-cut-evidence.mjs
@@ -122,9 +122,18 @@ function sanitizeIdentity(identity) {
 }
 
 function sanitizeCapabilities(capabilities) {
+  const editor = pickKnown(capabilities.editor, editorCapabilityKeys);
+  const analyzers = pickKnown(capabilities.analyzers, analyzerCapabilityKeys);
+  assert(typeof editor.canonicalTimelineMode === "string", "canonicalTimelineMode capability must be a string");
+  for (const key of editorCapabilityKeys.filter((key) => key !== "canonicalTimelineMode")) {
+    if (editor[key] !== undefined) assert(typeof editor[key] === "boolean", `${key} capability must be boolean`);
+  }
+  for (const key of analyzerCapabilityKeys) {
+    if (analyzers[key] !== undefined) assert(typeof analyzers[key] === "boolean", `${key} capability must be boolean`);
+  }
   return {
-    editor: pickKnown(capabilities.editor, editorCapabilityKeys),
-    analyzers: pickKnown(capabilities.analyzers, analyzerCapabilityKeys),
+    editor,
+    analyzers,
   };
 }
 

--- a/scripts/final-cut-evidence.mjs
+++ b/scripts/final-cut-evidence.mjs
@@ -104,6 +104,7 @@ function sanitizeEnvironment(environment) {
   assert(/^[0-9a-f]{40}$/i.test(gitCommit), "Git commit must be a full SHA-1");
   return {
     framekitVersion: requireString(environment?.framekitVersion, "Framekit version"),
+    finalCutVersion: requireString(environment?.finalCutVersion, "Final Cut version"),
     gitCommit,
     nodeVersion: requireString(environment?.nodeVersion, "Node version"),
     platform: requireString(environment?.platform, "platform"),

--- a/tests/integration/canonical-evidence.test.ts
+++ b/tests/integration/canonical-evidence.test.ts
@@ -143,6 +143,56 @@ test("canonical headed evidence requires an exact full Git commit", () => {
   );
 });
 
+test("canonical headed evidence rejects a non-advancing mutation revision", () => {
+  const nonAdvancingRun = structuredClone(rawRun);
+  nonAdvancingRun.after.revision = structuredClone(nonAdvancingRun.before.revision);
+
+  assert.throws(
+    () => sanitizeCanonicalEvidence(nonAdvancingRun, {
+      framekitVersion: "0.1.0",
+      finalCutVersion: "10.7.1",
+      gitCommit: "0123456789abcdef0123456789abcdef01234567",
+      nodeVersion: "v22.15.0",
+      platform: "darwin",
+      architecture: "arm64",
+      osVersion: "Darwin Kernel Version 25.5.0",
+    }),
+    /FINAL_CUT_E2E_EVIDENCE_INCOMPLETE: canonical mutation revision did not advance/,
+  );
+});
+
+test("canonical headed evidence rejects malformed summary scalar values", () => {
+  const malformedDurationRun = structuredClone(rawRun);
+  Reflect.set(malformedDurationRun.diff, "durationDelta", { value: 0 });
+  assert.throws(
+    () => sanitizeCanonicalEvidence(malformedDurationRun, {
+      framekitVersion: "0.1.0",
+      finalCutVersion: "10.7.1",
+      gitCommit: "0123456789abcdef0123456789abcdef01234567",
+      nodeVersion: "v22.15.0",
+      platform: "darwin",
+      architecture: "arm64",
+      osVersion: "Darwin Kernel Version 25.5.0",
+    }),
+    /FINAL_CUT_E2E_EVIDENCE_INCOMPLETE: duration delta must be a finite number/,
+  );
+
+  const malformedSequenceRun = structuredClone(rawRun);
+  Reflect.set(malformedSequenceRun.before.revision, "sequence", "10");
+  assert.throws(
+    () => sanitizeCanonicalEvidence(malformedSequenceRun, {
+      framekitVersion: "0.1.0",
+      finalCutVersion: "10.7.1",
+      gitCommit: "0123456789abcdef0123456789abcdef01234567",
+      nodeVersion: "v22.15.0",
+      platform: "darwin",
+      architecture: "arm64",
+      osVersion: "Darwin Kernel Version 25.5.0",
+    }),
+    /FINAL_CUT_E2E_EVIDENCE_INCOMPLETE: revision sequence must be a non-negative integer/,
+  );
+});
+
 test("canonical headed evidence rejects metadata-only capability claims", () => {
   const metadataOnlyRun = structuredClone(rawRun);
   metadataOnlyRun.capabilities.editor.canonicalTimelineMode = "metadata-only";

--- a/tests/integration/canonical-evidence.test.ts
+++ b/tests/integration/canonical-evidence.test.ts
@@ -74,6 +74,12 @@ test("canonical headed evidence keeps mutation proof while omitting private snap
       occurrenceId: "final-cut:occurrence:one",
       mediaId: "final-cut:media:one",
     },
+    toolResults: [
+      { name: "editor.inspect", status: "passed" },
+      { name: "project.inspect", status: "passed" },
+      { name: "timeline.edit", status: "VERIFIED" },
+      { name: "edit.undo", status: "passed" },
+    ],
     mutation: {
       operation: "rename-clip",
       status: "VERIFIED",
@@ -110,6 +116,20 @@ test("canonical headed evidence keeps mutation proof while omitting private snap
   assert.equal(serialized.includes("transaction-secret"), false);
 });
 
+test("canonical headed evidence requires an exact full Git commit", () => {
+  assert.throws(
+    () => sanitizeCanonicalEvidence(rawRun, {
+      framekitVersion: "0.1.0",
+      gitCommit: "HEAD",
+      nodeVersion: "v22.15.0",
+      platform: "darwin",
+      architecture: "arm64",
+      osVersion: "Darwin Kernel Version 25.5.0",
+    }),
+    /FINAL_CUT_E2E_EVIDENCE_INCOMPLETE: Git commit must be a full SHA-1/,
+  );
+});
+
 const baseRevision = (id: string, sequence: number, timestamp: string) => ({ id, sequence, timestamp });
 
 const rawRun = {
@@ -142,6 +162,12 @@ const rawRun = {
     sequenceId: "final-cut:sequence:disposable",
   },
   target: { occurrenceId: "final-cut:occurrence:one", mediaId: "final-cut:media:one" },
+  toolResults: [
+    { name: "editor.inspect", status: "passed" },
+    { name: "project.inspect", status: "passed" },
+    { name: "timeline.edit", status: "VERIFIED" },
+    { name: "edit.undo", status: "passed" },
+  ],
   editStatus: "VERIFIED",
   before: snapshot("Interview", baseRevision("rev-10", 10, "2026-08-26T10:00:01.000Z")),
   after: snapshot("Interview [Framekit E2E]", baseRevision("rev-11", 11, "2026-08-26T10:00:02.000Z")),

--- a/tests/integration/canonical-evidence.test.ts
+++ b/tests/integration/canonical-evidence.test.ts
@@ -26,6 +26,7 @@ test("canonical headed evidence documentation describes the sanitized review bou
 test("canonical headed evidence keeps mutation proof while omitting private snapshot data", () => {
   const evidence = sanitizeCanonicalEvidence(rawRun, {
     framekitVersion: "0.1.0",
+    finalCutVersion: "10.7.1",
     gitCommit: "0123456789abcdef0123456789abcdef01234567",
     nodeVersion: "v22.15.0",
     platform: "darwin",
@@ -40,6 +41,7 @@ test("canonical headed evidence keeps mutation proof while omitting private snap
     recordedAt: "2026-08-26T10:00:00.000Z",
     environment: {
       framekitVersion: "0.1.0",
+      finalCutVersion: "10.7.1",
       gitCommit: "0123456789abcdef0123456789abcdef01234567",
       nodeVersion: "v22.15.0",
       platform: "darwin",
@@ -130,6 +132,7 @@ test("canonical headed evidence requires an exact full Git commit", () => {
   assert.throws(
     () => sanitizeCanonicalEvidence(rawRun, {
       framekitVersion: "0.1.0",
+      finalCutVersion: "10.7.1",
       gitCommit: "HEAD",
       nodeVersion: "v22.15.0",
       platform: "darwin",
@@ -147,6 +150,7 @@ test("canonical headed evidence rejects metadata-only capability claims", () => 
   assert.throws(
     () => sanitizeCanonicalEvidence(metadataOnlyRun, {
       framekitVersion: "0.1.0",
+      finalCutVersion: "10.7.1",
       gitCommit: "0123456789abcdef0123456789abcdef01234567",
       nodeVersion: "v22.15.0",
       platform: "darwin",

--- a/tests/integration/canonical-evidence.test.ts
+++ b/tests/integration/canonical-evidence.test.ts
@@ -161,6 +161,24 @@ test("canonical headed evidence rejects metadata-only capability claims", () => 
   );
 });
 
+test("canonical headed evidence rejects path-like malformed capability values", () => {
+  const malformedRun = structuredClone(rawRun);
+  Reflect.set(malformedRun.capabilities.editor, "timelineWrite", "/Users/private/credentials.txt");
+
+  assert.throws(
+    () => sanitizeCanonicalEvidence(malformedRun, {
+      framekitVersion: "0.1.0",
+      finalCutVersion: "10.7.1",
+      gitCommit: "0123456789abcdef0123456789abcdef01234567",
+      nodeVersion: "v22.15.0",
+      platform: "darwin",
+      architecture: "arm64",
+      osVersion: "Darwin Kernel Version 25.5.0",
+    }),
+    /FINAL_CUT_E2E_EVIDENCE_INCOMPLETE: timelineWrite capability must be boolean/,
+  );
+});
+
 const baseRevision = (id: string, sequence: number, timestamp: string) => ({ id, sequence, timestamp });
 
 const rawRun = {

--- a/tests/integration/canonical-evidence.test.ts
+++ b/tests/integration/canonical-evidence.test.ts
@@ -1,6 +1,17 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
+import { join } from "node:path";
 import { sanitizeCanonicalEvidence } from "../../scripts/final-cut-evidence.mjs";
+
+test("canonical headed runner publishes the sanitized evidence contract", async () => {
+  const runner = await readFile(join(process.cwd(), "scripts/final-cut-canonical-headed-e2e.mjs"), "utf8");
+
+  assert.match(runner, /sanitizeCanonicalEvidence/);
+  assert.match(runner, /gitCommit/);
+  assert.match(runner, /editStatus: transaction\.status/);
+  assert.match(runner, /JSON\.stringify\(evidence, null, 2\)/);
+});
 
 test("canonical headed evidence keeps mutation proof while omitting private snapshot data", () => {
   const evidence = sanitizeCanonicalEvidence(rawRun, {

--- a/tests/integration/canonical-evidence.test.ts
+++ b/tests/integration/canonical-evidence.test.ts
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { sanitizeCanonicalEvidence } from "../../scripts/final-cut-evidence.mjs";
+
+test("canonical headed evidence keeps mutation proof while omitting private snapshot data", () => {
+  const evidence = sanitizeCanonicalEvidence(rawRun, {
+    framekitVersion: "0.1.0",
+    gitCommit: "0123456789abcdef0123456789abcdef01234567",
+    nodeVersion: "v22.15.0",
+    platform: "darwin",
+    architecture: "arm64",
+    osVersion: "Darwin Kernel Version 25.5.0",
+  });
+
+  assert.deepEqual(evidence, {
+    schemaVersion: 1,
+    evidenceType: "headed-native-canonical-mutation",
+    passed: true,
+    recordedAt: "2026-08-26T10:00:00.000Z",
+    environment: {
+      framekitVersion: "0.1.0",
+      gitCommit: "0123456789abcdef0123456789abcdef01234567",
+      nodeVersion: "v22.15.0",
+      platform: "darwin",
+      architecture: "arm64",
+      osVersion: "Darwin Kernel Version 25.5.0",
+    },
+    editor: {
+      name: "Final Cut Pro",
+      version: "10.7.1",
+      backend: "workflow-extension-ipc",
+    },
+    capabilities: {
+      editor: {
+        canonicalTimelineMode: "canonical-write",
+        projectRead: true,
+        timelineSnapshotRead: true,
+        timelineWrite: true,
+        timelineArtifactWrite: false,
+        readAfterWrite: true,
+        incrementalChanges: true,
+        rollback: true,
+        assetDiscovery: false,
+        liveStateRead: true,
+        playheadWrite: false,
+        frameCapture: false,
+        projectCatalogRead: true,
+        projectSelection: true,
+      },
+      analyzers: {
+        speechTranscribe: false,
+        speechVad: false,
+        audioLoudness: false,
+        visualTrack: false,
+      },
+    },
+    project: {
+      id: "final-cut:project:disposable",
+      name: "Framekit Canonical E2E",
+      sequenceId: "final-cut:sequence:disposable",
+    },
+    target: {
+      occurrenceId: "final-cut:occurrence:one",
+      mediaId: "final-cut:media:one",
+    },
+    mutation: {
+      operation: "rename-clip",
+      status: "VERIFIED",
+      timelineChanged: true,
+      beforeRevision: { id: "rev-10", sequence: 10, timestamp: "2026-08-26T10:00:01.000Z" },
+      afterRevision: { id: "rev-11", sequence: 11, timestamp: "2026-08-26T10:00:02.000Z" },
+      diff: {
+        addedCount: 0,
+        removedCount: 0,
+        modifiedCount: 1,
+        modifiedItemIds: ["final-cut:occurrence:one"],
+        durationDelta: 0,
+        affectedRangeCount: 0,
+      },
+    },
+    restoration: {
+      operation: "edit.undo",
+      status: "VERIFIED",
+      restored: true,
+      beforeDigest: "before-digest",
+      restoredDigest: "before-digest",
+      restoredRevision: { id: "rev-12", sequence: 12, timestamp: "2026-08-26T10:00:03.000Z" },
+    },
+    sanitization: {
+      strategy: "allowlisted-summary",
+      omitted: ["media sources", "raw snapshots", "transaction identifiers", "diagnostics"],
+    },
+  });
+
+  const serialized = JSON.stringify(evidence);
+  assert.equal(serialized.includes("/Users/private/secret-footage.mov"), false);
+  assert.equal(serialized.includes("do not publish this credential"), false);
+  assert.equal(serialized.includes("raw crash dump"), false);
+  assert.equal(serialized.includes("transaction-secret"), false);
+});
+
+const baseRevision = (id: string, sequence: number, timestamp: string) => ({ id, sequence, timestamp });
+
+const rawRun = {
+  passed: true,
+  recordedAt: "2026-08-26T10:00:00.000Z",
+  editor: { name: "Final Cut Pro", version: "10.7.1", backend: "workflow-extension-ipc" },
+  capabilities: {
+    editor: {
+      canonicalTimelineMode: "canonical-write",
+      projectRead: true,
+      timelineSnapshotRead: true,
+      timelineWrite: true,
+      timelineArtifactWrite: false,
+      readAfterWrite: true,
+      incrementalChanges: true,
+      rollback: true,
+      assetDiscovery: false,
+      liveStateRead: true,
+      playheadWrite: false,
+      frameCapture: false,
+      projectCatalogRead: true,
+      projectSelection: true,
+      secret: "do not publish this credential",
+    },
+    analyzers: { speechTranscribe: false, speechVad: false, audioLoudness: false, visualTrack: false },
+  },
+  project: {
+    id: "final-cut:project:disposable",
+    name: "Framekit Canonical E2E",
+    sequenceId: "final-cut:sequence:disposable",
+  },
+  target: { occurrenceId: "final-cut:occurrence:one", mediaId: "final-cut:media:one" },
+  editStatus: "VERIFIED",
+  before: snapshot("Interview", baseRevision("rev-10", 10, "2026-08-26T10:00:01.000Z")),
+  after: snapshot("Interview [Framekit E2E]", baseRevision("rev-11", 11, "2026-08-26T10:00:02.000Z")),
+  diff: {
+    from: baseRevision("rev-10", 10, "2026-08-26T10:00:01.000Z"),
+    to: baseRevision("rev-11", 11, "2026-08-26T10:00:02.000Z"),
+    added: [],
+    removed: [],
+    modified: [{
+      type: "ITEM_MODIFIED",
+      itemId: "final-cut:occurrence:one",
+      before: { name: "Interview" },
+      after: { name: "Interview [Framekit E2E]" },
+    }],
+    durationDelta: 0,
+    affectedRanges: [],
+    rawDiagnostics: "raw crash dump",
+  },
+  restored: snapshot("Interview", baseRevision("rev-12", 12, "2026-08-26T10:00:03.000Z")),
+  digests: { before: "before-digest", restored: "before-digest" },
+  transactionId: "transaction-secret",
+};
+
+function snapshot(name: string, revision: { id: string; sequence: number; timestamp: string }) {
+  return {
+    projectId: "final-cut:project:disposable",
+    projectName: "Framekit Canonical E2E",
+    timeline: {
+      id: "final-cut:sequence:disposable",
+      name: "Framekit Canonical E2E",
+      duration: 30,
+      clips: [{
+        id: "final-cut:occurrence:one",
+        mediaId: "final-cut:media:one",
+        name,
+        start: 0,
+        duration: 30,
+        track: 0,
+        startTime: { value: "0", timescale: "1" },
+        durationTime: { value: "30", timescale: "1" },
+      }],
+      storyElements: [],
+      markers: [],
+      captions: [],
+    },
+    media: [{
+      mediaId: "final-cut:media:one",
+      source: "/Users/private/secret-footage.mov",
+      mediaKind: "video",
+      duration: 30,
+    }],
+    revision,
+  };
+}

--- a/tests/integration/canonical-evidence.test.ts
+++ b/tests/integration/canonical-evidence.test.ts
@@ -13,6 +13,16 @@ test("canonical headed runner publishes the sanitized evidence contract", async 
   assert.match(runner, /JSON\.stringify\(evidence, null, 2\)/);
 });
 
+test("canonical headed evidence documentation describes the sanitized review boundary", async () => {
+  const documentation = await readFile(join(process.cwd(), "docs/tests/final-cut-live-e2e.md"), "utf8");
+
+  assert.match(documentation, /sanitized evidence document/);
+  assert.match(documentation, /full Git commit/);
+  assert.match(documentation, /tool results/);
+  assert.match(documentation, /raw snapshots/);
+  assert.match(documentation, /private media paths/);
+});
+
 test("canonical headed evidence keeps mutation proof while omitting private snapshot data", () => {
   const evidence = sanitizeCanonicalEvidence(rawRun, {
     framekitVersion: "0.1.0",

--- a/tests/integration/canonical-evidence.test.ts
+++ b/tests/integration/canonical-evidence.test.ts
@@ -140,6 +140,23 @@ test("canonical headed evidence requires an exact full Git commit", () => {
   );
 });
 
+test("canonical headed evidence rejects metadata-only capability claims", () => {
+  const metadataOnlyRun = structuredClone(rawRun);
+  metadataOnlyRun.capabilities.editor.canonicalTimelineMode = "metadata-only";
+
+  assert.throws(
+    () => sanitizeCanonicalEvidence(metadataOnlyRun, {
+      framekitVersion: "0.1.0",
+      gitCommit: "0123456789abcdef0123456789abcdef01234567",
+      nodeVersion: "v22.15.0",
+      platform: "darwin",
+      architecture: "arm64",
+      osVersion: "Darwin Kernel Version 25.5.0",
+    }),
+    /FINAL_CUT_E2E_EVIDENCE_INCOMPLETE: canonical-write capability is required/,
+  );
+});
+
 const baseRevision = (id: string, sequence: number, timestamp: string) => ({ id, sequence, timestamp });
 
 const rawRun = {


### PR DESCRIPTION
Issue: #65

## Summary

- add an allowlisted sanitizer for canonical headed mutation evidence
- publish verified mutation, read-after-write, undo, revision, diff, capability, tool-result, and provenance summaries without raw snapshots or private media paths
- record the full Framekit commit, runtime environment, and exact Final Cut Pro app version
- make the canonical headed runner fail closed for incomplete workflows, metadata-only bridges, malformed capability values, and non-immutable provenance
- document the sanitized evidence review boundary

## TDD delivery

Each behavior was introduced with a failing test, focused red/green validation, and a validated commit:

- b80b4fc test: define sanitized headed evidence contract
- 0e5b7cc feat: publish sanitized canonical headed evidence
- 86872f5 test: require complete headed evidence provenance
- d0db85f docs: document sanitized headed evidence
- 4972a0c test: reject metadata-only headed evidence
- 9ceb3eb feat: record exact Final Cut version in evidence
- bf30ab8 test: harden capability evidence sanitization

## Validation

- pnpm install --frozen-lockfile
- pnpm run build
- pnpm run test — 209 passed
- pnpm run check:boundaries
- pnpm run test:final-cut-headless — 80 passed
- pnpm run xcode:check
- xcodebuild -project adapters/final-cut/swift-bridge/FinalCutWorkflowExtension/FramekitFinalCutWorkflow.xcodeproj -list

## Live validation status

Final Cut Pro and the Workflow Extension socket were available, but the current bundled Swift bridge reported canonicalTimelineMode: metadata-only and rejected canonical snapshot access before timeline.edit. The headed runner therefore failed closed with CAPABILITY_UNAVAILABLE and no evidence JSON was committed. A real dated evidence document should be generated and reviewed after the native bridge implements canonical enumeration/mutation and reports canonical-write; this PR does not claim that the open timeline was changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved Final Cut Pro evidence validation for edits, undo operations, tool execution, and restoration.
  * Added sanitized evidence summaries with version, runtime, capability, and result details.
  * Evidence now confirms matching pre-edit and restored states while excluding sensitive information.

* **Bug Fixes**
  * Invalid or incomplete evidence now fails with clear validation errors.
  * Added checks for missing version and commit information, unsupported bridge modes, and incomplete workflows.

* **Tests**
  * Expanded coverage for metadata, capability validation, workflow integrity, and sensitive-data removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->