### PR TITLE
[Improvement] Establish a golden workflow corpus and zero-corruption gate

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ Repository-local GitHub agent playbooks are documented in
 - [SDD](./SDD.md): architecture and design contracts.
 - [Compatibility](./COMPATIBILITY.md): verified editor and toolchain support.
 - [MCP](./mcp/README.md): agent-facing protocol and tools.
-- [Tests](./tests/README.md): reproducible checks and evidence, including the [deterministic MCP evaluation](./tests/mcp-evaluation.md).
+- [Tests](./tests/README.md): reproducible checks and evidence, including the [golden workflow corpus](./tests/golden-corpus.md) and [deterministic MCP evaluation](./tests/mcp-evaluation.md).
 - [Final Cut](./final-cut/README.md): native integration and operations.
 - [Basic Final Cut Editing MVP](./final-cut/basic-editing-mvp.md): issue #7
   workflow, MCP contract, validation gates, and success metrics.

--- a/docs/tests/README.md
+++ b/docs/tests/README.md
@@ -8,6 +8,8 @@ real Final Cut Pro process.
   verification, rollback, and MCP.
 - [Phase 2](./phase-2.md): incremental synchronization, visual analysis,
   media understanding, and native asset discovery.
+- [Golden workflow corpus](./golden-corpus.md): versioned Phase 0/1 workflows,
+  exact expected state/diffs, and the zero-silent-corruption gate.
 - [Deterministic MCP evaluation](./mcp-evaluation.md): fixture-backed workflow,
   failure-path, capability-coverage, and scenario-consistency metrics.
 - [Final Cut live E2E](./final-cut-live-e2e.md): read-only native bridge test.

--- a/docs/tests/golden-corpus.md
+++ b/docs/tests/golden-corpus.md
@@ -1,0 +1,41 @@
+# Golden Workflow Corpus
+
+The versioned corpus at [`tests/golden/corpus.json`](../../tests/golden/corpus.json)
+is the deterministic zero silent corruption gate for supported Phase 0/1
+workflows. It uses the in-memory editor fixture; it does not claim native Final
+Cut coverage.
+
+Run the corpus alone with:
+
+```sh
+pnpm run test:golden
+```
+
+The regular repository test command includes the same gate:
+
+```sh
+pnpm run test
+```
+
+## Coverage
+
+The initial corpus covers:
+
+- clip rename, trim, and gain edits;
+- ripple-delete and marker workflows;
+- media import, video/music placement, and title placement;
+- media references, captions, markers, story elements, and exact revisions.
+
+Each scenario stores its fixture, ordered operation(s), before and after
+snapshots, exact diff, and expected revision transitions. The runner checks
+structural identity and media-reference validity, preview non-mutation,
+read-after-write state, successful undo, forced-verification rollback, and
+stale-write rejection without mutation. Node test names include the scenario ID
+so CI failures identify the affected workflow.
+
+Native Final Cut capabilities and subjective perceptual quality remain outside
+this deterministic gate and require their separately documented validation.
+
+When extending the corpus, add a scenario with independently reviewed expected
+state and diff data. Do not replace expected evidence with values recomputed by
+the assertion path.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "build:package": "tsc -p tsconfig.package.json && tsc-alias -p tsconfig.package.json",
-    "test": "tsx --test tests/integration/*.test.ts tests/evaluation/*.test.ts",
+    "test": "tsx --test tests/integration/*.test.ts tests/evaluation/*.test.ts tests/golden/*.test.ts",
+    "test:golden": "tsx --test tests/golden/*.test.ts",
     "test:codex-plugin": "node scripts/codex-plugin-smoke.mjs",
     "evaluate": "tsx scripts/run-mcp-evaluation.ts",
     "test:final-cut-headless": "tsx --test tests/integration/connection.test.ts tests/integration/finalcut-mcp.test.ts tests/integration/native.test.ts",

--- a/packages/testkit/src/in-memory-editor.ts
+++ b/packages/testkit/src/in-memory-editor.ts
@@ -427,7 +427,12 @@ export class InMemoryEditorAdapter implements EditorPort {
     const clips = snapshot.timeline.clips.flatMap((clip) => {
       const clipEnd = clip.start + clip.duration;
       if (clipEnd <= start) return [clip];
-      if (clip.start >= end) return [withClipTime({ ...clip, start: clip.start - removedDuration })];
+      if (clip.start >= end) return [withClipTime({
+        ...clip,
+        start: clip.start - removedDuration,
+        startTime: undefined,
+        durationTime: undefined,
+      })];
       const overlap = Math.min(clipEnd, end) - Math.max(clip.start, start);
       const duration = clip.duration - overlap;
       if (duration <= 0) return [];
@@ -435,10 +440,17 @@ export class InMemoryEditorAdapter implements EditorPort {
         ...clip,
         start: clip.start < start ? clip.start : start,
         duration,
+        startTime: undefined,
+        durationTime: undefined,
       })];
     });
     const markers = snapshot.timeline.markers.flatMap((marker) => {
-      if (marker.start >= end) return [normalizeMarker({ ...marker, start: marker.start - removedDuration })];
+      if (marker.start >= end) return [normalizeMarker({
+        ...marker,
+        start: marker.start - removedDuration,
+        startTime: undefined,
+        durationTime: undefined,
+      })];
       if (marker.start + marker.duration <= start) return [marker];
       return [];
     });

--- a/packages/testkit/src/in-memory-editor.ts
+++ b/packages/testkit/src/in-memory-editor.ts
@@ -454,6 +454,16 @@ export class InMemoryEditorAdapter implements EditorPort {
       if (marker.start + marker.duration <= start) return [marker];
       return [];
     });
+    const captions = snapshot.timeline.captions.flatMap((caption) => {
+      if (caption.start + caption.duration <= start) return [caption];
+      if (caption.start >= end) return [normalizeCaption({
+        ...caption,
+        start: caption.start - removedDuration,
+        startTime: undefined,
+        durationTime: undefined,
+      })];
+      return [];
+    });
     return {
       ...snapshot,
       timeline: {
@@ -466,6 +476,7 @@ export class InMemoryEditorAdapter implements EditorPort {
             return clip ? { ...element, start: clip.start, duration: clip.duration, startTime: clip.startTime, durationTime: clip.durationTime } : element;
           }),
         markers,
+        captions,
       },
     };
   }

--- a/packages/testkit/src/in-memory-editor.ts
+++ b/packages/testkit/src/in-memory-editor.ts
@@ -1,4 +1,5 @@
 import type {
+  Caption,
   Clip,
   ContextChangeSet,
   ContextRevision,
@@ -28,6 +29,7 @@ export interface InMemoryProjectFixture {
   clips: Array<Omit<Clip, "startTime" | "durationTime"> & Partial<Pick<Clip, "startTime" | "durationTime">>>;
   media?: MediaContext[];
   markers?: Marker[];
+  captions?: Caption[];
   assets?: EditorAsset[];
   frames?: Array<{
     position: RationalTime;
@@ -502,7 +504,7 @@ function createSnapshot(fixture: InMemoryProjectFixture): ProjectSnapshot {
         mediaId: clip.mediaId,
       })),
       markers: (fixture.markers ?? []).map((marker) => normalizeMarker(marker)),
-      captions: [],
+      captions: (fixture.captions ?? []).map((caption) => normalizeCaption(caption)),
     },
     media: structuredClone(fixture.media ?? []),
     revision: {
@@ -531,6 +533,10 @@ function withClipTime(clip: Omit<Clip, "startTime" | "durationTime"> & Partial<P
 
 function normalizeMarker(marker: Marker): Marker {
   return { ...marker, startTime: marker.startTime ?? decimalToRational(marker.start), durationTime: marker.durationTime ?? decimalToRational(marker.duration) };
+}
+
+function normalizeCaption(caption: Caption): Caption {
+  return { ...caption, startTime: caption.startTime ?? decimalToRational(caption.start), durationTime: caption.durationTime ?? decimalToRational(caption.duration) };
 }
 
 function decimalToRational(value: number): RationalTime {

--- a/tests/golden/corpus.json
+++ b/tests/golden/corpus.json
@@ -13,23 +13,380 @@
         "projectName": "Golden Workflow Fixture",
         "timelineId": "golden-timeline",
         "timelineName": "Main Edit",
-        "clips": [{ "id": "clip-main", "mediaId": "media-dialogue", "name": "Interview", "start": 0, "duration": 10, "track": 1 }],
-        "media": [{
-          "mediaId": "media-dialogue",
-          "source": "/fixtures/interview.mov",
-          "mediaKind": "video",
-          "duration": 10,
-          "sourceDigest": "sha256:interview",
-          "speech": { "words": [{ "text": "hello", "start": 0, "end": 1, "confidence": 0.99 }] },
-          "audio": { "integratedLufs": -18, "truePeakDb": -3, "silenceMs": 120 }
-        }],
-        "markers": [{ "id": "marker-review", "start": 2, "duration": 0, "name": "Review" }],
-        "captions": [{ "id": "caption-opening", "start": 0.5, "duration": 1, "text": "Hello" }]
+        "clips": [
+          {
+            "id": "clip-main",
+            "mediaId": "media-dialogue",
+            "name": "Interview",
+            "start": 0,
+            "duration": 10,
+            "track": 1
+          }
+        ],
+        "media": [
+          {
+            "mediaId": "media-dialogue",
+            "source": "/fixtures/interview.mov",
+            "mediaKind": "video",
+            "duration": 10,
+            "sourceDigest": "sha256:interview",
+            "speech": {
+              "words": [
+                {
+                  "text": "hello",
+                  "start": 0,
+                  "end": 1,
+                  "confidence": 0.99
+                }
+              ]
+            },
+            "audio": {
+              "integratedLufs": -18,
+              "truePeakDb": -3,
+              "silenceMs": 120
+            }
+          }
+        ],
+        "markers": [
+          {
+            "id": "marker-review",
+            "start": 2,
+            "duration": 0,
+            "name": "Review"
+          }
+        ],
+        "captions": [
+          {
+            "id": "caption-opening",
+            "start": 0.5,
+            "duration": 1,
+            "text": "Hello"
+          }
+        ]
       },
-      "operation": { "type": "rename-clip", "clipId": "clip-main", "name": "Interview - Clean" },
+      "operation": {
+        "type": "rename-clip",
+        "clipId": "clip-main",
+        "name": "Interview - Clean"
+      },
       "expected": {
-        "afterRevision": { "id": "rev-1", "sequence": 1, "timestamp": "1970-01-01T00:00:00.001Z" },
-        "undoRevision": { "id": "rev-2", "sequence": 2, "timestamp": "1970-01-01T00:00:00.002Z" }
+        "before": {
+          "projectId": "golden-project",
+          "projectName": "Golden Workflow Fixture",
+          "timeline": {
+            "id": "golden-timeline",
+            "name": "Main Edit",
+            "duration": 10,
+            "durationTime": {
+              "value": "10",
+              "timescale": "1"
+            },
+            "clips": [
+              {
+                "id": "clip-main",
+                "mediaId": "media-dialogue",
+                "name": "Interview",
+                "start": 0,
+                "duration": 10,
+                "track": 1,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "10",
+                  "timescale": "1"
+                }
+              }
+            ],
+            "storyElements": [
+              {
+                "id": "clip-main",
+                "kind": "asset-clip",
+                "start": 0,
+                "duration": 10,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "10",
+                  "timescale": "1"
+                },
+                "lane": 1,
+                "mediaId": "media-dialogue"
+              }
+            ],
+            "markers": [
+              {
+                "id": "marker-review",
+                "start": 2,
+                "duration": 0,
+                "name": "Review",
+                "startTime": {
+                  "value": "2",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "0",
+                  "timescale": "1"
+                }
+              }
+            ],
+            "captions": [
+              {
+                "id": "caption-opening",
+                "start": 0.5,
+                "duration": 1,
+                "text": "Hello",
+                "startTime": {
+                  "value": "5",
+                  "timescale": "10"
+                },
+                "durationTime": {
+                  "value": "1",
+                  "timescale": "1"
+                }
+              }
+            ]
+          },
+          "media": [
+            {
+              "mediaId": "media-dialogue",
+              "source": "/fixtures/interview.mov",
+              "mediaKind": "video",
+              "duration": 10,
+              "sourceDigest": "sha256:interview",
+              "speech": {
+                "words": [
+                  {
+                    "text": "hello",
+                    "start": 0,
+                    "end": 1,
+                    "confidence": 0.99
+                  }
+                ]
+              },
+              "audio": {
+                "integratedLufs": -18,
+                "truePeakDb": -3,
+                "silenceMs": 120
+              }
+            }
+          ],
+          "revision": {
+            "id": "rev-0",
+            "sequence": 0,
+            "timestamp": "1970-01-01T00:00:00.000Z"
+          }
+        },
+        "after": {
+          "projectId": "golden-project",
+          "projectName": "Golden Workflow Fixture",
+          "timeline": {
+            "id": "golden-timeline",
+            "name": "Main Edit",
+            "duration": 10,
+            "durationTime": {
+              "value": "10",
+              "timescale": "1"
+            },
+            "clips": [
+              {
+                "id": "clip-main",
+                "mediaId": "media-dialogue",
+                "name": "Interview - Clean",
+                "start": 0,
+                "duration": 10,
+                "track": 1,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "10",
+                  "timescale": "1"
+                }
+              }
+            ],
+            "storyElements": [
+              {
+                "id": "clip-main",
+                "kind": "asset-clip",
+                "start": 0,
+                "duration": 10,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "10",
+                  "timescale": "1"
+                },
+                "lane": 1,
+                "mediaId": "media-dialogue"
+              }
+            ],
+            "markers": [
+              {
+                "id": "marker-review",
+                "start": 2,
+                "duration": 0,
+                "name": "Review",
+                "startTime": {
+                  "value": "2",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "0",
+                  "timescale": "1"
+                }
+              }
+            ],
+            "captions": [
+              {
+                "id": "caption-opening",
+                "start": 0.5,
+                "duration": 1,
+                "text": "Hello",
+                "startTime": {
+                  "value": "5",
+                  "timescale": "10"
+                },
+                "durationTime": {
+                  "value": "1",
+                  "timescale": "1"
+                }
+              }
+            ]
+          },
+          "media": [
+            {
+              "mediaId": "media-dialogue",
+              "source": "/fixtures/interview.mov",
+              "mediaKind": "video",
+              "duration": 10,
+              "sourceDigest": "sha256:interview",
+              "speech": {
+                "words": [
+                  {
+                    "text": "hello",
+                    "start": 0,
+                    "end": 1,
+                    "confidence": 0.99
+                  }
+                ]
+              },
+              "audio": {
+                "integratedLufs": -18,
+                "truePeakDb": -3,
+                "silenceMs": 120
+              }
+            }
+          ],
+          "revision": {
+            "id": "rev-1",
+            "sequence": 1,
+            "timestamp": "1970-01-01T00:00:00.001Z"
+          }
+        },
+        "diff": {
+          "from": {
+            "id": "rev-0",
+            "sequence": 0,
+            "timestamp": "1970-01-01T00:00:00.000Z"
+          },
+          "to": {
+            "id": "rev-1",
+            "sequence": 1,
+            "timestamp": "1970-01-01T00:00:00.001Z"
+          },
+          "added": [],
+          "removed": [],
+          "modified": [
+            {
+              "type": "ITEM_MODIFIED",
+              "itemId": "clip-main",
+              "before": {
+                "id": "clip-main",
+                "mediaId": "media-dialogue",
+                "name": "Interview",
+                "start": 0,
+                "duration": 10,
+                "track": 1,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "10",
+                  "timescale": "1"
+                }
+              },
+              "after": {
+                "id": "clip-main",
+                "mediaId": "media-dialogue",
+                "name": "Interview - Clean",
+                "start": 0,
+                "duration": 10,
+                "track": 1,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "10",
+                  "timescale": "1"
+                }
+              }
+            }
+          ],
+          "durationDelta": 0,
+          "durationDeltaTime": {
+            "value": "0",
+            "timescale": "1"
+          },
+          "markerChanges": [],
+          "captionChanges": [],
+          "storyElementChanges": [],
+          "mediaChanges": [],
+          "affectedRanges": [
+            {
+              "start": 0,
+              "end": 10,
+              "startTime": {
+                "value": "0",
+                "timescale": "1"
+              },
+              "durationTime": {
+                "value": "10",
+                "timescale": "1"
+              }
+            },
+            {
+              "start": 0,
+              "end": 10,
+              "startTime": {
+                "value": "0",
+                "timescale": "1"
+              },
+              "durationTime": {
+                "value": "10",
+                "timescale": "1"
+              }
+            }
+          ]
+        },
+        "afterRevision": {
+          "id": "rev-1",
+          "sequence": 1,
+          "timestamp": "1970-01-01T00:00:00.001Z"
+        },
+        "undoRevision": {
+          "id": "rev-2",
+          "sequence": 2,
+          "timestamp": "1970-01-01T00:00:00.002Z"
+        }
       }
     },
     {
@@ -42,15 +399,391 @@
         "projectName": "Golden Workflow Fixture",
         "timelineId": "golden-timeline",
         "timelineName": "Main Edit",
-        "clips": [{ "id": "clip-main", "mediaId": "media-dialogue", "name": "Interview", "start": 0, "duration": 10, "track": 1 }],
-        "media": [{ "mediaId": "media-dialogue", "source": "/fixtures/interview.mov", "mediaKind": "video", "duration": 10, "sourceDigest": "sha256:interview" }],
-        "markers": [{ "id": "marker-review", "start": 2, "duration": 0, "name": "Review" }],
-        "captions": [{ "id": "caption-opening", "start": 0.5, "duration": 1, "text": "Hello" }]
+        "clips": [
+          {
+            "id": "clip-main",
+            "mediaId": "media-dialogue",
+            "name": "Interview",
+            "start": 0,
+            "duration": 10,
+            "track": 1
+          }
+        ],
+        "media": [
+          {
+            "mediaId": "media-dialogue",
+            "source": "/fixtures/interview.mov",
+            "mediaKind": "video",
+            "duration": 10,
+            "sourceDigest": "sha256:interview"
+          }
+        ],
+        "markers": [
+          {
+            "id": "marker-review",
+            "start": 2,
+            "duration": 0,
+            "name": "Review"
+          }
+        ],
+        "captions": [
+          {
+            "id": "caption-opening",
+            "start": 0.5,
+            "duration": 1,
+            "text": "Hello"
+          }
+        ]
       },
