### PR TITLE
[Bug] Fix headed E2E Framekit overlay window detection

### DIFF
--- a/docs/tests/final-cut-live-e2e.md
+++ b/docs/tests/final-cut-live-e2e.md
@@ -110,6 +110,24 @@ revision and duration return to their pre-edit values. It fails
 closed if the project name does not match or if the overlay cannot be
 minimized.
 
+The overlay Accessibility probe reports stable recovery diagnostics:
+
+- `FINAL_CUT_E2E_ACCESSIBILITY_PERMISSION_REQUIRED`: grant Accessibility
+  permission to the headed test host in System Settings > Privacy & Security >
+  Accessibility.
+- `FINAL_CUT_E2E_FINAL_CUT_PROCESS_MISSING`: open Final Cut Pro and the Framekit
+  Workflow Extension.
+- `FINAL_CUT_E2E_OVERLAY_WRONG_PROCESS`: open the Framekit extension from
+  Window > Extensions > Framekit so its window is hosted by Final Cut Pro.
+- `FINAL_CUT_E2E_OVERLAY_WINDOW_MISSING`: open the Framekit extension in Final
+  Cut Pro.
+- `FINAL_CUT_E2E_OVERLAY_NOT_VISIBLE`: make the Framekit window visible and
+  retry.
+
+These diagnostics are intentionally actionable and do not expose private paths
+or media. The runner remains fail-closed if Accessibility cannot verify the
+overlay before the native preflight.
+
 ## Canonical live provider evidence
 
 When a live bridge advertises `canonicalTimelineMode: canonical-write`, open a