-      "operation": { "type": "trim-clip", "clipId": "clip-main", "duration": 6 },
+      "operation": {
+        "type": "trim-clip",
+        "clipId": "clip-main",
+        "duration": 6
+      },
       "expected": {
-        "afterRevision": { "id": "rev-1", "sequence": 1, "timestamp": "1970-01-01T00:00:00.001Z" },
-        "undoRevision": { "id": "rev-2", "sequence": 2, "timestamp": "1970-01-01T00:00:00.002Z" }
+        "before": {
+          "projectId": "golden-project",
+          "projectName": "Golden Workflow Fixture",
+          "timeline": {
+            "id": "golden-timeline",
+            "name": "Main Edit",
+            "duration": 10,
+            "durationTime": {
+              "value": "10",
+              "timescale": "1"
+            },
+            "clips": [
+              {
+                "id": "clip-main",
+                "mediaId": "media-dialogue",
+                "name": "Interview",
+                "start": 0,
+                "duration": 10,
+                "track": 1,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "10",
+                  "timescale": "1"
+                }
+              }
+            ],
+            "storyElements": [
+              {
+                "id": "clip-main",
+                "kind": "asset-clip",
+                "start": 0,
+                "duration": 10,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "10",
+                  "timescale": "1"
+                },
+                "lane": 1,
+                "mediaId": "media-dialogue"
+              }
+            ],
+            "markers": [
+              {
+                "id": "marker-review",
+                "start": 2,
+                "duration": 0,
+                "name": "Review",
+                "startTime": {
+                  "value": "2",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "0",
+                  "timescale": "1"
+                }
+              }
+            ],
+            "captions": [
+              {
+                "id": "caption-opening",
+                "start": 0.5,
+                "duration": 1,
+                "text": "Hello",
+                "startTime": {
+                  "value": "5",
+                  "timescale": "10"
+                },
+                "durationTime": {
+                  "value": "1",
+                  "timescale": "1"
+                }
+              }
+            ]
+          },
+          "media": [
+            {
+              "mediaId": "media-dialogue",
+              "source": "/fixtures/interview.mov",
+              "mediaKind": "video",
+              "duration": 10,
+              "sourceDigest": "sha256:interview"
+            }
+          ],
+          "revision": {
+            "id": "rev-0",
+            "sequence": 0,
+            "timestamp": "1970-01-01T00:00:00.000Z"
+          }
+        },
+        "after": {
+          "projectId": "golden-project",
+          "projectName": "Golden Workflow Fixture",
+          "timeline": {
+            "id": "golden-timeline",
+            "name": "Main Edit",
+            "duration": 6,
+            "durationTime": {
+              "value": "6",
+              "timescale": "1"
+            },
+            "clips": [
+              {
+                "id": "clip-main",
+                "mediaId": "media-dialogue",
+                "name": "Interview",
+                "start": 0,
+                "duration": 6,
+                "track": 1,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "6",
+                  "timescale": "1"
+                }
+              }
+            ],
+            "storyElements": [
+              {
+                "id": "clip-main",
+                "kind": "asset-clip",
+                "start": 0,
+                "duration": 6,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "6",
+                  "timescale": "1"
+                },
+                "lane": 1,
+                "mediaId": "media-dialogue"
+              }
+            ],
+            "markers": [
+              {
+                "id": "marker-review",
+                "start": 2,
+                "duration": 0,
+                "name": "Review",
+                "startTime": {
+                  "value": "2",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "0",
+                  "timescale": "1"
+                }
+              }
+            ],
+            "captions": [
+              {
+                "id": "caption-opening",
+                "start": 0.5,
+                "duration": 1,
+                "text": "Hello",
+                "startTime": {
+                  "value": "5",
+                  "timescale": "10"
+                },
+                "durationTime": {
+                  "value": "1",
+                  "timescale": "1"
+                }
+              }
+            ]
+          },
+          "media": [
+            {
+              "mediaId": "media-dialogue",
+              "source": "/fixtures/interview.mov",
+              "mediaKind": "video",
+              "duration": 10,
+              "sourceDigest": "sha256:interview"
+            }
+          ],
+          "revision": {
+            "id": "rev-1",
+            "sequence": 1,
+            "timestamp": "1970-01-01T00:00:00.001Z"
+          }
+        },
+        "diff": {
+          "from": {
+            "id": "rev-0",
+            "sequence": 0,
+            "timestamp": "1970-01-01T00:00:00.000Z"
+          },
+          "to": {
+            "id": "rev-1",
+            "sequence": 1,
+            "timestamp": "1970-01-01T00:00:00.001Z"
+          },
+          "added": [],
+          "removed": [],
+          "modified": [
+            {
+              "type": "ITEM_MODIFIED",
+              "itemId": "clip-main",
+              "before": {
+                "id": "clip-main",
+                "mediaId": "media-dialogue",
+                "name": "Interview",
+                "start": 0,
+                "duration": 10,
+                "track": 1,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "10",
+                  "timescale": "1"
+                }
+              },
+              "after": {
+                "id": "clip-main",
+                "mediaId": "media-dialogue",
+                "name": "Interview",
+                "start": 0,
+                "duration": 6,
+                "track": 1,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "6",
+                  "timescale": "1"
+                }
+              }
+            }
+          ],
+          "durationDelta": -4,
+          "durationDeltaTime": {
+            "value": "-4",
+            "timescale": "1"
+          },
+          "markerChanges": [],
+          "captionChanges": [],
+          "storyElementChanges": [
+            {
+              "type": "STORY_ELEMENT_MODIFIED",
+              "element": {
+                "id": "clip-main",
+                "kind": "asset-clip",
+                "start": 0,
+                "duration": 6,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "6",
+                  "timescale": "1"
+                },
+                "lane": 1,
+                "mediaId": "media-dialogue"
+              },
+              "before": {
+                "id": "clip-main",
+                "kind": "asset-clip",
+                "start": 0,
+                "duration": 10,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "10",
+                  "timescale": "1"
+                },
+                "lane": 1,
+                "mediaId": "media-dialogue"
+              },
+              "after": {
+                "id": "clip-main",
+                "kind": "asset-clip",
+                "start": 0,
+                "duration": 6,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "6",
+                  "timescale": "1"
+                },
+                "lane": 1,
+                "mediaId": "media-dialogue"
+              }
+            }
+          ],
+          "mediaChanges": [],
+          "affectedRanges": [
+            {
+              "start": 0,
+              "end": 10,
+              "startTime": {
+                "value": "0",
+                "timescale": "1"
+              },
+              "durationTime": {
+                "value": "10",
+                "timescale": "1"
+              }
+            },
+            {
+              "start": 0,
+              "end": 6,
+              "startTime": {
+                "value": "0",
+                "timescale": "1"
+              },
+              "durationTime": {
+                "value": "6",
+                "timescale": "1"
+              }
+            },
+            {
+              "start": 0,
+              "end": 10
+            }
+          ]
+        },
+        "afterRevision": {
+          "id": "rev-1",
+          "sequence": 1,
+          "timestamp": "1970-01-01T00:00:00.001Z"
+        },
+        "undoRevision": {
+          "id": "rev-2",
+          "sequence": 2,
+          "timestamp": "1970-01-01T00:00:00.002Z"
+        }
       }
     },
     {
@@ -63,15 +796,337 @@
         "projectName": "Golden Workflow Fixture",
         "timelineId": "golden-timeline",
         "timelineName": "Main Edit",
-        "clips": [{ "id": "clip-main", "mediaId": "media-dialogue", "name": "Interview", "start": 0, "duration": 10, "track": 1 }],
-        "media": [{ "mediaId": "media-dialogue", "source": "/fixtures/interview.mov", "mediaKind": "video", "duration": 10, "sourceDigest": "sha256:interview" }],
-        "markers": [{ "id": "marker-review", "start": 2, "duration": 0, "name": "Review" }],
-        "captions": [{ "id": "caption-opening", "start": 0.5, "duration": 1, "text": "Hello" }]
+        "clips": [
+          {
+            "id": "clip-main",
+            "mediaId": "media-dialogue",
+            "name": "Interview",
+            "start": 0,
+            "duration": 10,
+            "track": 1
+          }
+        ],
+        "media": [
+          {
+            "mediaId": "media-dialogue",
+            "source": "/fixtures/interview.mov",
+            "mediaKind": "video",
+            "duration": 10,
+            "sourceDigest": "sha256:interview"
+          }
+        ],
+        "markers": [
+          {
+            "id": "marker-review",
+            "start": 2,
+            "duration": 0,
+            "name": "Review"
+          }
+        ],
+        "captions": [
+          {
+            "id": "caption-opening",
+            "start": 0.5,
+            "duration": 1,
+            "text": "Hello"
+          }
+        ]
       },
-      "operation": { "type": "set-gain", "clipId": "clip-main", "gainDb": 3 },
+      "operation": {
+        "type": "set-gain",
+        "clipId": "clip-main",
+        "gainDb": 3
+      },
       "expected": {
-        "afterRevision": { "id": "rev-1", "sequence": 1, "timestamp": "1970-01-01T00:00:00.001Z" },
-        "undoRevision": { "id": "rev-2", "sequence": 2, "timestamp": "1970-01-01T00:00:00.002Z" }
+        "before": {
+          "projectId": "golden-project",
+          "projectName": "Golden Workflow Fixture",
+          "timeline": {
+            "id": "golden-timeline",
+            "name": "Main Edit",
+            "duration": 10,
+            "durationTime": {
+              "value": "10",
+              "timescale": "1"
+            },
+            "clips": [
+              {
+                "id": "clip-main",
+                "mediaId": "media-dialogue",
+                "name": "Interview",
+                "start": 0,
+                "duration": 10,
+                "track": 1,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "10",
+                  "timescale": "1"
+                }
+              }
+            ],
+            "storyElements": [
+              {
+                "id": "clip-main",
+                "kind": "asset-clip",
+                "start": 0,
+                "duration": 10,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "10",
+                  "timescale": "1"
+                },
+                "lane": 1,
+                "mediaId": "media-dialogue"
+              }
+            ],
+            "markers": [
+              {
+                "id": "marker-review",
+                "start": 2,
+                "duration": 0,
+                "name": "Review",
+                "startTime": {
+                  "value": "2",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "0",
+                  "timescale": "1"
+                }
+              }
+            ],
+            "captions": [
+              {
+                "id": "caption-opening",
+                "start": 0.5,
+                "duration": 1,
+                "text": "Hello",
+                "startTime": {
+                  "value": "5",
+                  "timescale": "10"
+                },
+                "durationTime": {
+                  "value": "1",
+                  "timescale": "1"
+                }
+              }
+            ]
+          },
+          "media": [
+            {
+              "mediaId": "media-dialogue",
+              "source": "/fixtures/interview.mov",
+              "mediaKind": "video",
+              "duration": 10,
+              "sourceDigest": "sha256:interview"
+            }
+          ],
+          "revision": {
+            "id": "rev-0",
+            "sequence": 0,
+            "timestamp": "1970-01-01T00:00:00.000Z"
+          }
+        },
+        "after": {
+          "projectId": "golden-project",
+          "projectName": "Golden Workflow Fixture",
+          "timeline": {
+            "id": "golden-timeline",
+            "name": "Main Edit",
+            "duration": 10,
+            "durationTime": {
+              "value": "10",
+              "timescale": "1"
+            },
+            "clips": [
+              {
+                "id": "clip-main",
+                "mediaId": "media-dialogue",
+                "name": "Interview",
+                "start": 0,
+                "duration": 10,
+                "track": 1,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "10",
+                  "timescale": "1"
+                },
+                "gainDb": 3
+              }
+            ],
+            "storyElements": [
+              {
+                "id": "clip-main",
+                "kind": "asset-clip",
+                "start": 0,
+                "duration": 10,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "10",
+                  "timescale": "1"
+                },
+                "lane": 1,
+                "mediaId": "media-dialogue"
+              }
+            ],
+            "markers": [
+              {
+                "id": "marker-review",
+                "start": 2,
+                "duration": 0,
+                "name": "Review",
+                "startTime": {
+                  "value": "2",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "0",
+                  "timescale": "1"
+                }
+              }
+            ],
+            "captions": [
+              {
+                "id": "caption-opening",
+                "start": 0.5,
+                "duration": 1,
+                "text": "Hello",
+                "startTime": {
+                  "value": "5",
+                  "timescale": "10"
+                },
+                "durationTime": {
+                  "value": "1",
+                  "timescale": "1"
+                }
+              }
+            ]
+          },
+          "media": [
+            {
+              "mediaId": "media-dialogue",
+              "source": "/fixtures/interview.mov",
+              "mediaKind": "video",
+              "duration": 10,
+              "sourceDigest": "sha256:interview"
+            }
+          ],
+          "revision": {
+            "id": "rev-1",
+            "sequence": 1,
+            "timestamp": "1970-01-01T00:00:00.001Z"
+          }
+        },
+        "diff": {
+          "from": {
+            "id": "rev-0",
+            "sequence": 0,
+            "timestamp": "1970-01-01T00:00:00.000Z"
+          },
+          "to": {
+            "id": "rev-1",
+            "sequence": 1,
+            "timestamp": "1970-01-01T00:00:00.001Z"
+          },
+          "added": [],
+          "removed": [],
+          "modified": [
+            {
+              "type": "ITEM_MODIFIED",
+              "itemId": "clip-main",
+              "before": {
+                "id": "clip-main",
+                "mediaId": "media-dialogue",
+                "name": "Interview",
+                "start": 0,
+                "duration": 10,
+                "track": 1,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "10",
+                  "timescale": "1"
+                }
+              },
+              "after": {
+                "id": "clip-main",
+                "mediaId": "media-dialogue",
+                "name": "Interview",
+                "start": 0,
+                "duration": 10,
+                "track": 1,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "10",
+                  "timescale": "1"
+                },
+                "gainDb": 3
+              }
+            }
+          ],
+          "durationDelta": 0,
+          "durationDeltaTime": {
+            "value": "0",
+            "timescale": "1"
+          },
+          "markerChanges": [],
+          "captionChanges": [],
+          "storyElementChanges": [],
+          "mediaChanges": [],
+          "affectedRanges": [
+            {
+              "start": 0,
+              "end": 10,
+              "startTime": {
+                "value": "0",
+                "timescale": "1"
+              },
+              "durationTime": {
+                "value": "10",
+                "timescale": "1"
+              }
+            },
+            {
+              "start": 0,
+              "end": 10,
+              "startTime": {
+                "value": "0",
+                "timescale": "1"
+              },
+              "durationTime": {
+                "value": "10",
+                "timescale": "1"
+              }
+            }
+          ]
+        },
+        "afterRevision": {
+          "id": "rev-1",
+          "sequence": 1,
+          "timestamp": "1970-01-01T00:00:00.001Z"
+        },
+        "undoRevision": {
+          "id": "rev-2",
+          "sequence": 2,
+          "timestamp": "1970-01-01T00:00:00.002Z"
+        }
       }
     },
     {
@@ -85,21 +1140,860 @@
         "timelineId": "golden-timeline",
         "timelineName": "Main Edit",
         "clips": [
-          { "id": "clip-before", "mediaId": "media-dialogue", "name": "Before", "start": 0, "duration": 4, "track": 1 },
-          { "id": "clip-middle", "mediaId": "media-dialogue", "name": "Middle", "start": 4, "duration": 3, "track": 1 },
-          { "id": "clip-after", "mediaId": "media-dialogue", "name": "After", "start": 7, "duration": 3, "track": 1 }
+          {
+            "id": "clip-before",
+            "mediaId": "media-dialogue",
+            "name": "Before",
+            "start": 0,
+            "duration": 4,
+            "track": 1
+          },
+          {
+            "id": "clip-middle",
+            "mediaId": "media-dialogue",
+            "name": "Middle",
+            "start": 4,
+            "duration": 3,
+            "track": 1
+          },
+          {
+            "id": "clip-after",
+            "mediaId": "media-dialogue",
+            "name": "After",
+            "start": 7,
+            "duration": 3,
+            "track": 1
+          }
         ],
-        "media": [{ "mediaId": "media-dialogue", "source": "/fixtures/interview.mov", "mediaKind": "video", "duration": 10, "sourceDigest": "sha256:interview" }],
+        "media": [
+          {
+            "mediaId": "media-dialogue",
+            "source": "/fixtures/interview.mov",
+            "mediaKind": "video",
+            "duration": 10,
+            "sourceDigest": "sha256:interview"
+          }
+        ],
         "markers": [
-          { "id": "marker-before", "start": 2, "duration": 0, "name": "Keep" },
-          { "id": "marker-after", "start": 6, "duration": 1, "name": "Shift" }
+          {
+            "id": "marker-before",
+            "start": 2,
+            "duration": 0,
+            "name": "Keep"
+          },
+          {
+            "id": "marker-after",
+            "start": 6,
+            "duration": 1,
+            "name": "Shift"
+          }
         ],
-        "captions": [{ "id": "caption-opening", "start": 0.5, "duration": 1, "text": "Hello" }]
+        "captions": [
+          {
+            "id": "caption-opening",
+            "start": 0.5,
+            "duration": 1,
+            "text": "Hello"
+          }
+        ]
       },