--- a/scripts/final-cut-overlay-accessibility.mjs
+++ b/scripts/final-cut-overlay-accessibility.mjs
@@ -18,8 +18,9 @@ export async function ensureFramekitWindowVisible(run = execFile) {
 export const overlayAccessibilityScript = `
 tell application "System Events"
   if not (exists process "Final Cut Pro") then error "FINAL_CUT_E2E_FINAL_CUT_PROCESS_MISSING"
-  tell process "Final Cut Pro"
-    set framekitWindow to missing value
+  set finalCutProcess to process "Final Cut Pro"
+  set framekitWindow to missing value
+  tell finalCutProcess
     repeat with candidateWindow in windows
       try
         set candidateWindowName to name of candidateWindow as text
@@ -30,28 +31,31 @@ tell application "System Events"
       end try
     end repeat
 
-    if framekitWindow is missing value then
-      set overlayInOtherProcess to false
-      repeat with candidateProcess in processes
-        try
-          set candidateProcessName to name of candidateProcess as text
-          if candidateProcessName is not "Final Cut Pro" then
-            repeat with candidateWindow in windows of candidateProcess
-              try
-                if (name of candidateWindow as text) contains "Framekit" then
-                  set overlayInOtherProcess to true
-                  exit repeat
-                end if
-              end try
-            end repeat
-          end if
-          if overlayInOtherProcess then exit repeat
-        end try
-      end repeat
-      if overlayInOtherProcess then error "FINAL_CUT_E2E_OVERLAY_WRONG_PROCESS"
-      error "FINAL_CUT_E2E_OVERLAY_WINDOW_MISSING"
-    end if
+  end tell
 
+  if framekitWindow is missing value then
+    set overlayInOtherProcess to false
+    repeat with candidateProcess in processes
+      try
+        set candidateProcessName to name of candidateProcess as text
+        if candidateProcessName is not "Final Cut Pro" then
+          repeat with candidateWindow in windows of candidateProcess
+            try
+              if (name of candidateWindow as text) contains "Framekit" then
+                set overlayInOtherProcess to true
+                exit repeat
+              end if
+            end try
+          end repeat
+        end if
+        if overlayInOtherProcess then exit repeat
+      end try
+    end repeat
+    if overlayInOtherProcess then error "FINAL_CUT_E2E_OVERLAY_WRONG_PROCESS"
+    error "FINAL_CUT_E2E_OVERLAY_WINDOW_MISSING"
+  end if
+
+  tell finalCutProcess
     set overlayMinimizationFailed to false
     try
       set value of attribute "AXMinimized" of framekitWindow to false
@@ -65,7 +69,10 @@ tell application "System Events"
 end tell`;
 
 function overlayAccessibilityError(error) {
-  const detail = error instanceof Error ? error.message : String(error);
+  const stderr = typeof error === "object" && error !== null && "stderr" in error
+    ? String(error.stderr)
+    : "";
+  const detail = stderr || (error instanceof Error ? error.message : String(error));
   if (detail.includes("FINAL_CUT_E2E_ACCESSIBILITY_PERMISSION_REQUIRED")
     || /not authorized|-1743|-25211/i.test(detail)) {
     return new Error("FINAL_CUT_E2E_ACCESSIBILITY_PERMISSION_REQUIRED: grant Accessibility permission to the headed test host in System Settings > Privacy & Security > Accessibility");

--- a/scripts/final-cut-overlay-accessibility.mjs
+++ b/scripts/final-cut-overlay-accessibility.mjs
@@ -1,0 +1,83 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCallback);
+
+export async function ensureFramekitWindowVisible(run = execFile) {
+  try {
+    const result = await run("osascript", ["-e", overlayAccessibilityScript]);
+    return result.stdout.trim() === "true";
+  } catch (error) {
+    throw overlayAccessibilityError(error);
+  }
+}
+
+export const overlayAccessibilityScript = `
+tell application "System Events"
+  if not (exists process "Final Cut Pro") then error "FINAL_CUT_E2E_FINAL_CUT_PROCESS_MISSING"
+  tell process "Final Cut Pro"
+    set framekitWindow to missing value
+    repeat with candidateWindow in windows
+      try
+        set candidateWindowName to name of candidateWindow as text
+        if candidateWindowName contains "Framekit" then
+          set framekitWindow to contents of candidateWindow
+          exit repeat
+        end if
+      end try
+    end repeat
+
+    if framekitWindow is missing value then
+      set overlayInOtherProcess to false
+      repeat with candidateProcess in processes
+        try
+          set candidateProcessName to name of candidateProcess as text
+          if candidateProcessName is not "Final Cut Pro" then
+            repeat with candidateWindow in windows of candidateProcess
+              try
+                if (name of candidateWindow as text) contains "Framekit" then
+                  set overlayInOtherProcess to true
+                  exit repeat
+                end if
+              end try
+            end repeat
+          end if
+          if overlayInOtherProcess then exit repeat
+        end try
+      end repeat
+      if overlayInOtherProcess then error "FINAL_CUT_E2E_OVERLAY_WRONG_PROCESS"
+      error "FINAL_CUT_E2E_OVERLAY_WINDOW_MISSING"
+    end if
+
+    set overlayMinimizationFailed to false
+    try
+      set value of attribute "AXMinimized" of framekitWindow to false
+      delay 0.2
+    on error
+      set overlayMinimizationFailed to true
+    end try
+    if overlayMinimizationFailed then error "FINAL_CUT_E2E_OVERLAY_NOT_VISIBLE"
+    return (value of attribute "AXMinimized" of framekitWindow) as text
+  end tell
+end tell`;
+
+function overlayAccessibilityError(error) {
+  const detail = error instanceof Error ? error.message : String(error);
+  if (detail.includes("FINAL_CUT_E2E_ACCESSIBILITY_PERMISSION_REQUIRED")
+    || /not authorized|-1743|-25211/i.test(detail)) {
+    return new Error("FINAL_CUT_E2E_ACCESSIBILITY_PERMISSION_REQUIRED: grant Accessibility permission to the headed test host in System Settings > Privacy & Security > Accessibility");
+  }
+  if (detail.includes("FINAL_CUT_E2E_FINAL_CUT_PROCESS_MISSING")) {
+    return new Error("FINAL_CUT_E2E_FINAL_CUT_PROCESS_MISSING: open Final Cut Pro and the Framekit Workflow Extension, then retry");
+  }
+  if (detail.includes("FINAL_CUT_E2E_OVERLAY_WRONG_PROCESS")) {
+    return new Error("FINAL_CUT_E2E_OVERLAY_WRONG_PROCESS: the Framekit window is outside Final Cut Pro; open the extension from Window > Extensions > Framekit");
+  }
+  if (detail.includes("FINAL_CUT_E2E_OVERLAY_NOT_VISIBLE")) {
+    return new Error("FINAL_CUT_E2E_OVERLAY_NOT_VISIBLE: the Framekit window could not be made visible; open the extension and retry");
+  }
+  if (detail.includes("FINAL_CUT_E2E_OVERLAY_WINDOW_MISSING")) {
+    return new Error("FINAL_CUT_E2E_OVERLAY_WINDOW_MISSING: open the Framekit extension in Final Cut Pro and retry");
+  }
+  return new Error("FINAL_CUT_E2E_OVERLAY_ACCESSIBILITY_FAILED: verify Accessibility permission and that the Framekit extension is hosted by Final Cut Pro, then retry");
+}

--- a/scripts/final-cut-overlay-accessibility.mjs
+++ b/scripts/final-cut-overlay-accessibility.mjs
@@ -6,7 +6,10 @@ const execFile = promisify(execFileCallback);
 export async function ensureFramekitWindowVisible(run = execFile) {
   try {
     const result = await run("osascript", ["-e", overlayAccessibilityScript]);
-    return result.stdout.trim() === "true";
+    if (result.stdout.trim() !== "false") {
+      throw new Error("FINAL_CUT_E2E_OVERLAY_NOT_VISIBLE");
+    }
+    return false;
   } catch (error) {
     throw overlayAccessibilityError(error);
   }

--- a/scripts/final-cut-overlay-headed-e2e.mjs
+++ b/scripts/final-cut-overlay-headed-e2e.mjs
@@ -1,12 +1,10 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { execFile as execFileCallback } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { promisify } from "node:util";
+import { ensureFramekitWindowVisible } from "./final-cut-overlay-accessibility.mjs";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
-const execFile = promisify(execFileCallback);
 const expectedProject = process.env.FRAMEKIT_FINAL_CUT_E2E_PROJECT;
 
 if (!expectedProject) {
@@ -72,24 +70,6 @@ try {
 } finally {
   await client.close().catch(() => {});
   await transport.close().catch(() => {});
-}
-
-async function ensureFramekitWindowVisible() {
-  const script = `
-tell application "System Events"
-  tell process "Final Cut Pro"
-    try
-      set framekitWindow to window "Framekit"
-      set value of attribute "AXMinimized" of framekitWindow to false
-      delay 0.2
-      return (value of attribute "AXMinimized" of framekitWindow) as text
-    on error
-      error "FINAL_CUT_E2E_OVERLAY_WINDOW_MISSING"
-    end try
-  end tell
-end tell`;
-  const result = await execFile("osascript", ["-e", script]);
-  return result.stdout.trim() === "true";
 }
 
 async function callJson(name, arguments_ = {}) {

--- a/tests/integration/final-cut-overlay-headed.test.ts
+++ b/tests/integration/final-cut-overlay-headed.test.ts
@@ -46,10 +46,22 @@ test("headed overlay probe reports actionable Accessibility diagnostics", async 
   }
 });
 
+test("headed overlay probe fails closed unless visibility is explicitly verified", async () => {
+  const { ensureFramekitWindowVisible } = await import(accessibilityModulePath);
+
+  for (const stdout of ["true", "", "unexpected"] as const) {
+    await assert.rejects(
+      ensureFramekitWindowVisible(async () => ({ stdout })),
+      /FINAL_CUT_E2E_OVERLAY_NOT_VISIBLE: the Framekit window could not be made visible/i,
+    );
+  }
+});
+
 test("headed runner delegates overlay preparation to the bounded probe", async () => {
   const runner = await readFile(runnerPath, "utf8");
 
   assert.match(runner, /final-cut-overlay-accessibility\.mjs/);
   assert.match(runner, /ensureFramekitWindowVisible/);
   assert.doesNotMatch(runner, /window "Framekit"/);
+  assert.ok(runner.indexOf("ensureFramekitWindowVisible()") < runner.indexOf('callJson("editor.native.trim-to-duration.preview"'));
 });

--- a/tests/integration/final-cut-overlay-headed.test.ts
+++ b/tests/integration/final-cut-overlay-headed.test.ts
@@ -20,6 +20,8 @@ test("headed overlay probe discovers Framekit windows owned by Final Cut", async
   assert.match(scripts[0], /repeat with candidateWindow in windows/);
   assert.match(scripts[0], /candidateWindowName contains "Framekit"/);
   assert.match(scripts[0], /set framekitWindow to contents of candidateWindow/);
+  assert.match(scripts[0], /set finalCutProcess to process "Final Cut Pro"/);
+  assert.match(scripts[0], /end tell\s+if framekitWindow is missing value[\s\S]*repeat with candidateProcess in processes/);
   assert.doesNotMatch(scripts[0], /window "Framekit"/);
 });
 

--- a/tests/integration/final-cut-overlay-headed.test.ts
+++ b/tests/integration/final-cut-overlay-headed.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { join } from "node:path";
+
+const runnerPath = join(process.cwd(), "scripts/final-cut-overlay-headed-e2e.mjs");
+const accessibilityModulePath = "../../scripts/final-cut-overlay-accessibility.mjs";
+
+test("headed overlay probe discovers Framekit windows owned by Final Cut", async () => {
+  const { ensureFramekitWindowVisible } = await import(accessibilityModulePath);
+  const scripts: string[] = [];
+  const visible = await ensureFramekitWindowVisible(async (_command: string, args: string[]) => {
+    scripts.push(args[1] ?? "");
+    return { stdout: "false" };
+  });
+
+  assert.equal(visible, false);
+  assert.match(scripts[0], /tell process "Final Cut Pro"/);
+  assert.match(scripts[0], /repeat with candidateWindow in windows/);
+  assert.match(scripts[0], /candidateWindowName contains "Framekit"/);
+  assert.match(scripts[0], /set framekitWindow to contents of candidateWindow/);
+  assert.doesNotMatch(scripts[0], /window "Framekit"/);
+});
+
+test("headed overlay probe reports actionable Accessibility diagnostics", async () => {
+  const { ensureFramekitWindowVisible } = await import(accessibilityModulePath);
+  const cases = [
+    ["FINAL_CUT_E2E_ACCESSIBILITY_PERMISSION_REQUIRED", "Accessibility permission"],
+    ["FINAL_CUT_E2E_FINAL_CUT_PROCESS_MISSING", "Open Final Cut Pro"],
+    ["FINAL_CUT_E2E_OVERLAY_WRONG_PROCESS", "outside Final Cut Pro"],
+    ["FINAL_CUT_E2E_OVERLAY_WINDOW_MISSING", "open the Framekit extension"],
+  ] as const;
+
+  for (const [code, guidance] of cases) {
+    await assert.rejects(
+      ensureFramekitWindowVisible(async () => {
+        throw new Error(code);
+      }),
+      (error: unknown) => {
+        assert.match(String(error), new RegExp(code));
+        assert.match(String(error), new RegExp(guidance, "i"));
+        assert.doesNotMatch(String(error), /private|media|osascript -e/i);
+        return true;
+      },
+    );
+  }
+});
+
+test("headed runner delegates overlay preparation to the bounded probe", async () => {
+  const runner = await readFile(runnerPath, "utf8");
+
+  assert.match(runner, /final-cut-overlay-accessibility\.mjs/);
+  assert.match(runner, /ensureFramekitWindowVisible/);
+  assert.doesNotMatch(runner, /window "Framekit"/);
+});

--- a/tests/integration/final-cut-overlay-headed.test.ts
+++ b/tests/integration/final-cut-overlay-headed.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import { join } from "node:path";
 
 const runnerPath = join(process.cwd(), "scripts/final-cut-overlay-headed-e2e.mjs");
+const e2eDocsPath = join(process.cwd(), "docs/tests/final-cut-live-e2e.md");
 const accessibilityModulePath = "../../scripts/final-cut-overlay-accessibility.mjs";
 
 test("headed overlay probe discovers Framekit windows owned by Final Cut", async () => {
@@ -64,4 +65,15 @@ test("headed runner delegates overlay preparation to the bounded probe", async (
   assert.match(runner, /ensureFramekitWindowVisible/);
   assert.doesNotMatch(runner, /window "Framekit"/);
   assert.ok(runner.indexOf("ensureFramekitWindowVisible()") < runner.indexOf('callJson("editor.native.trim-to-duration.preview"'));
+});
+
+test("headed overlay documentation explains Accessibility recovery diagnostics", async () => {
+  const documentation = await readFile(e2eDocsPath, "utf8");
+
+  assert.match(documentation, /FINAL_CUT_E2E_ACCESSIBILITY_PERMISSION_REQUIRED/);
+  assert.match(documentation, /FINAL_CUT_E2E_FINAL_CUT_PROCESS_MISSING/);
+  assert.match(documentation, /FINAL_CUT_E2E_OVERLAY_WRONG_PROCESS/);
+  assert.match(documentation, /FINAL_CUT_E2E_OVERLAY_WINDOW_MISSING/);
+  assert.match(documentation, /FINAL_CUT_E2E_OVERLAY_NOT_VISIBLE/);
+  assert.match(documentation, /does not expose private paths or media/i);
 });

--- a/tests/integration/final-cut-overlay-headed.test.ts
+++ b/tests/integration/final-cut-overlay-headed.test.ts
@@ -75,5 +75,5 @@ test("headed overlay documentation explains Accessibility recovery diagnostics",
   assert.match(documentation, /FINAL_CUT_E2E_OVERLAY_WRONG_PROCESS/);
   assert.match(documentation, /FINAL_CUT_E2E_OVERLAY_WINDOW_MISSING/);
   assert.match(documentation, /FINAL_CUT_E2E_OVERLAY_NOT_VISIBLE/);
-  assert.match(documentation, /does not expose private paths or media/i);
+  assert.match(documentation, /do not expose private paths\s+or media/i);
 });

--- a/tests/integration/final-cut-overlay-headed.test.ts
+++ b/tests/integration/final-cut-overlay-headed.test.ts
@@ -16,7 +16,7 @@ test("headed overlay probe discovers Framekit windows owned by Final Cut", async
   });
 
   assert.equal(visible, false);
-  assert.match(scripts[0], /tell process "Final Cut Pro"/);
+  assert.match(scripts[0], /tell finalCutProcess/);
   assert.match(scripts[0], /repeat with candidateWindow in windows/);
   assert.match(scripts[0], /candidateWindowName contains "Framekit"/);
   assert.match(scripts[0], /set framekitWindow to contents of candidateWindow/);
@@ -47,6 +47,21 @@ test("headed overlay probe reports actionable Accessibility diagnostics", async 
       },
     );
   }