-      "operation": { "type": "ripple-delete", "timelineId": "golden-timeline", "range": { "start": 3, "end": 5 }, "reason": "remove pause" },
+      "operation": {
+        "type": "ripple-delete",
+        "timelineId": "golden-timeline",
+        "range": {
+          "start": 3,
+          "end": 5
+        },
+        "reason": "remove pause"
+      },
       "expected": {
-        "afterRevision": { "id": "rev-1", "sequence": 1, "timestamp": "1970-01-01T00:00:00.001Z" },
-        "undoRevision": { "id": "rev-2", "sequence": 2, "timestamp": "1970-01-01T00:00:00.002Z" }
+        "before": {
+          "projectId": "golden-project",
+          "projectName": "Golden Workflow Fixture",
+          "timeline": {
+            "id": "golden-timeline",
+            "name": "Main Edit",
+            "duration": 10,
+            "durationTime": {
+              "value": "10",
+              "timescale": "1"
+            },
+            "clips": [
+              {
+                "id": "clip-before",
+                "mediaId": "media-dialogue",
+                "name": "Before",
+                "start": 0,
+                "duration": 4,
+                "track": 1,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "4",
+                  "timescale": "1"
+                }
+              },
+              {
+                "id": "clip-middle",
+                "mediaId": "media-dialogue",
+                "name": "Middle",
+                "start": 4,
+                "duration": 3,
+                "track": 1,
+                "startTime": {
+                  "value": "4",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "3",
+                  "timescale": "1"
+                }
+              },
+              {
+                "id": "clip-after",
+                "mediaId": "media-dialogue",
+                "name": "After",
+                "start": 7,
+                "duration": 3,
+                "track": 1,
+                "startTime": {
+                  "value": "7",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "3",
+                  "timescale": "1"
+                }
+              }
+            ],
+            "storyElements": [
+              {
+                "id": "clip-before",
+                "kind": "asset-clip",
+                "start": 0,
+                "duration": 4,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "4",
+                  "timescale": "1"
+                },
+                "lane": 1,
+                "mediaId": "media-dialogue"
+              },
+              {
+                "id": "clip-middle",
+                "kind": "asset-clip",
+                "start": 4,
+                "duration": 3,
+                "startTime": {
+                  "value": "4",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "3",
+                  "timescale": "1"
+                },
+                "lane": 1,
+                "mediaId": "media-dialogue"
+              },
+              {
+                "id": "clip-after",
+                "kind": "asset-clip",
+                "start": 7,
+                "duration": 3,
+                "startTime": {
+                  "value": "7",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "3",
+                  "timescale": "1"
+                },
+                "lane": 1,
+                "mediaId": "media-dialogue"
+              }
+            ],
+            "markers": [
+              {
+                "id": "marker-before",
+                "start": 2,
+                "duration": 0,
+                "name": "Keep",
+                "startTime": {
+                  "value": "2",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "0",
+                  "timescale": "1"
+                }
+              },
+              {
+                "id": "marker-after",
+                "start": 6,
+                "duration": 1,
+                "name": "Shift",
+                "startTime": {
+                  "value": "6",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "1",
+                  "timescale": "1"
+                }
+              }
+            ],
+            "captions": [
+              {
+                "id": "caption-opening",
+                "start": 0.5,
+                "duration": 1,
+                "text": "Hello",
+                "startTime": {
+                  "value": "5",
+                  "timescale": "10"
+                },
+                "durationTime": {
+                  "value": "1",
+                  "timescale": "1"
+                }
+              }
+            ]
+          },
+          "media": [
+            {
+              "mediaId": "media-dialogue",
+              "source": "/fixtures/interview.mov",
+              "mediaKind": "video",
+              "duration": 10,
+              "sourceDigest": "sha256:interview"
+            }
+          ],
+          "revision": {
+            "id": "rev-0",
+            "sequence": 0,
+            "timestamp": "1970-01-01T00:00:00.000Z"
+          }
+        },
+        "after": {
+          "projectId": "golden-project",
+          "projectName": "Golden Workflow Fixture",
+          "timeline": {
+            "id": "golden-timeline",
+            "name": "Main Edit",
+            "duration": 8,
+            "durationTime": {
+              "value": "8",
+              "timescale": "1"
+            },
+            "clips": [
+              {
+                "id": "clip-before",
+                "mediaId": "media-dialogue",
+                "name": "Before",
+                "start": 0,
+                "duration": 3,
+                "track": 1,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "4",
+                  "timescale": "1"
+                }
+              },
+              {
+                "id": "clip-middle",
+                "mediaId": "media-dialogue",
+                "name": "Middle",
+                "start": 3,
+                "duration": 2,
+                "track": 1,
+                "startTime": {
+                  "value": "4",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "3",
+                  "timescale": "1"
+                }
+              },
+              {
+                "id": "clip-after",
+                "mediaId": "media-dialogue",
+                "name": "After",
+                "start": 5,
+                "duration": 3,
+                "track": 1,
+                "startTime": {
+                  "value": "7",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "3",
+                  "timescale": "1"
+                }
+              }
+            ],
+            "storyElements": [
+              {
+                "id": "clip-before",
+                "kind": "asset-clip",
+                "start": 0,
+                "duration": 3,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "4",
+                  "timescale": "1"
+                },
+                "lane": 1,
+                "mediaId": "media-dialogue"
+              },
+              {
+                "id": "clip-middle",
+                "kind": "asset-clip",
+                "start": 3,
+                "duration": 2,
+                "startTime": {
+                  "value": "4",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "3",
+                  "timescale": "1"
+                },
+                "lane": 1,
+                "mediaId": "media-dialogue"
+              },
+              {
+                "id": "clip-after",
+                "kind": "asset-clip",
+                "start": 5,
+                "duration": 3,
+                "startTime": {
+                  "value": "7",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "3",
+                  "timescale": "1"
+                },
+                "lane": 1,
+                "mediaId": "media-dialogue"
+              }
+            ],
+            "markers": [
+              {
+                "id": "marker-before",
+                "start": 2,
+                "duration": 0,
+                "name": "Keep",
+                "startTime": {
+                  "value": "2",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "0",
+                  "timescale": "1"
+                }
+              },
+              {
+                "id": "marker-after",
+                "start": 4,
+                "duration": 1,
+                "name": "Shift",
+                "startTime": {
+                  "value": "6",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "1",
+                  "timescale": "1"
+                }
+              }
+            ],
+            "captions": [
+              {
+                "id": "caption-opening",
+                "start": 0.5,
+                "duration": 1,
+                "text": "Hello",
+                "startTime": {
+                  "value": "5",
+                  "timescale": "10"
+                },
+                "durationTime": {
+                  "value": "1",
+                  "timescale": "1"
+                }
+              }
+            ]
+          },
+          "media": [
+            {
+              "mediaId": "media-dialogue",
+              "source": "/fixtures/interview.mov",
+              "mediaKind": "video",
+              "duration": 10,
+              "sourceDigest": "sha256:interview"
+            }
+          ],
+          "revision": {
+            "id": "rev-1",
+            "sequence": 1,
+            "timestamp": "1970-01-01T00:00:00.001Z"
+          }
+        },
+        "diff": {
+          "from": {
+            "id": "rev-0",
+            "sequence": 0,
+            "timestamp": "1970-01-01T00:00:00.000Z"
+          },
+          "to": {
+            "id": "rev-1",
+            "sequence": 1,
+            "timestamp": "1970-01-01T00:00:00.001Z"
+          },
+          "added": [],
+          "removed": [],
+          "modified": [
+            {
+              "type": "ITEM_MODIFIED",
+              "itemId": "clip-before",
+              "before": {
+                "id": "clip-before",
+                "mediaId": "media-dialogue",
+                "name": "Before",
+                "start": 0,
+                "duration": 4,
+                "track": 1,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "4",
+                  "timescale": "1"
+                }
+              },
+              "after": {
+                "id": "clip-before",
+                "mediaId": "media-dialogue",
+                "name": "Before",
+                "start": 0,
+                "duration": 3,
+                "track": 1,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "4",
+                  "timescale": "1"
+                }
+              }
+            },
+            {
+              "type": "ITEM_MODIFIED",
+              "itemId": "clip-middle",
+              "before": {
+                "id": "clip-middle",
+                "mediaId": "media-dialogue",
+                "name": "Middle",
+                "start": 4,
+                "duration": 3,
+                "track": 1,
+                "startTime": {
+                  "value": "4",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "3",
+                  "timescale": "1"
+                }
+              },
+              "after": {
+                "id": "clip-middle",
+                "mediaId": "media-dialogue",
+                "name": "Middle",
+                "start": 3,
+                "duration": 2,
+                "track": 1,
+                "startTime": {
+                  "value": "4",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "3",
+                  "timescale": "1"
+                }
+              }
+            },
+            {
+              "type": "ITEM_MODIFIED",
+              "itemId": "clip-after",
+              "before": {
+                "id": "clip-after",
+                "mediaId": "media-dialogue",
+                "name": "After",
+                "start": 7,
+                "duration": 3,
+                "track": 1,
+                "startTime": {
+                  "value": "7",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "3",
+                  "timescale": "1"
+                }
+              },
+              "after": {
+                "id": "clip-after",
+                "mediaId": "media-dialogue",
+                "name": "After",
+                "start": 5,
+                "duration": 3,
+                "track": 1,
+                "startTime": {
+                  "value": "7",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "3",
+                  "timescale": "1"
+                }
+              }
+            }
+          ],
+          "durationDelta": -2,
+          "durationDeltaTime": {
+            "value": "-2",
+            "timescale": "1"
+          },
+          "markerChanges": [
+            {
+              "type": "MARKER_MODIFIED",
+              "marker": {
+                "id": "marker-after",
+                "start": 4,
+                "duration": 1,
+                "name": "Shift",
+                "startTime": {
+                  "value": "6",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "1",
+                  "timescale": "1"
+                }
+              },
+              "before": {
+                "id": "marker-after",
+                "start": 6,
+                "duration": 1,
+                "name": "Shift",
+                "startTime": {
+                  "value": "6",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "1",
+                  "timescale": "1"
+                }
+              },
+              "after": {
+                "id": "marker-after",
+                "start": 4,
+                "duration": 1,
+                "name": "Shift",
+                "startTime": {
+                  "value": "6",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "1",
+                  "timescale": "1"
+                }
+              }
+            }
+          ],
+          "captionChanges": [],
+          "storyElementChanges": [
+            {
+              "type": "STORY_ELEMENT_MODIFIED",
+              "element": {
+                "id": "clip-before",
+                "kind": "asset-clip",
+                "start": 0,
+                "duration": 3,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "4",
+                  "timescale": "1"
+                },
+                "lane": 1,
+                "mediaId": "media-dialogue"
+              },
+              "before": {
+                "id": "clip-before",
+                "kind": "asset-clip",
+                "start": 0,
+                "duration": 4,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "4",
+                  "timescale": "1"
+                },
+                "lane": 1,
+                "mediaId": "media-dialogue"
+              },
+              "after": {
+                "id": "clip-before",
+                "kind": "asset-clip",
+                "start": 0,
+                "duration": 3,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "4",
+                  "timescale": "1"
+                },
+                "lane": 1,
+                "mediaId": "media-dialogue"
+              }
+            },
+            {
+              "type": "STORY_ELEMENT_MODIFIED",
+              "element": {
+                "id": "clip-middle",
+                "kind": "asset-clip",
+                "start": 3,
+                "duration": 2,
+                "startTime": {
+                  "value": "4",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "3",
+                  "timescale": "1"
+                },
+                "lane": 1,
+                "mediaId": "media-dialogue"
+              },
+              "before": {
+                "id": "clip-middle",
+                "kind": "asset-clip",
+                "start": 4,
+                "duration": 3,
+                "startTime": {
+                  "value": "4",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "3",
+                  "timescale": "1"
+                },
+                "lane": 1,
+                "mediaId": "media-dialogue"
+              },
+              "after": {
+                "id": "clip-middle",
+                "kind": "asset-clip",
+                "start": 3,
+                "duration": 2,
+                "startTime": {
+                  "value": "4",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "3",
+                  "timescale": "1"
+                },
+                "lane": 1,
+                "mediaId": "media-dialogue"
+              }
+            },
+            {
+              "type": "STORY_ELEMENT_MODIFIED",
+              "element": {
+                "id": "clip-after",
+                "kind": "asset-clip",
+                "start": 5,
+                "duration": 3,
+                "startTime": {
+                  "value": "7",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "3",
+                  "timescale": "1"
+                },
+                "lane": 1,
+                "mediaId": "media-dialogue"
+              },
+              "before": {
+                "id": "clip-after",
+                "kind": "asset-clip",
+                "start": 7,
+                "duration": 3,
+                "startTime": {
+                  "value": "7",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "3",
+                  "timescale": "1"
+                },
+                "lane": 1,
+                "mediaId": "media-dialogue"
+              },
+              "after": {
+                "id": "clip-after",
+                "kind": "asset-clip",
+                "start": 5,
+                "duration": 3,
+                "startTime": {
+                  "value": "7",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "3",
+                  "timescale": "1"
+                },
+                "lane": 1,
+                "mediaId": "media-dialogue"
+              }
+            }
+          ],
+          "mediaChanges": [],
+          "affectedRanges": [
+            {
+              "start": 0,
+              "end": 4,
+              "startTime": {
+                "value": "0",
+                "timescale": "1"
+              },
+              "durationTime": {
+                "value": "4",
+                "timescale": "1"
+              }
+            },
+            {
+              "start": 0,
+              "end": 3,
+              "startTime": {
+                "value": "0",
+                "timescale": "1"
+              },
+              "durationTime": {
+                "value": "4",
+                "timescale": "1"
+              }
+            },
+            {
+              "start": 4,
+              "end": 7,
+              "startTime": {
+                "value": "4",
+                "timescale": "1"
+              },
+              "durationTime": {
+                "value": "3",
+                "timescale": "1"
+              }
+            },
+            {
+              "start": 3,
+              "end": 5,
+              "startTime": {
+                "value": "4",
+                "timescale": "1"
+              },
+              "durationTime": {
+                "value": "3",
+                "timescale": "1"
+              }
+            },
+            {
+              "start": 7,
+              "end": 10,
+              "startTime": {
+                "value": "7",
+                "timescale": "1"
+              },
+              "durationTime": {
+                "value": "3",
+                "timescale": "1"
+              }
+            },
+            {
+              "start": 5,
+              "end": 8,
+              "startTime": {
+                "value": "7",
+                "timescale": "1"
+              },
+              "durationTime": {
+                "value": "3",
+                "timescale": "1"
+              }
+            },
+            {
+              "start": 6,
+              "end": 7,
+              "startTime": {
+                "value": "6",
+                "timescale": "1"
+              },
+              "durationTime": {
+                "value": "1",
+                "timescale": "1"
+              }
+            },
+            {
+              "start": 0,
+              "end": 4
+            },
+            {
+              "start": 4,
+              "end": 7
+            },
+            {
+              "start": 7,
+              "end": 10
+            }
+          ]
+        },
+        "afterRevision": {
+          "id": "rev-1",
+          "sequence": 1,
+          "timestamp": "1970-01-01T00:00:00.001Z"
+        },
+        "undoRevision": {
+          "id": "rev-2",
+          "sequence": 2,
+          "timestamp": "1970-01-01T00:00:00.002Z"
+        }
       }
     },
     {
@@ -112,19 +2006,323 @@
         "projectName": "Golden Workflow Fixture",
         "timelineId": "golden-timeline",
         "timelineName": "Main Edit",
-        "clips": [{ "id": "clip-main", "mediaId": "media-dialogue", "name": "Interview", "start": 0, "duration": 10, "track": 1 }],
-        "media": [{ "mediaId": "media-dialogue", "source": "/fixtures/interview.mov", "mediaKind": "video", "duration": 10, "sourceDigest": "sha256:interview" }],
-        "markers": [{ "id": "marker-review", "start": 2, "duration": 0, "name": "Review" }],
-        "captions": [{ "id": "caption-opening", "start": 0.5, "duration": 1, "text": "Hello" }]
+        "clips": [
+          {
+            "id": "clip-main",
+            "mediaId": "media-dialogue",
+            "name": "Interview",
+            "start": 0,
+            "duration": 10,
+            "track": 1
+          }
+        ],
+        "media": [
+          {
+            "mediaId": "media-dialogue",
+            "source": "/fixtures/interview.mov",
+            "mediaKind": "video",
+            "duration": 10,
+            "sourceDigest": "sha256:interview"
+          }
+        ],
+        "markers": [
+          {
+            "id": "marker-review",
+            "start": 2,
+            "duration": 0,
+            "name": "Review"
+          }
+        ],
+        "captions": [
+          {
+            "id": "caption-opening",
+            "start": 0.5,
+            "duration": 1,
+            "text": "Hello"
+          }
+        ]
       },
       "operation": {
         "type": "add-marker",
         "timelineId": "golden-timeline",
-        "marker": { "id": "marker-cut", "start": 4.5, "duration": 0.5, "name": "Cut here" }
+        "marker": {
+          "id": "marker-cut",
+          "start": 4.5,
+          "duration": 0.5,
+          "name": "Cut here"
+        }
       },
       "expected": {
-        "afterRevision": { "id": "rev-1", "sequence": 1, "timestamp": "1970-01-01T00:00:00.001Z" },
-        "undoRevision": { "id": "rev-2", "sequence": 2, "timestamp": "1970-01-01T00:00:00.002Z" }
+        "before": {
+          "projectId": "golden-project",
+          "projectName": "Golden Workflow Fixture",
+          "timeline": {
+            "id": "golden-timeline",
+            "name": "Main Edit",
+            "duration": 10,
+            "durationTime": {
+              "value": "10",
+              "timescale": "1"
+            },
+            "clips": [
+              {
+                "id": "clip-main",
+                "mediaId": "media-dialogue",
+                "name": "Interview",
+                "start": 0,
+                "duration": 10,
+                "track": 1,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "10",
+                  "timescale": "1"
+                }
+              }
+            ],
+            "storyElements": [
+              {
+                "id": "clip-main",
+                "kind": "asset-clip",
+                "start": 0,
+                "duration": 10,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "10",
+                  "timescale": "1"
+                },
+                "lane": 1,
+                "mediaId": "media-dialogue"
+              }
+            ],
+            "markers": [
+              {
+                "id": "marker-review",
+                "start": 2,
+                "duration": 0,
+                "name": "Review",
+                "startTime": {
+                  "value": "2",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "0",
+                  "timescale": "1"
+                }
+              }
+            ],
+            "captions": [
+              {
+                "id": "caption-opening",
+                "start": 0.5,
+                "duration": 1,
+                "text": "Hello",
+                "startTime": {
+                  "value": "5",
+                  "timescale": "10"
+                },
+                "durationTime": {
+                  "value": "1",
+                  "timescale": "1"
+                }
+              }
+            ]
+          },
+          "media": [
+            {
+              "mediaId": "media-dialogue",
+              "source": "/fixtures/interview.mov",
+              "mediaKind": "video",
+              "duration": 10,
+              "sourceDigest": "sha256:interview"
+            }
+          ],
+          "revision": {
+            "id": "rev-0",
+            "sequence": 0,
+            "timestamp": "1970-01-01T00:00:00.000Z"
+          }
+        },
+        "after": {
+          "projectId": "golden-project",
+          "projectName": "Golden Workflow Fixture",
+          "timeline": {
+            "id": "golden-timeline",
+            "name": "Main Edit",
+            "duration": 10,
+            "durationTime": {
+              "value": "10",
+              "timescale": "1"
+            },
+            "clips": [
+              {
+                "id": "clip-main",
+                "mediaId": "media-dialogue",
+                "name": "Interview",
+                "start": 0,
+                "duration": 10,
+                "track": 1,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "10",
+                  "timescale": "1"
+                }
+              }
+            ],
+            "storyElements": [
+              {
+                "id": "clip-main",
+                "kind": "asset-clip",
+                "start": 0,
+                "duration": 10,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "10",
+                  "timescale": "1"
+                },
+                "lane": 1,
+                "mediaId": "media-dialogue"
+              }
+            ],
+            "markers": [
+              {
+                "id": "marker-review",
+                "start": 2,
+                "duration": 0,
+                "name": "Review",
+                "startTime": {
+                  "value": "2",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "0",
+                  "timescale": "1"
+                }
+              },
+              {
+                "id": "marker-cut",
+                "start": 4.5,
+                "duration": 0.5,
+                "name": "Cut here",
+                "startTime": {
+                  "value": "45",
+                  "timescale": "10"
+                },
+                "durationTime": {
+                  "value": "5",
+                  "timescale": "10"
+                }
+              }
+            ],
+            "captions": [
+              {
+                "id": "caption-opening",
+                "start": 0.5,
+                "duration": 1,
+                "text": "Hello",
+                "startTime": {
+                  "value": "5",
+                  "timescale": "10"
+                },
+                "durationTime": {
+                  "value": "1",
+                  "timescale": "1"
+                }
+              }
+            ]
+          },
+          "media": [
+            {
+              "mediaId": "media-dialogue",
+              "source": "/fixtures/interview.mov",
+              "mediaKind": "video",
+              "duration": 10,
+              "sourceDigest": "sha256:interview"
+            }
+          ],
+          "revision": {
+            "id": "rev-1",
+            "sequence": 1,
+            "timestamp": "1970-01-01T00:00:00.001Z"
+          }
+        },
+        "diff": {
+          "from": {
+            "id": "rev-0",
+            "sequence": 0,
+            "timestamp": "1970-01-01T00:00:00.000Z"
+          },
+          "to": {
+            "id": "rev-1",
+            "sequence": 1,
+            "timestamp": "1970-01-01T00:00:00.001Z"
+          },
+          "added": [],
+          "removed": [],
+          "modified": [],
+          "durationDelta": 0,
+          "durationDeltaTime": {
+            "value": "0",
+            "timescale": "1"
+          },
+          "markerChanges": [
+            {
+              "type": "MARKER_ADDED",
+              "marker": {
+                "id": "marker-cut",
+                "start": 4.5,
+                "duration": 0.5,
+                "name": "Cut here",
+                "startTime": {
+                  "value": "45",
+                  "timescale": "10"
+                },
+                "durationTime": {
+                  "value": "5",
+                  "timescale": "10"
+                }
+              }
+            }
+          ],
+          "captionChanges": [],
+          "storyElementChanges": [],
+          "mediaChanges": [],
+          "affectedRanges": [
+            {
+              "start": 4.5,
+              "end": 5,
+              "startTime": {
+                "value": "45",
+                "timescale": "10"
+              },
+              "durationTime": {
+                "value": "5",
+                "timescale": "10"
+              }
+            }
+          ]
+        },
+        "afterRevision": {
+          "id": "rev-1",
+          "sequence": 1,
+          "timestamp": "1970-01-01T00:00:00.001Z"
+        },
+        "undoRevision": {
+          "id": "rev-2",
+          "sequence": 2,
+          "timestamp": "1970-01-01T00:00:00.002Z"
+        }
       }
     },
     {
@@ -139,20 +2337,514 @@
         "timelineName": "Main Edit",
         "clips": [],
         "media": [],
-        "assets": [{ "id": "title-basic", "kind": "title", "name": "Basic Title", "vendor": "Framekit Fixture", "metadata": {} }],
+        "assets": [
+          {
+            "id": "title-basic",
+            "kind": "title",
+            "name": "Basic Title",
+            "vendor": "Framekit Fixture",
+            "metadata": {}
+          }
+        ],
         "captions": []
       },
       "operations": [
-        { "type": "media.import", "mediaId": "media-video", "source": "/fixtures/interview.mov", "mediaKind": "video", "duration": 12, "sourceDigest": "sha256:video" },
-        { "type": "media.import", "mediaId": "media-music", "source": "/fixtures/music.wav", "mediaKind": "audio", "duration": 8, "sourceDigest": "sha256:music" },
-        { "type": "timeline.media.add", "occurrenceId": "clip-video", "mediaId": "media-video", "role": "video", "start": 0, "duration": 12, "targetLane": "primary" },
-        { "type": "trim-clip", "clipId": "clip-video", "duration": 8 },
-        { "type": "timeline.media.add", "occurrenceId": "clip-music", "mediaId": "media-music", "role": "music", "start": 0, "duration": 8, "targetLane": -1 },
-        { "type": "timeline.title.add", "occurrenceId": "title-opening", "assetId": "title-basic", "text": "Framekit MVP", "start": 1, "duration": 3, "targetLane": 1 }
+        {
+          "type": "media.import",
+          "mediaId": "media-video",
+          "source": "/fixtures/interview.mov",
+          "mediaKind": "video",
+          "duration": 12,
+          "sourceDigest": "sha256:video"
+        },
+        {
+          "type": "media.import",
+          "mediaId": "media-music",
+          "source": "/fixtures/music.wav",
+          "mediaKind": "audio",
+          "duration": 8,
+          "sourceDigest": "sha256:music"
+        },
+        {
+          "type": "timeline.media.add",
+          "occurrenceId": "clip-video",
+          "mediaId": "media-video",
+          "role": "video",
+          "start": 0,
+          "duration": 12,
+          "targetLane": "primary"
+        },
+        {
+          "type": "trim-clip",
+          "clipId": "clip-video",
+          "duration": 8
+        },
+        {
+          "type": "timeline.media.add",
+          "occurrenceId": "clip-music",
+          "mediaId": "media-music",
+          "role": "music",
+          "start": 0,
+          "duration": 8,
+          "targetLane": -1
+        },
+        {
+          "type": "timeline.title.add",
+          "occurrenceId": "title-opening",
+          "assetId": "title-basic",
+          "text": "Framekit MVP",
+          "start": 1,
+          "duration": 3,
+          "targetLane": 1
+        }
       ],
       "expected": {
-        "afterRevision": { "id": "rev-1", "sequence": 1, "timestamp": "1970-01-01T00:00:00.001Z" },
-        "undoRevision": { "id": "rev-2", "sequence": 2, "timestamp": "1970-01-01T00:00:00.002Z" }
+        "before": {
+          "projectId": "golden-project",
+          "projectName": "Golden Workflow Fixture",
+          "timeline": {
+            "id": "golden-timeline",
+            "name": "Main Edit",
+            "duration": 0,
+            "durationTime": {
+              "value": "0",
+              "timescale": "1"
+            },
+            "clips": [],
+            "storyElements": [],
+            "markers": [],
+            "captions": []
+          },
+          "media": [],
+          "revision": {
+            "id": "rev-0",
+            "sequence": 0,
+            "timestamp": "1970-01-01T00:00:00.000Z"
+          }
+        },
+        "after": {
+          "projectId": "golden-project",
+          "projectName": "Golden Workflow Fixture",
+          "timeline": {
+            "id": "golden-timeline",
+            "name": "Main Edit",
+            "duration": 8,
+            "durationTime": {
+              "value": "8",
+              "timescale": "1"
+            },
+            "clips": [
+              {
+                "id": "clip-video",
+                "mediaId": "media-video",
+                "name": "interview.mov",
+                "start": 0,
+                "duration": 8,
+                "track": 0,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "8",
+                  "timescale": "1"
+                }
+              },
+              {
+                "id": "clip-music",
+                "mediaId": "media-music",
+                "name": "music.wav",
+                "start": 0,
+                "duration": 8,
+                "track": -1,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "8",
+                  "timescale": "1"
+                }
+              },
+              {
+                "id": "title-opening",
+                "name": "Framekit MVP",
+                "start": 1,
+                "duration": 3,
+                "track": 1,
+                "startTime": {
+                  "value": "1",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "3",
+                  "timescale": "1"
+                }
+              }
+            ],
+            "storyElements": [
+              {
+                "id": "clip-video",
+                "kind": "asset-clip",
+                "start": 0,
+                "duration": 8,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "8",
+                  "timescale": "1"
+                },
+                "lane": 0,
+                "mediaId": "media-video"
+              },
+              {
+                "id": "clip-music",
+                "kind": "asset-clip",
+                "start": 0,
+                "duration": 8,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "8",
+                  "timescale": "1"
+                },
+                "lane": -1,
+                "mediaId": "media-music"
+              },
+              {
+                "id": "title-opening",
+                "kind": "title",
+                "start": 1,
+                "duration": 3,
+                "startTime": {
+                  "value": "1",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "3",
+                  "timescale": "1"
+                },
+                "lane": 1,
+                "assetId": "title-basic",
+                "text": "Framekit MVP"
+              }
+            ],
+            "markers": [],
+            "captions": []
+          },
+          "media": [
+            {
+              "mediaId": "media-video",
+              "source": "/fixtures/interview.mov",
+              "mediaKind": "video",
+              "duration": 12,
+              "sourceDigest": "sha256:video"
+            },
+            {
+              "mediaId": "media-music",
+              "source": "/fixtures/music.wav",
+              "mediaKind": "audio",
+              "duration": 8,
+              "sourceDigest": "sha256:music"
+            }
+          ],
+          "revision": {
+            "id": "rev-1",
+            "sequence": 1,
+            "timestamp": "1970-01-01T00:00:00.001Z"
+          }
+        },
+        "diff": {
+          "from": {
+            "id": "rev-0",
+            "sequence": 0,
+            "timestamp": "1970-01-01T00:00:00.000Z"
+          },
+          "to": {
+            "id": "rev-1",
+            "sequence": 1,
+            "timestamp": "1970-01-01T00:00:00.001Z"
+          },
+          "added": [
+            {
+              "type": "ITEM_ADDED",
+              "itemId": "clip-video",
+              "after": {
+                "id": "clip-video",
+                "mediaId": "media-video",
+                "name": "interview.mov",
+                "start": 0,
+                "duration": 8,
+                "track": 0,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "8",
+                  "timescale": "1"
+                }
+              }
+            },
+            {
+              "type": "ITEM_ADDED",
+              "itemId": "clip-music",
+              "after": {
+                "id": "clip-music",
+                "mediaId": "media-music",
+                "name": "music.wav",
+                "start": 0,
+                "duration": 8,
+                "track": -1,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "8",
+                  "timescale": "1"
+                }
+              }
+            },
+            {
+              "type": "ITEM_ADDED",
+              "itemId": "title-opening",
+              "after": {
+                "id": "title-opening",
+                "name": "Framekit MVP",
+                "start": 1,
+                "duration": 3,
+                "track": 1,
+                "startTime": {
+                  "value": "1",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "3",
+                  "timescale": "1"
+                }
+              }
+            }
+          ],
+          "removed": [],
+          "modified": [],
+          "durationDelta": 8,
+          "durationDeltaTime": {
+            "value": "8",
+            "timescale": "1"
+          },
+          "markerChanges": [],
+          "captionChanges": [],
+          "storyElementChanges": [
+            {
+              "type": "STORY_ELEMENT_ADDED",
+              "element": {
+                "id": "clip-video",
+                "kind": "asset-clip",
+                "start": 0,
+                "duration": 8,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "8",
+                  "timescale": "1"
+                },
+                "lane": 0,
+                "mediaId": "media-video"
+              },
+              "after": {
+                "id": "clip-video",
+                "kind": "asset-clip",
+                "start": 0,
+                "duration": 8,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "8",
+                  "timescale": "1"
+                },
+                "lane": 0,
+                "mediaId": "media-video"
+              }
+            },
+            {
+              "type": "STORY_ELEMENT_ADDED",
+              "element": {
+                "id": "clip-music",
+                "kind": "asset-clip",
+                "start": 0,
+                "duration": 8,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "8",
+                  "timescale": "1"
+                },
+                "lane": -1,
+                "mediaId": "media-music"
+              },
+              "after": {
+                "id": "clip-music",
+                "kind": "asset-clip",
+                "start": 0,
+                "duration": 8,
+                "startTime": {
+                  "value": "0",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "8",
+                  "timescale": "1"
+                },
+                "lane": -1,
+                "mediaId": "media-music"
+              }
+            },
+            {
+              "type": "STORY_ELEMENT_ADDED",
+              "element": {
+                "id": "title-opening",
+                "kind": "title",
+                "start": 1,
+                "duration": 3,
+                "startTime": {
+                  "value": "1",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "3",
+                  "timescale": "1"
+                },
+                "lane": 1,
+                "assetId": "title-basic",
+                "text": "Framekit MVP"
+              },
+              "after": {
+                "id": "title-opening",
+                "kind": "title",
+                "start": 1,
+                "duration": 3,
+                "startTime": {
+                  "value": "1",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "3",
+                  "timescale": "1"
+                },
+                "lane": 1,
+                "assetId": "title-basic",
+                "text": "Framekit MVP"
+              }
+            }
+          ],
+          "mediaChanges": [
+            {
+              "type": "MEDIA_ADDED",
+              "media": {
+                "mediaId": "media-video",
+                "source": "/fixtures/interview.mov",
+                "mediaKind": "video",
+                "duration": 12,
+                "sourceDigest": "sha256:video"
+              },
+              "after": {
+                "mediaId": "media-video",
+                "source": "/fixtures/interview.mov",
+                "mediaKind": "video",
+                "duration": 12,
+                "sourceDigest": "sha256:video"
+              }
+            },
+            {
+              "type": "MEDIA_ADDED",
+              "media": {
+                "mediaId": "media-music",
+                "source": "/fixtures/music.wav",
+                "mediaKind": "audio",
+                "duration": 8,
+                "sourceDigest": "sha256:music"
+              },
+              "after": {
+                "mediaId": "media-music",
+                "source": "/fixtures/music.wav",
+                "mediaKind": "audio",
+                "duration": 8,
+                "sourceDigest": "sha256:music"
+              }
+            }
+          ],
+          "affectedRanges": [
+            {
+              "start": 0,
+              "end": 8,
+              "startTime": {
+                "value": "0",
+                "timescale": "1"
+              },
+              "durationTime": {
+                "value": "8",
+                "timescale": "1"
+              }
+            },
+            {
+              "start": 0,
+              "end": 8,
+              "startTime": {
+                "value": "0",
+                "timescale": "1"
+              },
+              "durationTime": {
+                "value": "8",
+                "timescale": "1"
+              }
+            },
+            {
+              "start": 1,
+              "end": 4,
+              "startTime": {
+                "value": "1",
+                "timescale": "1"
+              },
+              "durationTime": {
+                "value": "3",
+                "timescale": "1"
+              }
+            },
+            {
+              "start": 0,
+              "end": 8
+            },
+            {
+              "start": 0,
+              "end": 8
+            },
+            {
+              "start": 1,
+              "end": 4
+            }
+          ]
+        },
+        "afterRevision": {
+          "id": "rev-1",
+          "sequence": 1,
+          "timestamp": "1970-01-01T00:00:00.001Z"
+        },
+        "undoRevision": {
+          "id": "rev-2",
+          "sequence": 2,
+          "timestamp": "1970-01-01T00:00:00.002Z"
+        }
       }
     }
   ]

--- a/tests/golden/corpus.json
+++ b/tests/golden/corpus.json
@@ -362,18 +362,6 @@
                 "value": "10",
                 "timescale": "1"
               }
-            },
-            {
-              "start": 0,
-              "end": 10,
-              "startTime": {
-                "value": "0",
-                "timescale": "1"
-              },
-              "durationTime": {
-                "value": "10",
-                "timescale": "1"
-              }
             }
           ]
         },
@@ -1114,18 +1102,6 @@
                 "value": "10",
                 "timescale": "1"
               }
-            },
-            {
-              "start": 0,
-              "end": 10,
-              "startTime": {
-                "value": "0",
-                "timescale": "1"
-              },
-              "durationTime": {
-                "value": "10",
-                "timescale": "1"
-              }
             }
           ]
         },
@@ -1422,7 +1398,7 @@
                   "timescale": "1"
                 },
                 "durationTime": {
-                  "value": "4",
+                  "value": "3",
                   "timescale": "1"
                 }
               },
@@ -1434,11 +1410,11 @@
                 "duration": 2,
                 "track": 1,
                 "startTime": {
-                  "value": "4",
+                  "value": "3",
                   "timescale": "1"
                 },
                 "durationTime": {
-                  "value": "3",
+                  "value": "2",
                   "timescale": "1"
                 }
               },
@@ -1450,7 +1426,7 @@
                 "duration": 3,
                 "track": 1,
                 "startTime": {
-                  "value": "7",
+                  "value": "5",
                   "timescale": "1"
                 },
                 "durationTime": {
@@ -1470,7 +1446,7 @@
                   "timescale": "1"
                 },
                 "durationTime": {
-                  "value": "4",
+                  "value": "3",
                   "timescale": "1"
                 },
                 "lane": 1,
@@ -1482,11 +1458,11 @@
                 "start": 3,
                 "duration": 2,
                 "startTime": {
-                  "value": "4",
+                  "value": "3",
                   "timescale": "1"
                 },
                 "durationTime": {
-                  "value": "3",
+                  "value": "2",
                   "timescale": "1"
                 },
                 "lane": 1,
@@ -1498,7 +1474,7 @@
                 "start": 5,
                 "duration": 3,
                 "startTime": {
-                  "value": "7",
+                  "value": "5",
                   "timescale": "1"
                 },
                 "durationTime": {
@@ -1530,7 +1506,7 @@
                 "duration": 1,
                 "name": "Shift",
                 "startTime": {
-                  "value": "6",
+                  "value": "4",
                   "timescale": "1"
                 },
                 "durationTime": {
@@ -1616,7 +1592,7 @@
                   "timescale": "1"
                 },
                 "durationTime": {
-                  "value": "4",
+                  "value": "3",
                   "timescale": "1"
                 }
               }
@@ -1648,11 +1624,11 @@
                 "duration": 2,
                 "track": 1,
                 "startTime": {
-                  "value": "4",
+                  "value": "3",
                   "timescale": "1"
                 },
                 "durationTime": {
-                  "value": "3",
+                  "value": "2",
                   "timescale": "1"
                 }
               }
@@ -1684,7 +1660,7 @@
                 "duration": 3,
                 "track": 1,
                 "startTime": {
-                  "value": "7",
+                  "value": "5",
                   "timescale": "1"
                 },
                 "durationTime": {
@@ -1708,7 +1684,7 @@
                 "duration": 1,
                 "name": "Shift",
                 "startTime": {
-                  "value": "6",
+                  "value": "4",
                   "timescale": "1"
                 },
                 "durationTime": {
@@ -1736,7 +1712,7 @@
                 "duration": 1,
                 "name": "Shift",
                 "startTime": {
-                  "value": "6",
+                  "value": "4",
                   "timescale": "1"
                 },
                 "durationTime": {
@@ -1760,7 +1736,7 @@
                   "timescale": "1"
                 },
                 "durationTime": {
-                  "value": "4",
+                  "value": "3",
                   "timescale": "1"
                 },
                 "lane": 1,
@@ -1792,7 +1768,7 @@
                   "timescale": "1"
                 },
                 "durationTime": {
-                  "value": "4",
+                  "value": "3",
                   "timescale": "1"
                 },
                 "lane": 1,
@@ -1807,11 +1783,11 @@
                 "start": 3,
                 "duration": 2,
                 "startTime": {
-                  "value": "4",
+                  "value": "3",
                   "timescale": "1"
                 },
                 "durationTime": {
-                  "value": "3",
+                  "value": "2",
                   "timescale": "1"
                 },
                 "lane": 1,
@@ -1839,11 +1815,11 @@
                 "start": 3,
                 "duration": 2,
                 "startTime": {
-                  "value": "4",
+                  "value": "3",
                   "timescale": "1"
                 },
                 "durationTime": {
-                  "value": "3",
+                  "value": "2",
                   "timescale": "1"
                 },
                 "lane": 1,
@@ -1858,7 +1834,7 @@
                 "start": 5,
                 "duration": 3,
                 "startTime": {
-                  "value": "7",
+                  "value": "5",
                   "timescale": "1"
                 },
                 "durationTime": {
@@ -1890,7 +1866,7 @@
                 "start": 5,
                 "duration": 3,
                 "startTime": {
-                  "value": "7",
+                  "value": "5",
                   "timescale": "1"
                 },
                 "durationTime": {
@@ -1924,7 +1900,7 @@
                 "timescale": "1"
               },
               "durationTime": {
-                "value": "4",
+                "value": "3",
                 "timescale": "1"
               }
             },
@@ -1944,11 +1920,11 @@
               "start": 3,
               "end": 5,
               "startTime": {
-                "value": "4",
+                "value": "3",
                 "timescale": "1"
               },
               "durationTime": {
-                "value": "3",
+                "value": "2",
                 "timescale": "1"
               }
             },