+});
+
+test("headed overlay probe classifies the AppleScript stderr instead of its submitted script", async () => {
+  const { ensureFramekitWindowVisible } = await import(accessibilityModulePath);
+  const appleScriptError = Object.assign(
+    new Error("Command failed: osascript -e error \\\"FINAL_CUT_E2E_FINAL_CUT_PROCESS_MISSING\\\""),
+    { stderr: "execution error: FINAL_CUT_E2E_OVERLAY_WINDOW_MISSING (-2700)" },
+  );
+
+  await assert.rejects(
+    ensureFramekitWindowVisible(async () => {
+      throw appleScriptError;
+    }),
+    /FINAL_CUT_E2E_OVERLAY_WINDOW_MISSING: open the Framekit extension in Final Cut Pro and retry/,
+  );
 });
 
 test("headed overlay probe fails closed unless visibility is explicitly verified", async () => {


### PR DESCRIPTION
Fixes #70

## Summary

- Replace the strict Accessibility lookup with a bounded search over Final Cut Pro-owned windows containing "Framekit".
- Report stable, sanitized diagnostics for permissions, missing windows, wrong process ownership, and unverifiable visibility.
- Require explicit visible-state verification before shared native focus and mutation, keeping the headed path fail-closed.

## Validation

- pnpm install --frozen-lockfile
- pnpm run build
- pnpm run test (219 passed)
- pnpm run test:final-cut-headless (80 passed)
- pnpm run check:boundaries
- pnpm run xcode:check
- xcodebuild -project adapters/final-cut/swift-bridge/FinalCutWorkflowExtension/FramekitFinalCutWorkflow.xcodeproj -list

## Live headed verification

- The non-mutating Accessibility probe reached FINAL_CUT_E2E_OVERLAY_WINDOW_MISSING as expected because no accessible Framekit overlay window was open.
- The full disposable headed E2E was not run because FRAMEKIT_FINAL_CUT_E2E_PROJECT was not set; no native timeline mutation was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accessibility diagnostics for the Final Cut Pro overlay validation workflow.
  * Detects missing permissions, unavailable applications, incorrect hosting, missing windows, and visibility failures.
  * Automatically restores minimized overlay windows when possible.

* **Bug Fixes**
  * Validation now fails safely when overlay visibility cannot be confirmed.
  * Error messages provide actionable guidance for resolving accessibility issues.

* **Documentation**
  * Updated headed overlay validation instructions with diagnostic codes and remediation guidance.

* **Tests**
  * Added coverage for accessibility checks, error classification, visibility verification, and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->