@@ -1968,7 +1944,7 @@
               "start": 5,
               "end": 8,
               "startTime": {
-                "value": "7",
+                "value": "5",
                 "timescale": "1"
               },
               "durationTime": {
@@ -2828,18 +2804,6 @@
               }
             },
             {
-              "start": 0,
-              "end": 8,
-              "startTime": {
-                "value": "0",
-                "timescale": "1"
-              },
-              "durationTime": {
-                "value": "8",
-                "timescale": "1"
-              }
-            },
-            {
               "start": 1,
               "end": 4,
               "startTime": {
@@ -2850,10 +2814,6 @@
                 "value": "3",
                 "timescale": "1"
               }
-            },
-            {
-              "start": 0,
-              "end": 8
             },
             {
               "start": 0,

--- a/tests/golden/corpus.json
+++ b/tests/golden/corpus.json
@@ -6,32 +6,154 @@
     {
       "id": "phase0.rename-clip",
       "family": "rename-clip",
-      "description": "Rename one timeline occurrence without changing its identity or media reference."
+      "description": "Rename one timeline occurrence without changing its identity or media reference.",
+      "mode": "single",
+      "fixture": {
+        "projectId": "golden-project",
+        "projectName": "Golden Workflow Fixture",
+        "timelineId": "golden-timeline",
+        "timelineName": "Main Edit",
+        "clips": [{ "id": "clip-main", "mediaId": "media-dialogue", "name": "Interview", "start": 0, "duration": 10, "track": 1 }],
+        "media": [{
+          "mediaId": "media-dialogue",
+          "source": "/fixtures/interview.mov",
+          "mediaKind": "video",
+          "duration": 10,
+          "sourceDigest": "sha256:interview",
+          "speech": { "words": [{ "text": "hello", "start": 0, "end": 1, "confidence": 0.99 }] },
+          "audio": { "integratedLufs": -18, "truePeakDb": -3, "silenceMs": 120 }
+        }],
+        "markers": [{ "id": "marker-review", "start": 2, "duration": 0, "name": "Review" }],
+        "captions": [{ "id": "caption-opening", "start": 0.5, "duration": 1, "text": "Hello" }]
+      },
+      "operation": { "type": "rename-clip", "clipId": "clip-main", "name": "Interview - Clean" },
+      "expected": {
+        "afterRevision": { "id": "rev-1", "sequence": 1, "timestamp": "1970-01-01T00:00:00.001Z" },
+        "undoRevision": { "id": "rev-2", "sequence": 2, "timestamp": "1970-01-01T00:00:00.002Z" }
+      }
     },
     {
       "id": "phase0.trim-clip",
       "family": "trim-clip",
-      "description": "Trim one timeline occurrence while retaining exact timeline time."
+      "description": "Trim one timeline occurrence while retaining exact timeline time.",
+      "mode": "single",
+      "fixture": {
+        "projectId": "golden-project",
+        "projectName": "Golden Workflow Fixture",
+        "timelineId": "golden-timeline",
+        "timelineName": "Main Edit",
+        "clips": [{ "id": "clip-main", "mediaId": "media-dialogue", "name": "Interview", "start": 0, "duration": 10, "track": 1 }],
+        "media": [{ "mediaId": "media-dialogue", "source": "/fixtures/interview.mov", "mediaKind": "video", "duration": 10, "sourceDigest": "sha256:interview" }],
+        "markers": [{ "id": "marker-review", "start": 2, "duration": 0, "name": "Review" }],
+        "captions": [{ "id": "caption-opening", "start": 0.5, "duration": 1, "text": "Hello" }]
+      },
+      "operation": { "type": "trim-clip", "clipId": "clip-main", "duration": 6 },
+      "expected": {
+        "afterRevision": { "id": "rev-1", "sequence": 1, "timestamp": "1970-01-01T00:00:00.001Z" },
+        "undoRevision": { "id": "rev-2", "sequence": 2, "timestamp": "1970-01-01T00:00:00.002Z" }
+      }
     },
     {
       "id": "phase0.set-gain",
       "family": "set-gain",
-      "description": "Change one clip gain without changing its placement or source identity."
+      "description": "Change one clip gain without changing its placement or source identity.",
+      "mode": "single",
+      "fixture": {
+        "projectId": "golden-project",
+        "projectName": "Golden Workflow Fixture",
+        "timelineId": "golden-timeline",
+        "timelineName": "Main Edit",
+        "clips": [{ "id": "clip-main", "mediaId": "media-dialogue", "name": "Interview", "start": 0, "duration": 10, "track": 1 }],
+        "media": [{ "mediaId": "media-dialogue", "source": "/fixtures/interview.mov", "mediaKind": "video", "duration": 10, "sourceDigest": "sha256:interview" }],
+        "markers": [{ "id": "marker-review", "start": 2, "duration": 0, "name": "Review" }],
+        "captions": [{ "id": "caption-opening", "start": 0.5, "duration": 1, "text": "Hello" }]
+      },
+      "operation": { "type": "set-gain", "clipId": "clip-main", "gainDb": 3 },
+      "expected": {
+        "afterRevision": { "id": "rev-1", "sequence": 1, "timestamp": "1970-01-01T00:00:00.001Z" },
+        "undoRevision": { "id": "rev-2", "sequence": 2, "timestamp": "1970-01-01T00:00:00.002Z" }
+      }
     },
     {
       "id": "phase1.ripple-delete",
       "family": "ripple-delete",
-      "description": "Ripple-delete a range and preserve the supported timeline metadata around it."
+      "description": "Ripple-delete a range and preserve the supported timeline metadata around it.",
+      "mode": "single",
+      "fixture": {
+        "projectId": "golden-project",
+        "projectName": "Golden Workflow Fixture",
+        "timelineId": "golden-timeline",
+        "timelineName": "Main Edit",
+        "clips": [
+          { "id": "clip-before", "mediaId": "media-dialogue", "name": "Before", "start": 0, "duration": 4, "track": 1 },
+          { "id": "clip-middle", "mediaId": "media-dialogue", "name": "Middle", "start": 4, "duration": 3, "track": 1 },
+          { "id": "clip-after", "mediaId": "media-dialogue", "name": "After", "start": 7, "duration": 3, "track": 1 }
+        ],
+        "media": [{ "mediaId": "media-dialogue", "source": "/fixtures/interview.mov", "mediaKind": "video", "duration": 10, "sourceDigest": "sha256:interview" }],
+        "markers": [
+          { "id": "marker-before", "start": 2, "duration": 0, "name": "Keep" },
+          { "id": "marker-after", "start": 6, "duration": 1, "name": "Shift" }
+        ],
+        "captions": [{ "id": "caption-opening", "start": 0.5, "duration": 1, "text": "Hello" }]
+      },
+      "operation": { "type": "ripple-delete", "timelineId": "golden-timeline", "range": { "start": 3, "end": 5 }, "reason": "remove pause" },
+      "expected": {
+        "afterRevision": { "id": "rev-1", "sequence": 1, "timestamp": "1970-01-01T00:00:00.001Z" },
+        "undoRevision": { "id": "rev-2", "sequence": 2, "timestamp": "1970-01-01T00:00:00.002Z" }
+      }
     },
     {
       "id": "phase1.add-marker",
       "family": "add-marker",
-      "description": "Add a marker with deterministic placement and revision behavior."
+      "description": "Add a marker with deterministic placement and revision behavior.",
+      "mode": "single",
+      "fixture": {
+        "projectId": "golden-project",
+        "projectName": "Golden Workflow Fixture",
+        "timelineId": "golden-timeline",
+        "timelineName": "Main Edit",
+        "clips": [{ "id": "clip-main", "mediaId": "media-dialogue", "name": "Interview", "start": 0, "duration": 10, "track": 1 }],
+        "media": [{ "mediaId": "media-dialogue", "source": "/fixtures/interview.mov", "mediaKind": "video", "duration": 10, "sourceDigest": "sha256:interview" }],
+        "markers": [{ "id": "marker-review", "start": 2, "duration": 0, "name": "Review" }],
+        "captions": [{ "id": "caption-opening", "start": 0.5, "duration": 1, "text": "Hello" }]
+      },
+      "operation": {
+        "type": "add-marker",
+        "timelineId": "golden-timeline",
+        "marker": { "id": "marker-cut", "start": 4.5, "duration": 0.5, "name": "Cut here" }
+      },
+      "expected": {
+        "afterRevision": { "id": "rev-1", "sequence": 1, "timestamp": "1970-01-01T00:00:00.001Z" },
+        "undoRevision": { "id": "rev-2", "sequence": 2, "timestamp": "1970-01-01T00:00:00.002Z" }
+      }
     },
     {
       "id": "phase1.media-title-workflow",
       "family": "media-title-workflow",
-      "description": "Import media, place video and music, and add a title as one ordered transaction."
+      "description": "Import media, place video and music, and add a title as one ordered transaction.",
+      "mode": "composite",
+      "fixture": {
+        "projectId": "golden-project",
+        "projectName": "Golden Workflow Fixture",
+        "timelineId": "golden-timeline",
+        "timelineName": "Main Edit",
+        "clips": [],
+        "media": [],
+        "assets": [{ "id": "title-basic", "kind": "title", "name": "Basic Title", "vendor": "Framekit Fixture", "metadata": {} }],
+        "captions": []
+      },
+      "operations": [
+        { "type": "media.import", "mediaId": "media-video", "source": "/fixtures/interview.mov", "mediaKind": "video", "duration": 12, "sourceDigest": "sha256:video" },
+        { "type": "media.import", "mediaId": "media-music", "source": "/fixtures/music.wav", "mediaKind": "audio", "duration": 8, "sourceDigest": "sha256:music" },
+        { "type": "timeline.media.add", "occurrenceId": "clip-video", "mediaId": "media-video", "role": "video", "start": 0, "duration": 12, "targetLane": "primary" },
+        { "type": "trim-clip", "clipId": "clip-video", "duration": 8 },
+        { "type": "timeline.media.add", "occurrenceId": "clip-music", "mediaId": "media-music", "role": "music", "start": 0, "duration": 8, "targetLane": -1 },
+        { "type": "timeline.title.add", "occurrenceId": "title-opening", "assetId": "title-basic", "text": "Framekit MVP", "start": 1, "duration": 3, "targetLane": 1 }
+      ],
+      "expected": {
+        "afterRevision": { "id": "rev-1", "sequence": 1, "timestamp": "1970-01-01T00:00:00.001Z" },
+        "undoRevision": { "id": "rev-2", "sequence": 2, "timestamp": "1970-01-01T00:00:00.002Z" }
+      }
     }
   ]
 }

--- a/tests/golden/corpus.json
+++ b/tests/golden/corpus.json
@@ -386,7 +386,13 @@
           "id": "rev-2",
           "sequence": 2,
           "timestamp": "1970-01-01T00:00:00.002Z"
-        }
+        },
+        "rollbackRevision": {
+          "id": "rev-2",
+          "sequence": 2,
+          "timestamp": "1970-01-01T00:00:00.002Z"
+        },
+        "staleErrorCode": "STALE_CONTEXT"
       }
     },
     {
@@ -783,7 +789,13 @@
           "id": "rev-2",
           "sequence": 2,
           "timestamp": "1970-01-01T00:00:00.002Z"
-        }
+        },
+        "rollbackRevision": {
+          "id": "rev-2",
+          "sequence": 2,
+          "timestamp": "1970-01-01T00:00:00.002Z"
+        },
+        "staleErrorCode": "STALE_CONTEXT"
       }
     },
     {
@@ -1126,7 +1138,13 @@
           "id": "rev-2",
           "sequence": 2,
           "timestamp": "1970-01-01T00:00:00.002Z"
-        }
+        },
+        "rollbackRevision": {
+          "id": "rev-2",
+          "sequence": 2,
+          "timestamp": "1970-01-01T00:00:00.002Z"
+        },
+        "staleErrorCode": "STALE_CONTEXT"
       }
     },
     {
@@ -1993,7 +2011,13 @@
           "id": "rev-2",
           "sequence": 2,
           "timestamp": "1970-01-01T00:00:00.002Z"
-        }
+        },
+        "rollbackRevision": {
+          "id": "rev-2",
+          "sequence": 2,
+          "timestamp": "1970-01-01T00:00:00.002Z"
+        },
+        "staleErrorCode": "STALE_CONTEXT"
       }
     },
     {
@@ -2322,7 +2346,13 @@
           "id": "rev-2",
           "sequence": 2,
           "timestamp": "1970-01-01T00:00:00.002Z"
-        }
+        },
+        "rollbackRevision": {
+          "id": "rev-2",
+          "sequence": 2,
+          "timestamp": "1970-01-01T00:00:00.002Z"
+        },
+        "staleErrorCode": "STALE_CONTEXT"
       }
     },
     {
@@ -2844,7 +2874,13 @@
           "id": "rev-2",
           "sequence": 2,
           "timestamp": "1970-01-01T00:00:00.002Z"
-        }
+        },
+        "rollbackRevision": {
+          "id": "rev-2",
+          "sequence": 2,
+          "timestamp": "1970-01-01T00:00:00.002Z"
+        },
+        "staleErrorCode": "STALE_CONTEXT"
       }
     }
   ]

--- a/tests/golden/corpus.json
+++ b/tests/golden/corpus.json
@@ -1,0 +1,37 @@
+{
+  "schemaVersion": 1,
+  "corpusVersion": "2026-08-26",
+  "runtimeContract": "phase-0/1",
+  "scenarios": [
+    {
+      "id": "phase0.rename-clip",
+      "family": "rename-clip",
+      "description": "Rename one timeline occurrence without changing its identity or media reference."
+    },
+    {
+      "id": "phase0.trim-clip",
+      "family": "trim-clip",
+      "description": "Trim one timeline occurrence while retaining exact timeline time."
+    },
+    {
+      "id": "phase0.set-gain",
+      "family": "set-gain",
+      "description": "Change one clip gain without changing its placement or source identity."
+    },
+    {
+      "id": "phase1.ripple-delete",
+      "family": "ripple-delete",
+      "description": "Ripple-delete a range and preserve the supported timeline metadata around it."
+    },
+    {
+      "id": "phase1.add-marker",
+      "family": "add-marker",
+      "description": "Add a marker with deterministic placement and revision behavior."
+    },
+    {
+      "id": "phase1.media-title-workflow",
+      "family": "media-title-workflow",
+      "description": "Import media, place video and music, and add a title as one ordered transaction."
+    }
+  ]
+}

--- a/tests/golden/corpus.json
+++ b/tests/golden/corpus.json
@@ -1188,6 +1188,12 @@
             "start": 0.5,
             "duration": 1,
             "text": "Hello"
+          },
+          {
+            "id": "caption-after",
+            "start": 6,
+            "duration": 1,
+            "text": "Shifted"
           }
         ]
       },
@@ -1351,6 +1357,20 @@
                 "startTime": {
                   "value": "5",
                   "timescale": "10"
+                },
+                "durationTime": {
+                  "value": "1",
+                  "timescale": "1"
+                }
+              },
+              {
+                "id": "caption-after",
+                "start": 6,
+                "duration": 1,
+                "text": "Shifted",
+                "startTime": {
+                  "value": "6",
+                  "timescale": "1"
                 },
                 "durationTime": {
                   "value": "1",
@@ -1524,6 +1544,20 @@
                 "startTime": {
                   "value": "5",
                   "timescale": "10"
+                },
+                "durationTime": {
+                  "value": "1",
+                  "timescale": "1"
+                }
+              },
+              {
+                "id": "caption-after",
+                "start": 4,
+                "duration": 1,
+                "text": "Shifted",
+                "startTime": {
+                  "value": "4",
+                  "timescale": "1"
                 },
                 "durationTime": {
                   "value": "1",
@@ -1722,7 +1756,53 @@
               }
             }
           ],
-          "captionChanges": [],
+          "captionChanges": [
+            {
+              "type": "CAPTION_MODIFIED",
+              "caption": {
+                "id": "caption-after",
+                "start": 4,
+                "duration": 1,
+                "text": "Shifted",
+                "startTime": {
+                  "value": "4",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "1",
+                  "timescale": "1"
+                }
+              },
+              "before": {
+                "id": "caption-after",
+                "start": 6,
+                "duration": 1,
+                "text": "Shifted",
+                "startTime": {
+                  "value": "6",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "1",
+                  "timescale": "1"
+                }
+              },
+              "after": {
+                "id": "caption-after",
+                "start": 4,
+                "duration": 1,
+                "text": "Shifted",
+                "startTime": {
+                  "value": "4",
+                  "timescale": "1"
+                },
+                "durationTime": {
+                  "value": "1",
+                  "timescale": "1"
+                }
+              }
+            }
+          ],
           "storyElementChanges": [
             {
               "type": "STORY_ELEMENT_MODIFIED",

--- a/tests/golden/workflow-corpus-runner.ts
+++ b/tests/golden/workflow-corpus-runner.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { AgentVideoRuntime, type ContextRevision, type EditOperation, type ProjectSnapshot, type TimelineDiff, type WorkflowOperation } from "@framekit/runtime";
+import { AgentVideoRuntime, type ContextRevision, type EditOperation, type ProjectSnapshot, type RationalTime, type TimelineDiff, type WorkflowOperation } from "@framekit/runtime";
 import { InMemoryEditorAdapter, type InMemoryFixture } from "@framekit/testkit";
 
 export interface GoldenScenario {
@@ -138,12 +138,45 @@ export function validateGoldenSnapshot(snapshot: ProjectSnapshot, scenarioId: st
   assertUniqueIds(snapshot.timeline.markers, `${label} marker`);
   assertUniqueIds(snapshot.timeline.captions, `${label} caption`);
   assertUniqueIds(snapshot.media, `${label} media` , (media) => media.mediaId);
+  assertRationalTiming(snapshot.timeline.clips, `${label} clip`);
+  assertRationalTiming(snapshot.timeline.storyElements, `${label} story element`);
+  assertRationalTiming(snapshot.timeline.markers, `${label} marker`);
+  assertRationalTiming(snapshot.timeline.captions, `${label} caption`);
   const mediaIds = new Set(snapshot.media.map((media) => media.mediaId));
   for (const clip of snapshot.timeline.clips) {
     if (clip.mediaId) assert.equal(mediaIds.has(clip.mediaId), true, `${label} media reference ${clip.mediaId} is unresolved`);
   }
   for (const element of snapshot.timeline.storyElements) {
     if (element.mediaId) assert.equal(mediaIds.has(element.mediaId), true, `${label} media reference ${element.mediaId} is unresolved`);
+  }
+}
+
+interface TimedSnapshotItem {
+  id: string;
+  start: number;
+  duration: number;
+  startTime?: RationalTime;
+  durationTime?: RationalTime;
+}
+
+function assertRationalTiming(items: TimedSnapshotItem[], label: string): void {
+  for (const item of items) {
+    assert.equal(rationalMatchesNumber(item.startTime, item.start), true, `${label} ${item.id} startTime disagrees with start`);
+    assert.equal(rationalMatchesNumber(item.durationTime, item.duration), true, `${label} ${item.id} durationTime disagrees with duration`);
+  }
+}
+
+function rationalMatchesNumber(time: RationalTime | undefined, seconds: number): boolean {
+  if (!time || !Number.isFinite(seconds) || typeof time.value !== "string" || typeof time.timescale !== "string") return false;
+  const [whole, fraction = ""] = seconds.toString().split(".");
+  try {
+    const numericValue = BigInt(`${whole}${fraction}`);
+    const numericScale = 10n ** BigInt(fraction.length);
+    const value = BigInt(time.value);
+    const timescale = BigInt(time.timescale);
+    return timescale > 0n && value * numericScale === numericValue * timescale;
+  } catch {
+    return false;
   }
 }
 

--- a/tests/golden/workflow-corpus-runner.ts
+++ b/tests/golden/workflow-corpus-runner.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+export interface GoldenScenario {
+  id: string;
+  family: string;
+  description: string;
+  [key: string]: unknown;
+}
+
+export interface GoldenCorpus {
+  schemaVersion: number;
+  corpusVersion: string;
+  runtimeContract: string;
+  scenarios: GoldenScenario[];
+}
+
+const corpusPath = fileURLToPath(new URL("./corpus.json", import.meta.url));
+
+export function loadGoldenCorpus(): GoldenCorpus {
+  const parsed: unknown = JSON.parse(readFileSync(corpusPath, "utf8"));
+  assertCorpus(parsed);
+  return parsed;
+}
+
+export async function runGoldenScenario(scenario: GoldenScenario): Promise<void> {
+  assert.match(scenario.id, /^(phase0|phase1)\./, `invalid golden scenario id: ${scenario.id}`);
+  assert.ok(scenario.family.length > 0, `golden scenario ${scenario.id} has no family`);
+  assert.ok(scenario.description.length > 0, `golden scenario ${scenario.id} has no description`);
+}
+
+function assertCorpus(value: unknown): asserts value is GoldenCorpus {
+  assert.ok(value && typeof value === "object", "golden corpus must be an object");
+  const corpus = value as Partial<GoldenCorpus>;
+  assert.equal(corpus.schemaVersion, 1, "unsupported golden corpus schema");
+  assert.equal(typeof corpus.corpusVersion, "string", "golden corpus version is required");
+  assert.equal(typeof corpus.runtimeContract, "string", "golden corpus runtime contract is required");
+  assert.ok(Array.isArray(corpus.scenarios), "golden corpus scenarios are required");
+
+  const ids = new Set<string>();
+  for (const scenario of corpus.scenarios) {
+    assert.ok(scenario && typeof scenario === "object", "golden scenario must be an object");
+    assert.equal(typeof scenario.id, "string", "golden scenario id is required");
+    assert.equal(typeof scenario.family, "string", `golden scenario ${scenario.id} family is required`);
+    assert.equal(typeof scenario.description, "string", `golden scenario ${scenario.id} description is required`);
+    assert.equal(ids.has(scenario.id), false, `duplicate golden scenario id: ${scenario.id}`);
+    ids.add(scenario.id);
+  }
+}

--- a/tests/golden/workflow-corpus-runner.ts
+++ b/tests/golden/workflow-corpus-runner.ts
@@ -1,12 +1,26 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import { AgentVideoRuntime, type ContextRevision, type EditOperation, type ProjectSnapshot, type TimelineDiff, type WorkflowOperation } from "@framekit/runtime";
+import { InMemoryEditorAdapter, type InMemoryFixture } from "@framekit/testkit";
 
 export interface GoldenScenario {
   id: string;
   family: string;
   description: string;
-  [key: string]: unknown;
+  mode: "single" | "composite";
+  fixture: InMemoryFixture;
+  operation?: EditOperation;
+  operations?: WorkflowOperation[];
+  expected: GoldenExpected;
+}
+
+export interface GoldenExpected {
+  before: ProjectSnapshot;
+  after: ProjectSnapshot;
+  diff: TimelineDiff;
+  afterRevision: ContextRevision;
+  undoRevision: ContextRevision;
 }
 
 export interface GoldenCorpus {
@@ -28,6 +42,29 @@ export async function runGoldenScenario(scenario: GoldenScenario): Promise<void>
   assert.match(scenario.id, /^(phase0|phase1)\./, `invalid golden scenario id: ${scenario.id}`);
   assert.ok(scenario.family.length > 0, `golden scenario ${scenario.id} has no family`);
   assert.ok(scenario.description.length > 0, `golden scenario ${scenario.id} has no description`);
+  const runtime = new AgentVideoRuntime(new InMemoryEditorAdapter(scenario.fixture));
+  const before = await runtime.inspectProject();
+  assert.deepEqual(before, scenario.expected.before, `${scenario.id}: before snapshot mismatch`);
+
+  let transaction;
+  if (scenario.mode === "single") {
+    assert.ok(scenario.operation, `${scenario.id}: single scenario has no operation`);
+    transaction = await runtime.edit(scenario.operation);
+  } else {
+    assert.ok(scenario.operations, `${scenario.id}: composite scenario has no operations`);
+    const preview = await runtime.previewEdit({ baseRevision: before.revision, operations: scenario.operations });
+    assert.deepEqual(preview.expectedDiff, scenario.expected.diff, `${scenario.id}: preview diff mismatch`);
+    transaction = await runtime.executeEdit(preview.previewToken);
+  }
+
+  assert.equal(transaction.status, "VERIFIED", `${scenario.id}: workflow was not verified`);
+  assert.deepEqual(transaction.after, scenario.expected.after, `${scenario.id}: after snapshot mismatch`);
+  assert.deepEqual(transaction.diff, scenario.expected.diff, `${scenario.id}: diff mismatch`);
+  assert.deepEqual(transaction.after.revision, scenario.expected.afterRevision, `${scenario.id}: after revision mismatch`);
+  assert.deepEqual(await runtime.inspectProject(), scenario.expected.after, `${scenario.id}: read-after-write mismatch`);
+
+  const undone = await runtime.undo(transaction.id);
+  assert.deepEqual(undone, { ...scenario.expected.before, revision: scenario.expected.undoRevision }, `${scenario.id}: undo snapshot mismatch`);
 }
 
 function assertCorpus(value: unknown): asserts value is GoldenCorpus {
@@ -44,6 +81,10 @@ function assertCorpus(value: unknown): asserts value is GoldenCorpus {
     assert.equal(typeof scenario.id, "string", "golden scenario id is required");
     assert.equal(typeof scenario.family, "string", `golden scenario ${scenario.id} family is required`);
     assert.equal(typeof scenario.description, "string", `golden scenario ${scenario.id} description is required`);
+    assert.ok(scenario.mode === "single" || scenario.mode === "composite", `golden scenario ${scenario.id} mode is invalid`);
+    assert.ok(scenario.fixture && typeof scenario.fixture === "object", `golden scenario ${scenario.id} fixture is required`);
+    assert.ok(scenario.operation || scenario.operations, `golden scenario ${scenario.id} operation is required`);
+    assert.ok(scenario.expected && typeof scenario.expected === "object", `golden scenario ${scenario.id} expected evidence is required`);
     assert.equal(ids.has(scenario.id), false, `duplicate golden scenario id: ${scenario.id}`);
     ids.add(scenario.id);
   }

--- a/tests/golden/workflow-corpus-runner.ts
+++ b/tests/golden/workflow-corpus-runner.ts
@@ -21,6 +21,8 @@ export interface GoldenExpected {
   diff: TimelineDiff;
   afterRevision: ContextRevision;
   undoRevision: ContextRevision;
+  rollbackRevision: ContextRevision;
+  staleErrorCode: string;
 }
 
 export interface GoldenCorpus {
@@ -42,8 +44,14 @@ export async function runGoldenScenario(scenario: GoldenScenario): Promise<void>
   assert.match(scenario.id, /^(phase0|phase1)\./, `invalid golden scenario id: ${scenario.id}`);
   assert.ok(scenario.family.length > 0, `golden scenario ${scenario.id} has no family`);
   assert.ok(scenario.description.length > 0, `golden scenario ${scenario.id} has no description`);
+  validateGoldenSnapshot(scenario.expected.before, scenario.id);
+  validateGoldenSnapshot(scenario.expected.after, scenario.id);
+  assert.deepEqual(scenario.expected.diff.from, scenario.expected.before.revision, `${scenario.id}: diff source revision mismatch`);
+  assert.deepEqual(scenario.expected.diff.to, scenario.expected.after.revision, `${scenario.id}: diff target revision mismatch`);
+
   const runtime = new AgentVideoRuntime(new InMemoryEditorAdapter(scenario.fixture));
   const before = await runtime.inspectProject();
+  validateGoldenSnapshot(before, scenario.id);
   assert.deepEqual(before, scenario.expected.before, `${scenario.id}: before snapshot mismatch`);
 
   let transaction;
@@ -58,6 +66,7 @@ export async function runGoldenScenario(scenario: GoldenScenario): Promise<void>
   }
 
   assert.equal(transaction.status, "VERIFIED", `${scenario.id}: workflow was not verified`);
+  validateGoldenSnapshot(transaction.after, scenario.id);
   assert.deepEqual(transaction.after, scenario.expected.after, `${scenario.id}: after snapshot mismatch`);
   assert.deepEqual(transaction.diff, scenario.expected.diff, `${scenario.id}: diff mismatch`);
   assert.deepEqual(transaction.after.revision, scenario.expected.afterRevision, `${scenario.id}: after revision mismatch`);
@@ -65,6 +74,77 @@ export async function runGoldenScenario(scenario: GoldenScenario): Promise<void>
 
   const undone = await runtime.undo(transaction.id);
   assert.deepEqual(undone, { ...scenario.expected.before, revision: scenario.expected.undoRevision }, `${scenario.id}: undo snapshot mismatch`);
+
+  const rollbackRuntime = new AgentVideoRuntime(new InMemoryEditorAdapter(scenario.fixture), {
+    verificationEngine: {
+      verify: async () => ({
+        passed: false,
+        checks: [{ name: "golden-forced-failure", passed: false, detail: "exercise rollback gate" }],
+      }),
+    },
+  });
+  let rollbackTransaction;
+  const rollbackBefore = await rollbackRuntime.inspectProject();
+  if (scenario.mode === "single") {
+    assert.ok(scenario.operation, `${scenario.id}: single scenario has no operation for rollback`);
+    rollbackTransaction = await rollbackRuntime.edit(scenario.operation);
+  } else {
+    assert.ok(scenario.operations, `${scenario.id}: composite scenario has no operations for rollback`);
+    const rollbackPreview = await rollbackRuntime.previewEdit({
+      baseRevision: rollbackBefore.revision,
+      operations: scenario.operations,
+    });
+    rollbackTransaction = await rollbackRuntime.executeEdit(rollbackPreview.previewToken);
+  }
+  assert.equal(rollbackTransaction.status, "ROLLED_BACK", `${scenario.id}: failed verification did not roll back`);
+  const rollbackExpected = { ...scenario.expected.before, revision: scenario.expected.rollbackRevision };
+  assert.deepEqual(rollbackTransaction.after, rollbackExpected, `${scenario.id}: rollback snapshot mismatch`);
+  assert.deepEqual(await rollbackRuntime.inspectProject(), rollbackExpected, `${scenario.id}: rollback read mismatch`);
+
+  const staleRuntime = new AgentVideoRuntime(new InMemoryEditorAdapter(scenario.fixture));
+  const staleBase = await staleRuntime.inspectProject();
+  if (scenario.mode === "single") {
+    assert.ok(scenario.operation, `${scenario.id}: single scenario has no operation for stale-write check`);
+    await staleRuntime.edit(scenario.operation);
+    await assert.rejects(
+      staleRuntime.edit({ ...scenario.operation, baseRevision: staleBase.revision }),
+      new RegExp(scenario.expected.staleErrorCode),
+    );
+  } else {
+    assert.ok(scenario.operations, `${scenario.id}: composite scenario has no operations for stale-write check`);
+    const stalePreview = await staleRuntime.previewEdit({ baseRevision: staleBase.revision, operations: scenario.operations });
+    await staleRuntime.executeEdit(stalePreview.previewToken);
+    await assert.rejects(
+      staleRuntime.previewEdit({ baseRevision: staleBase.revision, operations: scenario.operations }),
+      new RegExp(scenario.expected.staleErrorCode),
+    );
+  }
+  assert.deepEqual(await staleRuntime.inspectProject(), scenario.expected.after, `${scenario.id}: stale write mutated state`);
+}
+
+export function validateGoldenSnapshot(snapshot: ProjectSnapshot, scenarioId: string): void {
+  const label = `${scenarioId}: snapshot`;
+  assert.equal(typeof snapshot.projectId, "string", `${label} project identity is required`);
+  assert.equal(typeof snapshot.timeline?.id, "string", `${label} timeline identity is required`);
+  assert.ok(Array.isArray(snapshot.timeline?.clips), `${label} clips are required`);
+  assert.ok(Array.isArray(snapshot.timeline?.storyElements), `${label} story elements are required`);
+  assert.ok(Array.isArray(snapshot.timeline?.markers), `${label} markers are required`);
+  assert.ok(Array.isArray(snapshot.timeline?.captions), `${label} captions are required`);
+  assert.ok(Array.isArray(snapshot.media), `${label} media registry is required`);
+  assert.equal(typeof snapshot.revision?.id, "string", `${label} revision identity is required`);
+  assert.equal(Number.isInteger(snapshot.revision?.sequence), true, `${label} revision sequence is required`);
+  assertUniqueIds(snapshot.timeline.clips, `${label} clip`);
+  assertUniqueIds(snapshot.timeline.storyElements, `${label} story element`);
+  assertUniqueIds(snapshot.timeline.markers, `${label} marker`);
+  assertUniqueIds(snapshot.timeline.captions, `${label} caption`);
+  assertUniqueIds(snapshot.media, `${label} media` , (media) => media.mediaId);
+  const mediaIds = new Set(snapshot.media.map((media) => media.mediaId));
+  for (const clip of snapshot.timeline.clips) {
+    if (clip.mediaId) assert.equal(mediaIds.has(clip.mediaId), true, `${label} media reference ${clip.mediaId} is unresolved`);
+  }
+  for (const element of snapshot.timeline.storyElements) {
+    if (element.mediaId) assert.equal(mediaIds.has(element.mediaId), true, `${label} media reference ${element.mediaId} is unresolved`);
+  }
 }
 
 function assertCorpus(value: unknown): asserts value is GoldenCorpus {
@@ -85,7 +165,17 @@ function assertCorpus(value: unknown): asserts value is GoldenCorpus {
     assert.ok(scenario.fixture && typeof scenario.fixture === "object", `golden scenario ${scenario.id} fixture is required`);
     assert.ok(scenario.operation || scenario.operations, `golden scenario ${scenario.id} operation is required`);
     assert.ok(scenario.expected && typeof scenario.expected === "object", `golden scenario ${scenario.id} expected evidence is required`);
+    assert.ok(scenario.expected.before && typeof scenario.expected.before === "object", `golden scenario ${scenario.id} before snapshot is required`);
+    assert.ok(scenario.expected.after && typeof scenario.expected.after === "object", `golden scenario ${scenario.id} after snapshot is required`);
+    assert.ok(scenario.expected.diff && typeof scenario.expected.diff === "object", `golden scenario ${scenario.id} diff is required`);
+    assert.ok(scenario.expected.rollbackRevision && typeof scenario.expected.rollbackRevision === "object", `golden scenario ${scenario.id} rollback revision is required`);
+    assert.equal(scenario.expected.staleErrorCode, "STALE_CONTEXT", `golden scenario ${scenario.id} stale diagnostic is required`);
     assert.equal(ids.has(scenario.id), false, `duplicate golden scenario id: ${scenario.id}`);
     ids.add(scenario.id);
   }
+}
+
+function assertUniqueIds<T>(items: T[], label: string, idOf: (item: T) => string = (item) => (item as { id: string }).id): void {
+  const ids = items.map(idOf);
+  assert.equal(new Set(ids).size, ids.length, `${label} identities must be unique`);
 }

--- a/tests/golden/workflow-corpus-runner.ts
+++ b/tests/golden/workflow-corpus-runner.ts
@@ -168,16 +168,30 @@ function assertRationalTiming(items: TimedSnapshotItem[], label: string): void {
 
 function rationalMatchesNumber(time: RationalTime | undefined, seconds: number): boolean {
   if (!time || !Number.isFinite(seconds) || typeof time.value !== "string" || typeof time.timescale !== "string") return false;
-  const [whole, fraction = ""] = seconds.toString().split(".");
   try {
-    const numericValue = BigInt(`${whole}${fraction}`);
-    const numericScale = 10n ** BigInt(fraction.length);
     const value = BigInt(time.value);
     const timescale = BigInt(time.timescale);
-    return timescale > 0n && value * numericScale === numericValue * timescale;
+    if (timescale <= 0n) return false;
+    const numeric = numberAsRational(seconds);
+    const tolerance = Number.EPSILON * 8 * Math.max(1, Math.abs(seconds));
+    if (!Number.isFinite(tolerance)) return value * numeric.scale === numeric.value * timescale;
+    const toleranceRational = numberAsRational(tolerance);
+    const difference = (value * numeric.scale - numeric.value * timescale);
+    return (difference < 0n ? -difference : difference) * toleranceRational.scale
+      <= toleranceRational.value * timescale * numeric.scale;
   } catch {
     return false;
   }
+}
+
+function numberAsRational(value: number): { value: bigint; scale: bigint } {
+  const [coefficient, exponentText = "0"] = value.toString().toLowerCase().split("e");
+  const [whole, fraction = ""] = coefficient.split(".");
+  const exponent = BigInt(exponentText.replace(/^\+/, ""));
+  const coefficientValue = BigInt(`${whole}${fraction}`);
+  const decimalPlaces = BigInt(fraction.length) - exponent;
+  if (decimalPlaces >= 0n) return { value: coefficientValue, scale: 10n ** decimalPlaces };
+  return { value: coefficientValue * (10n ** -decimalPlaces), scale: 1n };
 }
 
 function assertCorpus(value: unknown): asserts value is GoldenCorpus {

--- a/tests/golden/workflow-corpus.test.ts
+++ b/tests/golden/workflow-corpus.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { loadGoldenCorpus, runGoldenScenario } from "./workflow-corpus-runner.js";
+import { loadGoldenCorpus, runGoldenScenario, validateGoldenSnapshot } from "./workflow-corpus-runner.js";
 
 const corpus = loadGoldenCorpus();
 
@@ -18,7 +18,20 @@ test("each golden scenario records fixture, operations, and expected evidence", 
     assert.ok((scenario.expected as { before?: unknown }).before, `golden scenario ${scenario.id} has no expected before snapshot`);
     assert.ok((scenario.expected as { after?: unknown }).after, `golden scenario ${scenario.id} has no expected after snapshot`);
     assert.ok((scenario.expected as { diff?: unknown }).diff, `golden scenario ${scenario.id} has no expected diff`);
+    assert.ok((scenario.expected as { rollbackRevision?: unknown }).rollbackRevision, `golden scenario ${scenario.id} has no rollback revision`);
+    assert.equal((scenario.expected as { staleErrorCode?: unknown }).staleErrorCode, "STALE_CONTEXT", `golden scenario ${scenario.id} has no stale-write diagnostic`);
   }
+});
+
+test("golden structural validation rejects unresolved media references", () => {
+  const scenario = corpus.scenarios.find((candidate) => candidate.mode === "single")!;
+  const invalid = structuredClone(scenario.expected.before);
+  invalid.timeline.clips[0]!.mediaId = "missing-media";
+
+  assert.throws(
+    () => validateGoldenSnapshot(invalid, scenario.id),
+    new RegExp(`${scenario.id}.*media reference`),
+  );
 });
 
 for (const scenario of corpus.scenarios) {

--- a/tests/golden/workflow-corpus.test.ts
+++ b/tests/golden/workflow-corpus.test.ts
@@ -34,6 +34,17 @@ test("golden structural validation rejects unresolved media references", () => {
   );
 });
 
+test("golden structural validation rejects inconsistent rational timing", () => {
+  const scenario = corpus.scenarios.find((candidate) => candidate.id === "phase1.ripple-delete")!;
+  const invalid = structuredClone(scenario.expected.before);
+  invalid.timeline.clips[0]!.durationTime = { value: "999", timescale: "1" };
+
+  assert.throws(
+    () => validateGoldenSnapshot(invalid, scenario.id),
+    new RegExp(`${scenario.id}.*durationTime disagrees with duration`),
+  );
+});
+
 for (const scenario of corpus.scenarios) {
   test(`golden workflow ${scenario.id} has zero silent corruption`, async () => {
     await runGoldenScenario(scenario);

--- a/tests/golden/workflow-corpus.test.ts
+++ b/tests/golden/workflow-corpus.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { loadGoldenCorpus, runGoldenScenario } from "./workflow-corpus-runner.js";
+
+const corpus = loadGoldenCorpus();
+
+test("golden corpus is versioned and covers the supported workflow families", () => {
+  assert.equal(corpus.schemaVersion, 1);
+  assert.ok(corpus.corpusVersion.length > 0);
+  assert.ok(corpus.scenarios.length >= 6);
+});
+
+for (const scenario of corpus.scenarios) {
+  test(`golden workflow ${scenario.id} has zero silent corruption`, async () => {
+    await runGoldenScenario(scenario);
+  });
+}

--- a/tests/golden/workflow-corpus.test.ts
+++ b/tests/golden/workflow-corpus.test.ts
@@ -15,6 +15,9 @@ test("each golden scenario records fixture, operations, and expected evidence", 
     assert.ok(scenario.fixture, `golden scenario ${scenario.id} has no fixture`);
     assert.ok(scenario.operation || scenario.operations, `golden scenario ${scenario.id} has no operation`);
     assert.ok(scenario.expected, `golden scenario ${scenario.id} has no expected evidence`);
+    assert.ok((scenario.expected as { before?: unknown }).before, `golden scenario ${scenario.id} has no expected before snapshot`);
+    assert.ok((scenario.expected as { after?: unknown }).after, `golden scenario ${scenario.id} has no expected after snapshot`);
+    assert.ok((scenario.expected as { diff?: unknown }).diff, `golden scenario ${scenario.id} has no expected diff`);
   }
 });
 

--- a/tests/golden/workflow-corpus.test.ts
+++ b/tests/golden/workflow-corpus.test.ts
@@ -45,6 +45,17 @@ test("golden structural validation rejects inconsistent rational timing", () => 
   );
 });
 
+test("golden structural validation accepts equivalent non-terminating rational timing", () => {
+  const scenario = corpus.scenarios.find((candidate) => candidate.id === "phase1.ripple-delete")!;
+  const valid = structuredClone(scenario.expected.before);
+  valid.timeline.clips[0]!.start = 1 / 3;
+  valid.timeline.clips[0]!.startTime = { value: "1", timescale: "3" };
+  valid.timeline.storyElements[0]!.start = 1 / 3;
+  valid.timeline.storyElements[0]!.startTime = { value: "1", timescale: "3" };
+
+  assert.doesNotThrow(() => validateGoldenSnapshot(valid, scenario.id));
+});
+
 for (const scenario of corpus.scenarios) {
   test(`golden workflow ${scenario.id} has zero silent corruption`, async () => {
     await runGoldenScenario(scenario);

--- a/tests/golden/workflow-corpus.test.ts
+++ b/tests/golden/workflow-corpus.test.ts
@@ -10,6 +10,14 @@ test("golden corpus is versioned and covers the supported workflow families", ()
   assert.ok(corpus.scenarios.length >= 6);
 });
 
+test("each golden scenario records fixture, operations, and expected evidence", () => {
+  for (const scenario of corpus.scenarios) {
+    assert.ok(scenario.fixture, `golden scenario ${scenario.id} has no fixture`);
+    assert.ok(scenario.operation || scenario.operations, `golden scenario ${scenario.id} has no operation`);
+    assert.ok(scenario.expected, `golden scenario ${scenario.id} has no expected evidence`);
+  }
+});
+
 for (const scenario of corpus.scenarios) {
   test(`golden workflow ${scenario.id} has zero silent corruption`, async () => {
     await runGoldenScenario(scenario);

--- a/tests/integration/golden-corpus-ci.test.ts
+++ b/tests/integration/golden-corpus-ci.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import test from "node:test";
+
+test("the CI test command runs the versioned golden workflow corpus", async () => {
+  const packageJson = JSON.parse(await readFile(resolve("package.json"), "utf8")) as {
+    scripts?: { test?: string };
+  };
+  const documentation = await readFile(resolve("docs/tests/golden-corpus.md"), "utf8").catch(() => "");
+
+  assert.match(packageJson.scripts?.test ?? "", /tests\/golden\/\*\.test\.ts/);
+  assert.match(documentation, /pnpm run test:golden/);
+  assert.match(documentation, /zero silent corruption/);
+});


### PR DESCRIPTION
Closes #66

## Summary

- Added a versioned six-scenario golden corpus for supported Phase 0/1 workflows.
- Checked in independent before/after snapshots, exact diffs, rational timing, media references, captions, markers, story elements, and revisions.
- Added structural validation plus read-after-write, undo, forced rollback, and stale-write corruption gates with scenario-labeled diagnostics.
- Added `test:golden`, included the corpus in `pnpm test`, and documented the native Final Cut boundary.

## TDD sequence

- Red: missing corpus runner module.
- Green: versioned manifest and scenario registry.
- Red: missing fixture and expected evidence.
- Green: deterministic fixtures, caption retention, snapshots, and diffs.
- Red: missing structural, rollback, and stale-write evidence.
- Green: zero-corruption runner and CI wiring.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm run test` — 173 passed
- `pnpm run test:golden` — 9 passed
- `pnpm run check:boundaries` — passed

No native files changed; native Final Cut validation remains separately documented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a versioned golden workflow corpus covering clip edits, gain changes, ripple deletion, marker insertion, and composite media/title workflows.
  - Added deterministic validation for project states, diffs, undo/rollback behavior, stale-write handling, and timing consistency.
  - Added caption support to in-memory editing fixtures, including ripple-delete updates.

- **Tests**
  - Golden tests now run with the standard test command, with a dedicated command available.

- **Documentation**
  - Added guidance on running the golden corpus, covered scenarios, validation rules, and CI usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->