### PR TITLE
[Feature] Expose a canonical timeline snapshot for the open Final Cut project

### DIFF
--- a/adapters/final-cut/typescript/src/fcpxml.ts
+++ b/adapters/final-cut/typescript/src/fcpxml.ts
@@ -394,7 +394,11 @@ function timelineEntries(spine: XmlNode): TimelineEntry[] {
   const visit = (node: XmlNode, parentStart: RationalTime, parentPath: string): void => {
     storyEntries(node).forEach(({ kind, node: child }, index) => {
       const path = parentPath.length === 0 ? String(index) : `${parentPath}.${index}`;
-      const localStart = parseRational(attribute(child, "offset") ?? attribute(child, "start") ?? "0s");
+      const localStart = parseRational(
+        attribute(child, "offset")
+          ?? ((kind === "marker" || kind === "caption") ? attribute(child, "start") : undefined)
+          ?? "0s",
+      );
       const durationTime = parseRational(attribute(child, "duration") ?? "0s");
       const startTime = addRational(parentStart, localStart);
       if (TIMELINE_KINDS.has(kind)) {

--- a/adapters/final-cut/typescript/src/fcpxml.ts
+++ b/adapters/final-cut/typescript/src/fcpxml.ts
@@ -23,8 +23,25 @@ import type {
 
 type XmlNode = Record<string, any>;
 type OrderedXml = XmlNode[];
+type TimelineEntry = {
+  kind: string;
+  node: XmlNode;
+  path: string;
+  startTime: RationalTime;
+  durationTime: RationalTime;
+};
 
-const CLIP_KINDS = new Set(["asset-clip", "clip", "ref-clip", "sync-clip", "audio", "video"]);
+const CLIP_KINDS = new Set(["asset-clip", "clip", "ref-clip", "sync-clip", "mc-clip", "audio", "video"]);
+const TIMELINE_KINDS = new Set([
+  ...CLIP_KINDS,
+  "gap",
+  "title",
+  "transition",
+  "caption",
+  "marker",
+  "audition",
+  "live-drawing",
+]);
 
 /**
  * FCPXML document interchange adapter. It edits the artifact on disk; it does
@@ -93,15 +110,14 @@ export class FcpxmlDocumentAdapter implements EditorPort {
     const projectId = stableProjectId(project);
     const sequenceName = String(attribute(sequenceNode ?? {}, "name") ?? projectName);
     const timelineId = stableTimelineId(project, sequenceNode);
-    const elements = storyEntries(spine);
+    const elements = timelineEntries(spine);
     const storyElements = elements
-      .map(({ kind, node }, index) => ({ kind, element: this.storyElementFromXml(node, kind, index, timelineId) }))
+      .map((entry) => ({ kind: entry.kind, element: this.storyElementFromXml(entry, timelineId) }))
       .filter(({ kind }) => kind !== "marker" && kind !== "caption")
       .map(({ element }) => element);
     const clips = elements
-      .map(({ kind, node }, index) => ({ kind, node, index }))
       .filter(({ kind }) => CLIP_KINDS.has(kind))
-      .map(({ kind, node, index }) => this.clipFromXml(node, kind, index, timelineId));
+      .map((entry) => this.clipFromXml(entry, timelineId));
     const durationValue = attribute(sequence, "duration")
       ?? formatSeconds(Math.max(0, ...storyElements.map((element) => element.start + element.duration)));
     return {
@@ -114,8 +130,8 @@ export class FcpxmlDocumentAdapter implements EditorPort {
         durationTime: parseRational(durationValue),
         clips,
         storyElements,
-        markers: this.markersFromXml(spine),
-        captions: this.captionsFromXml(spine),
+        markers: this.markersFromXml(elements),
+        captions: this.captionsFromXml(elements),
       },
       media: this.mediaFromResources(),
       revision: this.revision(),
@@ -244,48 +260,45 @@ export class FcpxmlDocumentAdapter implements EditorPort {
     return findElement(this.xml ?? [], "project") ?? {};
   }
 
-  private storyElementFromXml(node: XmlNode, kind: string, index: number, timelineId: string): StoryElement {
-    const startValue = attribute(node, "offset") ?? attribute(node, "start") ?? "0s";
-    const durationValue = attribute(node, "duration") ?? "0s";
+  private storyElementFromXml(entry: TimelineEntry, timelineId: string): StoryElement {
+    const { node, kind, path, startTime, durationTime } = entry;
     return {
-      id: this.instanceId(node, kind, index, timelineId),
+      id: this.instanceId(node, kind, path, timelineId),
       kind,
-      start: parseSeconds(startValue),
-      duration: parseSeconds(durationValue),
-      startTime: parseRational(startValue),
-      durationTime: parseRational(durationValue),
+      start: rationalSeconds(startTime),
+      duration: rationalSeconds(durationTime),
+      startTime,
+      durationTime,
       ...(attribute(node, "lane") !== undefined ? { lane: Number(attribute(node, "lane")) } : {}),
       ...(attribute(node, "ref") !== undefined ? { mediaId: String(attribute(node, "ref")) } : {}),
     };
   }
 
-  private clipFromXml(node: XmlNode, kind: string, index: number, timelineId: string): Clip {
-    const startValue = attribute(node, "offset") ?? attribute(node, "start") ?? "0s";
-    const durationValue = attribute(node, "duration") ?? "0s";
+  private clipFromXml(entry: TimelineEntry, timelineId: string): Clip {
+    const { node, kind, path, startTime, durationTime } = entry;
     const gain = firstChild(node, "adjust-volume");
     return {
-      id: this.instanceId(node, kind, index, timelineId),
+      id: this.instanceId(node, kind, path, timelineId),
       mediaId: attribute(node, "ref") === undefined ? undefined : String(attribute(node, "ref")),
-      name: String(attribute(node, "name") ?? attribute(node, "ref") ?? `Clip ${index + 1}`),
-      start: parseSeconds(startValue),
-      duration: parseSeconds(durationValue),
+      name: String(attribute(node, "name") ?? attribute(node, "ref") ?? `Clip ${path.includes(".") ? path : path + 1}`),
+      start: rationalSeconds(startTime),
+      duration: rationalSeconds(durationTime),
       track: Number(attribute(node, "lane") ?? 0),
-      startTime: parseRational(startValue),
-      durationTime: parseRational(durationValue),
+      startTime,
+      durationTime,
       ...(gain ? { gainDb: parseDb(attribute(gain, "amount") ?? "0dB") } : {}),
     };
   }
 
-  private instanceId(node: XmlNode, kind: string, index: number, timelineId: string): string {
+  private instanceId(node: XmlNode, kind: string, path: string, timelineId: string): string {
     const explicit = attribute(node, "id") ?? attribute(node, "uid");
-    return String(explicit ?? `${timelineId}:spine:${index}:${kind}`);
+    return String(explicit ?? `${timelineId}:spine:${path}:${kind}`);
   }
 
   private findClipNode(spine: XmlNode, clipId: string, timelineId: string): XmlNode | undefined {
-    return storyEntries(spine)
-      .map(({ kind, node }, index) => ({ kind, node, index }))
+    return timelineEntries(spine)
       .filter(({ kind }) => CLIP_KINDS.has(kind))
-      .find(({ kind, node, index }) => this.instanceId(node, kind, index, timelineId) === clipId)
+      .find(({ kind, node, path }) => this.instanceId(node, kind, path, timelineId) === clipId)
       ?.node;
   }
 
@@ -298,44 +311,40 @@ export class FcpxmlDocumentAdapter implements EditorPort {
     appendChild(node, "adjust-volume", { ":@": { "@_amount": formatDb(gainDb) } });
   }
 
-  private markersFromXml(spine: XmlNode): Marker[] {
-    return storyEntries(spine)
+  private markersFromXml(elements: TimelineEntry[]): Marker[] {
+    return elements
       .filter(({ kind }) => kind === "marker")
-      .map(({ node }, index) => {
-        const start = attribute(node, "start") ?? "0s";
-        const duration = attribute(node, "duration") ?? "0s";
+      .map(({ node, startTime, durationTime }, index) => {
         return {
           id: String(attribute(node, "id") ?? `marker-${index + 1}`),
-          start: parseSeconds(start),
-          duration: parseSeconds(duration),
-          startTime: parseRational(start),
-          durationTime: parseRational(duration),
+          start: rationalSeconds(startTime),
+          duration: rationalSeconds(durationTime),
+          startTime,
+          durationTime,
           name: String(attribute(node, "value") ?? attribute(node, "name") ?? `Marker ${index + 1}`),
         };
       });
   }
 
-  private captionsFromXml(spine: XmlNode): Caption[] {
-    return storyEntries(spine)
+  private captionsFromXml(elements: TimelineEntry[]): Caption[] {
+    return elements
       .filter(({ kind }) => kind === "caption")
-      .map(({ node }, index) => {
-        const start = attribute(node, "start") ?? "0s";
-        const duration = attribute(node, "duration") ?? "0s";
+      .map(({ node, startTime, durationTime }, index) => {
         return {
           id: String(attribute(node, "id") ?? `caption-${index + 1}`),
-          start: parseSeconds(start),
-          duration: parseSeconds(duration),
-          startTime: parseRational(start),
-          durationTime: parseRational(duration),
+          start: rationalSeconds(startTime),
+          duration: rationalSeconds(durationTime),
+          startTime,
+          durationTime,
           text: String(attribute(node, "text") ?? attribute(node, "name") ?? ""),
         };
       });
   }
 
   private updateSequenceDuration(sequence: XmlNode, spine: XmlNode): void {
-    const duration = Math.max(0, ...storyEntries(spine)
+    const duration = Math.max(0, ...timelineEntries(spine)
       .filter(({ kind }) => kind !== "marker" && kind !== "caption")
-      .map(({ node }) => parseSeconds(attribute(node, "offset") ?? attribute(node, "start") ?? "0s") + parseSeconds(attribute(node, "duration") ?? "0s")));
+      .map(({ startTime, durationTime }) => rationalSeconds(startTime) + rationalSeconds(durationTime)));
     setAttribute(sequence, "duration", formatSeconds(duration));
   }
 
@@ -379,6 +388,26 @@ function storyEntries(node: XmlNode): Array<{ kind: string; node: XmlNode }> {
       : []);
 }
 
+function timelineEntries(spine: XmlNode): TimelineEntry[] {
+  const entries: TimelineEntry[] = [];
+
+  const visit = (node: XmlNode, parentStart: RationalTime, parentPath: string): void => {
+    storyEntries(node).forEach(({ kind, node: child }, index) => {
+      const path = parentPath.length === 0 ? String(index) : `${parentPath}.${index}`;
+      const localStart = parseRational(attribute(child, "offset") ?? attribute(child, "start") ?? "0s");
+      const durationTime = parseRational(attribute(child, "duration") ?? "0s");
+      const startTime = addRational(parentStart, localStart);
+      if (TIMELINE_KINDS.has(kind)) {
+        entries.push({ kind, node: child, path, startTime, durationTime });
+      }
+      visit(child, startTime, path);
+    });
+  };
+
+  visit(spine, { value: "0", timescale: "1" }, "");
+  return entries;
+}
+
 function findElement(nodes: OrderedXml | XmlNode, kind: string): XmlNode | undefined {
   const containers = Array.isArray(nodes) ? nodes : [nodes];
   for (const container of containers) {
@@ -420,12 +449,7 @@ function setAttribute(node: XmlNode, name: string, value: string): void {
 }
 
 function parseSeconds(value: unknown): number {
-  const normalized = String(value).replace(/s$/, "");
-  if (normalized.includes("/")) {
-    const [numerator, denominator] = normalized.split("/").map(Number);
-    return denominator === 0 ? 0 : numerator / denominator;
-  }
-  return Number(normalized) || 0;
+  return rationalSeconds(parseRational(value));
 }
 
 function parseDb(value: unknown): number {
@@ -433,9 +457,53 @@ function parseDb(value: unknown): number {
 }
 
 function parseRational(value: unknown): RationalTime {
+  return rationalTime(rationalParts(value));
+}
+
+function rationalSeconds(value: RationalTime): number {
+  const seconds = Number(value.value) / Number(value.timescale);
+  if (!Number.isFinite(seconds)) throw new Error("FCPXML_INVALID_TIME: rational time is not finite");
+  return seconds;
+}
+
+function rationalParts(value: unknown): { numerator: bigint; denominator: bigint } {
   const normalized = String(value).replace(/s$/, "");
-  const [numerator, denominator = "1"] = normalized.split("/");
-  return { value: numerator, timescale: denominator };
+  const parts = normalized.split("/");
+  if (parts.length > 2) throw new Error(`FCPXML_INVALID_TIME: ${String(value)}`);
+  const [numeratorText, denominatorText = "1"] = parts;
+  if (!/^-?\d+$/.test(numeratorText) || !/^\d+$/.test(denominatorText)) {
+    throw new Error(`FCPXML_INVALID_TIME: ${String(value)}`);
+  }
+  const numerator = BigInt(numeratorText);
+  const denominator = BigInt(denominatorText);
+  if (denominator <= 0n) throw new Error(`FCPXML_INVALID_TIME: ${String(value)}`);
+  return { numerator, denominator };
+}
+
+function rationalTime(parts: { numerator: bigint; denominator: bigint }): RationalTime {
+  const divisor = greatestCommonDivisor(parts.numerator, parts.denominator);
+  return {
+    value: String(parts.numerator / divisor),
+    timescale: String(parts.denominator / divisor),
+  };
+}
+
+function addRational(left: RationalTime, right: RationalTime): RationalTime {
+  return rationalTime({
+    numerator: BigInt(left.value) * BigInt(right.timescale) + BigInt(right.value) * BigInt(left.timescale),
+    denominator: BigInt(left.timescale) * BigInt(right.timescale),
+  });
+}
+
+function greatestCommonDivisor(left: bigint, right: bigint): bigint {
+  let a = left < 0n ? -left : left;
+  let b = right < 0n ? -right : right;
+  while (b !== 0n) {
+    const remainder = a % b;
+    a = b;
+    b = remainder;
+  }
+  return a === 0n ? 1n : a;
 }
 
 function formatRational(value: RationalTime): string {

--- a/adapters/final-cut/typescript/src/live.ts
+++ b/adapters/final-cut/typescript/src/live.ts
@@ -14,6 +14,7 @@ import type {
   ProjectCatalog,
   ProjectSnapshot,
   ProjectSelection,
+  RationalTime,
 } from "@framekit/runtime";
 
 export const FINAL_CUT_LIVE_PROTOCOL_VERSION = 1;
@@ -258,17 +259,45 @@ function validateCanonicalSnapshot(snapshot: ProjectSnapshot): void {
   requireArray(snapshot.media, "media references");
   validateRevision(snapshot.revision, "revision");
 
+  for (const media of snapshot.media) {
+    requireRecord(media, "media");
+    requireNonEmpty(media.mediaId, "media id");
+    requireNonEmpty(media.source, `media ${media.mediaId} source`);
+    if (media.duration !== undefined) requireFiniteNonNegative(media.duration, `media ${media.mediaId} duration`);
+  }
   const mediaIds = uniqueIds(snapshot.media, ({ mediaId }) => mediaId, "media");
   uniqueIds(snapshot.timeline.markers, ({ id }) => id, "marker");
   uniqueIds(snapshot.timeline.captions, ({ id }) => id, "caption");
   const occurrenceIds = uniqueIds(snapshot.timeline.clips, ({ id }) => id, "timeline occurrence");
   const storyElementIds = uniqueIds(snapshot.timeline.storyElements, ({ id }) => id, "story element");
+  const timelineDuration = rationalSeconds(snapshot.timeline.durationTime, "timeline duration time");
+  assertMatchingSeconds(snapshot.timeline.duration, timelineDuration, "timeline duration");
+  for (const storyElement of snapshot.timeline.storyElements) {
+    validateCanonicalCoordinates(storyElement, `story element ${storyElement.id}`);
+    if (storyElement.lane !== undefined && !Number.isInteger(storyElement.lane)) {
+      protocolError(`story element ${storyElement.id} lane must be an integer`);
+    }
+    if (storyElement.mediaId && !mediaIds.has(storyElement.mediaId)) {
+      protocolError(`story element ${storyElement.id} references missing media ${storyElement.mediaId}`);
+    }
+  }
+  for (const marker of snapshot.timeline.markers) {
+    validateCanonicalCoordinates(marker, `marker ${marker.id}`);
+    requireNonEmpty(marker.name, `marker ${marker.id} name`);
+  }
+  for (const caption of snapshot.timeline.captions) {
+    validateCanonicalCoordinates(caption, `caption ${caption.id}`);
+    if (typeof caption.text !== "string") protocolError(`caption ${caption.id} text must be a string`);
+  }
   for (const clip of snapshot.timeline.clips) {
-    requireFiniteNonNegative(clip.start, `occurrence ${clip.id} start`);
-    requireFiniteNonNegative(clip.duration, `occurrence ${clip.id} duration`);
+    requireNonEmpty(clip.name, `occurrence ${clip.id} name`);
+    validateCanonicalCoordinates(clip, `occurrence ${clip.id}`);
     if (!Number.isInteger(clip.track)) protocolError(`occurrence ${clip.id} track must be an integer`);
-    requireRational(clip.startTime, `occurrence ${clip.id} start time`);
-    requireRational(clip.durationTime, `occurrence ${clip.id} duration time`);
+    const storyElement = snapshot.timeline.storyElements.find(({ id }) => id === clip.id);
+    if (!storyElement) protocolError(`occurrence ${clip.id} has no storyline relationship`);
+    if (storyElement && (storyElement.start !== clip.start || storyElement.duration !== clip.duration)) {
+      protocolError(`occurrence ${clip.id} does not match its storyline coordinates`);
+    }
     if (clip.mediaId && !mediaIds.has(clip.mediaId)) {
       protocolError(`occurrence ${clip.id} references missing media ${clip.mediaId}`);
     }
@@ -409,6 +438,30 @@ function requireNonEmpty(value: unknown, field: string): asserts value is string
 function requireFiniteNonNegative(value: unknown, field: string): asserts value is number {
   if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
     protocolError(`${field} must be finite and non-negative`);
+  }
+}
+
+function validateCanonicalCoordinates(
+  value: { start: number; duration: number; startTime?: RationalTime; durationTime?: RationalTime },
+  field: string,
+): void {
+  requireFiniteNonNegative(value.start, `${field} start`);
+  requireFiniteNonNegative(value.duration, `${field} duration`);
+  assertMatchingSeconds(value.start, rationalSeconds(value.startTime, `${field} start time`), `${field} start`);
+  assertMatchingSeconds(value.duration, rationalSeconds(value.durationTime, `${field} duration time`), `${field} duration`);
+}
+
+function rationalSeconds(value: unknown, field: string): number {
+  const candidate = value as { value?: unknown; timescale?: unknown } | undefined;
+  requireRational(candidate, field);
+  const seconds = Number(candidate!.value) / Number(candidate!.timescale);
+  if (!Number.isFinite(seconds)) protocolError(`${field} must represent a finite time`);
+  return seconds;
+}
+
+function assertMatchingSeconds(actual: number, expected: number, field: string): void {
+  if (Math.abs(actual - expected) > Math.max(1e-9, Math.abs(actual) * 1e-12)) {
+    protocolError(`${field} time does not match seconds`);
   }
 }
 

--- a/adapters/final-cut/typescript/src/live.ts
+++ b/adapters/final-cut/typescript/src/live.ts
@@ -273,6 +273,7 @@ function validateCanonicalSnapshot(snapshot: ProjectSnapshot): void {
   const timelineDuration = rationalSeconds(snapshot.timeline.durationTime, "timeline duration time");
   assertMatchingSeconds(snapshot.timeline.duration, timelineDuration, "timeline duration");
   for (const storyElement of snapshot.timeline.storyElements) {
+    requireNonEmpty(storyElement.kind, `story element ${storyElement.id} kind`);
     validateCanonicalCoordinates(storyElement, `story element ${storyElement.id}`);
     if (storyElement.lane !== undefined && !Number.isInteger(storyElement.lane)) {
       protocolError(`story element ${storyElement.id} lane must be an integer`);

--- a/docs/tests/final-cut-live-e2e.md
+++ b/docs/tests/final-cut-live-e2e.md
@@ -139,6 +139,29 @@ no private media paths, raw snapshots, transaction identifiers, credentials,
 or diagnostics. The runner and sanitizer both fail closed when the mutation,
 undo, required tool sequence, or full commit provenance is incomplete.
 
+## Canonical live read evidence
+
+When a live bridge advertises `canonicalTimelineMode: canonical-read` (or the
+read-capable `canonical-write` mode), the read-only evidence runner verifies the
+active project and sequence catalog against `project.inspect` without selecting
+a project or calling any mutation tool:
+
+```sh
+FRAMEKIT_FINAL_CUT_E2E_PROJECT="Framekit Canonical E2E" \
+FRAMEKIT_FINAL_CUT_E2E_SEQUENCE_ID="final-cut:sequence:example" \
+pnpm run test:final-cut-canonical-read-headed \
+  > docs/tests/evidence/$(date +%F)-canonical-live-read.json
+```
+
+The sequence variable is optional only when the bridge reports an unambiguous
+active sequence. The sanitized document records the full commit, target
+identity, revision, exact-coordinate coverage, and counts of clips, ordered
+story elements, media references, markers, and captions; it never includes raw
+snapshots or media sources. Metadata-only bridges fail before `project.inspect`.
+The bundled Workflow Extension remains metadata-only because the public host API
+does not expose complete timeline enumeration; this runner becomes a passing
+gate only after a real enumeration-capable bridge is installed.
+
 ## Optional native UI validation
 
 Final Cut Pro does not provide a supported headless Accessibility mode. Native

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "evaluate": "tsx scripts/run-mcp-evaluation.ts",
     "test:final-cut-headless": "tsx --test tests/integration/connection.test.ts tests/integration/finalcut-mcp.test.ts tests/integration/native.test.ts",
     "test:final-cut-overlay-headed": "node scripts/final-cut-overlay-headed-e2e.mjs",
+    "test:final-cut-canonical-read-headed": "node scripts/final-cut-canonical-read-headed-e2e.mjs",
     "test:final-cut-canonical-headed": "node scripts/final-cut-canonical-headed-e2e.mjs",
     "test:watch": "tsx --test --watch tests/integration/*.test.ts tests/evaluation/*.test.ts",
     "hooks:install": "node scripts/install-git-hooks.mjs",

--- a/scripts/final-cut-canonical-headed-e2e.mjs
+++ b/scripts/final-cut-canonical-headed-e2e.mjs
@@ -1,16 +1,11 @@
 import { createHash } from "node:crypto";
-import { readFile } from "node:fs/promises";
-import os from "node:os";
-import { execFile as execFileCallback } from "node:child_process";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { promisify } from "node:util";
-import { sanitizeCanonicalEvidence } from "./final-cut-evidence.mjs";
+import { evidenceEnvironment, sanitizeCanonicalEvidence } from "./final-cut-evidence.mjs";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
-const execFile = promisify(execFileCallback);
 const expectedProject = process.env.FRAMEKIT_FINAL_CUT_E2E_PROJECT;
 const clipId = process.env.FRAMEKIT_FINAL_CUT_E2E_CLIP_ID;
 
@@ -83,7 +78,7 @@ try {
     diff: transaction.diff,
     restored,
     digests: { before: beforeDigest, restored: restoredDigest },
-  }, await evidenceEnvironment());
+  }, await evidenceEnvironment(root));
   process.stdout.write(`${JSON.stringify(evidence, null, 2)}\n`);
 } catch (error) {
   if (transactionId) {
@@ -130,34 +125,4 @@ function stableJson(value) {
 
 function compareText(left, right) {
   return left < right ? -1 : left > right ? 1 : 0;
-}
-
-async function evidenceEnvironment() {
-  const packageJson = JSON.parse(await readFile(join(root, "package.json"), "utf8"));
-  let gitCommit;
-  try {
-    gitCommit = (await execFile("git", ["rev-parse", "HEAD"], { cwd: root })).stdout.trim();
-  } catch (error) {
-    throw new Error(`FINAL_CUT_E2E_COMMIT_UNAVAILABLE: ${String(error)}`);
-  }
-  if (!gitCommit) throw new Error("FINAL_CUT_E2E_COMMIT_UNAVAILABLE: git returned an empty commit");
-  return {
-    framekitVersion: packageJson.version,
-    finalCutVersion: await finalCutVersion(),
-    gitCommit,
-    nodeVersion: process.version,
-    platform: process.platform,
-    architecture: process.arch,
-    osVersion: os.version(),
-  };
-}
-
-async function finalCutVersion() {
-  try {
-    const version = (await execFile("osascript", ["-e", 'tell application "Final Cut Pro" to get version'])).stdout.trim();
-    if (version) return version;
-  } catch (error) {
-    throw new Error(`FINAL_CUT_E2E_FINAL_CUT_VERSION_UNAVAILABLE: ${String(error)}`);
-  }
-  throw new Error("FINAL_CUT_E2E_FINAL_CUT_VERSION_UNAVAILABLE: Final Cut Pro returned an empty version");
 }

--- a/scripts/final-cut-canonical-read-headed-e2e.mjs
+++ b/scripts/final-cut-canonical-read-headed-e2e.mjs
@@ -1,0 +1,110 @@
+import { readFile } from "node:fs/promises";
+import os from "node:os";
+import { execFile as execFileCallback } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { sanitizeCanonicalReadEvidence } from "./final-cut-evidence.mjs";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const execFile = promisify(execFileCallback);
+const expectedProject = process.env.FRAMEKIT_FINAL_CUT_E2E_PROJECT;
+const expectedSequence = process.env.FRAMEKIT_FINAL_CUT_E2E_SEQUENCE_ID;
+
+if (!expectedProject) {
+  throw new Error("Set FRAMEKIT_FINAL_CUT_E2E_PROJECT before running the canonical headed read E2E");
+}
+
+const transport = new StdioClientTransport({
+  command: process.execPath,
+  args: ["--import", "tsx", join(root, "apps/mcp-server/src/main.ts")],
+  env: {
+    ...process.env,
+    FRAMEKIT_EDITOR: "final-cut-live",
+    FRAMEKIT_AUTO_CONNECT: "0",
+    FRAMEKIT_FCPXML_PATH: "",
+    FRAMEKIT_FINAL_CUT_HEADLESS: "0",
+    FRAMEKIT_FINAL_CUT_NATIVE_WRITES: "0",
+  },
+  stderr: "pipe",
+});
+const client = new Client({ name: "framekit-canonical-read-headed-e2e", version: "0.1.0" });
+
+try {
+  await client.connect(transport);
+  const editor = await callJson("editor.inspect");
+  const mode = editor.capabilities?.editor?.canonicalTimelineMode;
+  if (mode !== "canonical-read" && mode !== "canonical-write") {
+    throw new Error(`CAPABILITY_UNAVAILABLE: live bridge reported ${mode ?? "unknown"}; canonical-read is required`);
+  }
+
+  const catalog = await callJson("project.list");
+  if (catalog.activeProjectId === undefined || catalog.activeSequenceId === undefined) {
+    throw new Error("TARGET_UNAVAILABLE: active project and sequence identities are required");
+  }
+  const project = catalog.projects?.find(({ id }) => id === catalog.activeProjectId);
+  if (!project) throw new Error("TARGET_MISMATCH: active project is absent from the project catalog");
+  if (project.name !== expectedProject) {
+    throw new Error(`FINAL_CUT_E2E_PROJECT_MISMATCH: expected ${expectedProject}, observed ${project.name}`);
+  }
+  if (!expectedSequence && project.sequences?.length !== 1) {
+    throw new Error("AMBIGUOUS_PROJECT_TARGET: set FRAMEKIT_FINAL_CUT_E2E_SEQUENCE_ID for a multi-sequence project");
+  }
+  if (expectedSequence && catalog.activeSequenceId !== expectedSequence) {
+    throw new Error(`FINAL_CUT_E2E_SEQUENCE_MISMATCH: expected ${expectedSequence}, observed ${catalog.activeSequenceId}`);
+  }
+  const sequence = project.sequences?.find(({ id }) => id === catalog.activeSequenceId);
+  if (!sequence) throw new Error("TARGET_MISMATCH: active sequence is absent from the active project");
+
+  const snapshot = await callJson("project.inspect");
+  if (snapshot.projectName !== expectedProject) {
+    throw new Error(`FINAL_CUT_E2E_PROJECT_MISMATCH: expected ${expectedProject}, observed ${snapshot.projectName ?? "unknown"}`);
+  }
+  if (snapshot.projectId !== catalog.activeProjectId || snapshot.timeline?.id !== catalog.activeSequenceId) {
+    throw new Error("TARGET_MISMATCH: canonical snapshot does not match the active catalog target");
+  }
+
+  const evidence = sanitizeCanonicalReadEvidence({
+    passed: true,
+    recordedAt: new Date().toISOString(),
+    editor: editor.identity,
+    capabilities: editor.capabilities,
+    project: { id: project.id, name: project.name, sequenceId: sequence.id },
+    catalog,
+    snapshot,
+  }, await evidenceEnvironment());
+  process.stdout.write(`${JSON.stringify(evidence, null, 2)}\n`);
+} finally {
+  await client.close().catch(() => {});
+  await transport.close().catch(() => {});
+}
+
+async function callJson(name, arguments_ = {}) {
+  const result = await client.callTool({ name, arguments: arguments_ });
+  const text = result.content?.find((item) => item.type === "text")?.text ?? "";
+  if (result.isError) throw new Error(text || `${name} failed`);
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(`${name} returned invalid JSON: ${text}`);
+  }
+}
+
+async function evidenceEnvironment() {
+  const packageJson = JSON.parse(await readFile(join(root, "package.json"), "utf8"));
+  const gitCommit = (await execFile("git", ["rev-parse", "HEAD"], { cwd: root })).stdout.trim();
+  if (!/^[0-9a-f]{40}$/i.test(gitCommit)) throw new Error("FINAL_CUT_E2E_COMMIT_UNAVAILABLE: git returned an invalid commit");
+  const finalCutVersion = (await execFile("osascript", ["-e", 'tell application "Final Cut Pro" to get version'])).stdout.trim();
+  if (!finalCutVersion) throw new Error("FINAL_CUT_E2E_FINAL_CUT_VERSION_UNAVAILABLE: Final Cut Pro returned an empty version");
+  return {
+    framekitVersion: packageJson.version,
+    finalCutVersion,
+    gitCommit,
+    nodeVersion: process.version,
+    platform: process.platform,
+    architecture: process.arch,
+    osVersion: os.version(),
+  };
+}

--- a/scripts/final-cut-canonical-read-headed-e2e.mjs
+++ b/scripts/final-cut-canonical-read-headed-e2e.mjs
@@ -1,15 +1,10 @@
-import { readFile } from "node:fs/promises";
-import os from "node:os";
-import { execFile as execFileCallback } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { promisify } from "node:util";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { sanitizeCanonicalReadEvidence } from "./final-cut-evidence.mjs";
+import { evidenceEnvironment, sanitizeCanonicalReadEvidence } from "./final-cut-evidence.mjs";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
-const execFile = promisify(execFileCallback);
 const expectedProject = process.env.FRAMEKIT_FINAL_CUT_E2E_PROJECT;
 const expectedSequence = process.env.FRAMEKIT_FINAL_CUT_E2E_SEQUENCE_ID;
 
@@ -74,7 +69,7 @@ try {
     project: { id: project.id, name: project.name, sequenceId: sequence.id },
     catalog,
     snapshot,
-  }, await evidenceEnvironment());
+  }, await evidenceEnvironment(root));
   process.stdout.write(`${JSON.stringify(evidence, null, 2)}\n`);
 } finally {
   await client.close().catch(() => {});
@@ -90,21 +85,4 @@ async function callJson(name, arguments_ = {}) {
   } catch {
     throw new Error(`${name} returned invalid JSON: ${text}`);
   }
-}
-
-async function evidenceEnvironment() {
-  const packageJson = JSON.parse(await readFile(join(root, "package.json"), "utf8"));
-  const gitCommit = (await execFile("git", ["rev-parse", "HEAD"], { cwd: root })).stdout.trim();
-  if (!/^[0-9a-f]{40}$/i.test(gitCommit)) throw new Error("FINAL_CUT_E2E_COMMIT_UNAVAILABLE: git returned an invalid commit");
-  const finalCutVersion = (await execFile("osascript", ["-e", 'tell application "Final Cut Pro" to get version'])).stdout.trim();
-  if (!finalCutVersion) throw new Error("FINAL_CUT_E2E_FINAL_CUT_VERSION_UNAVAILABLE: Final Cut Pro returned an empty version");
-  return {
-    framekitVersion: packageJson.version,
-    finalCutVersion,
-    gitCommit,
-    nodeVersion: process.version,
-    platform: process.platform,
-    architecture: process.arch,
-    osVersion: os.version(),
-  };
 }

--- a/scripts/final-cut-evidence.d.mts
+++ b/scripts/final-cut-evidence.d.mts
@@ -1,3 +1,13 @@
+export function evidenceEnvironment(root: string): Promise<{
+  framekitVersion: string;
+  finalCutVersion: string;
+  gitCommit: string;
+  nodeVersion: string;
+  platform: string;
+  architecture: string;
+  osVersion: string;
+}>;
+
 export function sanitizeCanonicalEvidence(run: unknown, environment: {
   framekitVersion: string;
   finalCutVersion: string;

--- a/scripts/final-cut-evidence.d.mts
+++ b/scripts/final-cut-evidence.d.mts
@@ -7,3 +7,13 @@ export function sanitizeCanonicalEvidence(run: unknown, environment: {
   architecture: string;
   osVersion: string;
 }): unknown;
+
+export function sanitizeCanonicalReadEvidence(run: unknown, environment: {
+  framekitVersion: string;
+  finalCutVersion: string;
+  gitCommit: string;
+  nodeVersion: string;
+  platform: string;
+  architecture: string;
+  osVersion: string;
+}): unknown;

--- a/scripts/final-cut-evidence.mjs
+++ b/scripts/final-cut-evidence.mjs
@@ -186,11 +186,13 @@ function validateReadSnapshot(snapshot) {
     }
     return media.mediaId;
   });
-  const storyElementIds = uniqueReadIds(snapshot.timeline.storyElements, "story element", (element) => {
+  const storyElementsById = new Map();
+  uniqueReadIds(snapshot.timeline.storyElements, "story element", (element) => {
     requireString(element.id, "story element id");
     validateReadCoordinates(element, `story element ${element.id}`);
     if (element.lane !== undefined) assert(Number.isInteger(element.lane), `story element ${element.id} lane must be an integer`);
     if (element.mediaId !== undefined) assert(mediaIds.has(element.mediaId), `story element ${element.id} references missing media`);
+    storyElementsById.set(element.id, element);
     return element.id;
   });
   uniqueReadIds(snapshot.timeline.markers, "marker", (marker) => {
@@ -211,8 +213,8 @@ function validateReadSnapshot(snapshot) {
     assert(Number.isInteger(clip.track), `occurrence ${clip.id} track must be an integer`);
     validateReadCoordinates(clip, `occurrence ${clip.id}`);
     if (clip.mediaId !== undefined) assert(mediaIds.has(clip.mediaId), `occurrence ${clip.id} references missing media`);
-    const storyElement = snapshot.timeline.storyElements.find(({ id }) => id === clip.id);
-    assert(storyElementIds.has(clip.id) && storyElement, `occurrence ${clip.id} has no storyline relationship`);
+    const storyElement = storyElementsById.get(clip.id);
+    assert(storyElement, `occurrence ${clip.id} has no storyline relationship`);
     assert(storyElement.start === clip.start && storyElement.duration === clip.duration, `occurrence ${clip.id} does not match storyline coordinates`);
     return clip.id;
   });

--- a/scripts/final-cut-evidence.mjs
+++ b/scripts/final-cut-evidence.mjs
@@ -1,3 +1,11 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import os from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCallback);
+
 const editorCapabilityKeys = [
   "canonicalTimelineMode",
   "projectRead",
@@ -29,6 +37,35 @@ const requiredToolResults = [
   ["timeline.edit", "VERIFIED"],
   ["edit.undo", "passed"],
 ];
+
+export async function evidenceEnvironment(root) {
+  const packageJson = JSON.parse(await readFile(join(root, "package.json"), "utf8"));
+  let gitCommit;
+  try {
+    gitCommit = (await execFile("git", ["rev-parse", "HEAD"], { cwd: root })).stdout.trim();
+  } catch (error) {
+    throw new Error(`FINAL_CUT_E2E_COMMIT_UNAVAILABLE: ${String(error)}`);
+  }
+  if (!/^[0-9a-f]{40}$/i.test(gitCommit)) {
+    throw new Error("FINAL_CUT_E2E_COMMIT_UNAVAILABLE: git returned an invalid commit");
+  }
+  let finalCutVersion;
+  try {
+    finalCutVersion = (await execFile("osascript", ["-e", 'tell application "Final Cut Pro" to get version'])).stdout.trim();
+  } catch (error) {
+    throw new Error(`FINAL_CUT_E2E_FINAL_CUT_VERSION_UNAVAILABLE: ${String(error)}`);
+  }
+  if (!finalCutVersion) throw new Error("FINAL_CUT_E2E_FINAL_CUT_VERSION_UNAVAILABLE: Final Cut Pro returned an empty version");
+  return {
+    framekitVersion: packageJson.version,
+    finalCutVersion,
+    gitCommit,
+    nodeVersion: process.version,
+    platform: process.platform,
+    architecture: process.arch,
+    osVersion: os.version(),
+  };
+}
 
 export function sanitizeCanonicalEvidence(run, environment) {
   assert(run?.passed === true, "headed run did not pass");

--- a/scripts/final-cut-evidence.mjs
+++ b/scripts/final-cut-evidence.mjs
@@ -103,6 +103,160 @@ export function sanitizeCanonicalEvidence(run, environment) {
   };
 }
 
+export function sanitizeCanonicalReadEvidence(run, environment) {
+  assert(run?.passed === true, "headed read did not pass");
+  assert(run.editor, "editor identity is missing");
+  assert(run.capabilities, "capability payload is missing");
+  const capabilities = sanitizeCapabilities(run.capabilities);
+  assert(
+    capabilities.editor.canonicalTimelineMode === "canonical-read"
+      || capabilities.editor.canonicalTimelineMode === "canonical-write",
+    "canonical-read or canonical-write capability is required",
+  );
+  assert(run.project && run.catalog && run.snapshot, "project, catalog, or canonical snapshot is missing");
+  assert(run.catalog.activeProjectId === run.project.id, "catalog active project does not match the requested target");
+  assert(run.catalog.activeSequenceId === run.project.sequenceId, "catalog active sequence does not match the requested target");
+  assert(run.snapshot.projectId === run.project.id, "snapshot project does not match the requested target");
+  assert(run.snapshot.projectName === run.project.name, "snapshot project name does not match the requested target");
+  assert(run.snapshot.timeline.id === run.project.sequenceId, "snapshot sequence does not match the requested target");
+  const snapshot = validateReadSnapshot(run.snapshot);
+
+  return {
+    schemaVersion: 1,
+    evidenceType: "headed-native-canonical-read",
+    passed: true,
+    recordedAt: requireString(run.recordedAt, "recordedAt"),
+    environment: sanitizeEnvironment(environment),
+    editor: sanitizeIdentity(run.editor),
+    capabilities,
+    project: {
+      id: requireString(run.project.id, "project id"),
+      name: requireString(run.project.name, "project name"),
+      sequenceId: requireString(run.project.sequenceId, "sequence id"),
+    },
+    snapshot: {
+      revision: summarizeRevision(snapshot.revision),
+      timeline: {
+        id: requireString(snapshot.timeline.id, "timeline id"),
+        name: requireString(snapshot.timeline.name, "timeline name"),
+        duration: requireFiniteNumber(snapshot.timeline.duration, "timeline duration"),
+        durationTime: snapshot.timeline.durationTime,
+        clipCount: snapshot.timeline.clips.length,
+        storyElementCount: snapshot.timeline.storyElements.length,
+        markerCount: snapshot.timeline.markers.length,
+        captionCount: snapshot.timeline.captions.length,
+        exactCoordinateCounts: {
+          clips: snapshot.timeline.clips.length,
+          storyElements: snapshot.timeline.storyElements.length,
+          markers: snapshot.timeline.markers.length,
+          captions: snapshot.timeline.captions.length,
+        },
+      },
+      mediaCount: snapshot.media.length,
+    },
+    sanitization: {
+      strategy: "allowlisted-summary",
+      omitted: ["media sources", "raw snapshots", "diagnostics"],
+    },
+  };
+}
+
+function validateReadSnapshot(snapshot) {
+  requireString(snapshot.projectId, "snapshot project id");
+  requireString(snapshot.projectName, "snapshot project name");
+  requireString(snapshot.timeline?.id, "snapshot timeline id");
+  requireString(snapshot.timeline?.name, "snapshot timeline name");
+  requireFiniteNumber(snapshot.timeline?.duration, "timeline duration");
+  assert(snapshot.timeline.duration >= 0, "timeline duration must be non-negative");
+  validateReadRational(snapshot.timeline.durationTime, "timeline duration time");
+  assertReadRationalMatches(snapshot.timeline.duration, snapshot.timeline.durationTime, "timeline duration");
+  requireReadArray(snapshot.timeline.clips, "timeline clips");
+  requireReadArray(snapshot.timeline.storyElements, "timeline story elements");
+  requireReadArray(snapshot.timeline.markers, "timeline markers");
+  requireReadArray(snapshot.timeline.captions, "timeline captions");
+  requireReadArray(snapshot.media, "media references");
+  summarizeRevision(snapshot.revision);
+
+  const mediaIds = uniqueReadIds(snapshot.media, "media", (media) => {
+    requireString(media.mediaId, "media id");
+    requireString(media.source, `media ${media.mediaId} source`);
+    if (media.duration !== undefined) {
+      requireFiniteNumber(media.duration, `media ${media.mediaId} duration`);
+      assert(media.duration >= 0, `media ${media.mediaId} duration must be non-negative`);
+    }
+    return media.mediaId;
+  });
+  const storyElementIds = uniqueReadIds(snapshot.timeline.storyElements, "story element", (element) => {
+    requireString(element.id, "story element id");
+    validateReadCoordinates(element, `story element ${element.id}`);
+    if (element.lane !== undefined) assert(Number.isInteger(element.lane), `story element ${element.id} lane must be an integer`);
+    if (element.mediaId !== undefined) assert(mediaIds.has(element.mediaId), `story element ${element.id} references missing media`);
+    return element.id;
+  });
+  uniqueReadIds(snapshot.timeline.markers, "marker", (marker) => {
+    requireString(marker.id, "marker id");
+    requireString(marker.name, `marker ${marker.id} name`);
+    validateReadCoordinates(marker, `marker ${marker.id}`);
+    return marker.id;
+  });
+  uniqueReadIds(snapshot.timeline.captions, "caption", (caption) => {
+    requireString(caption.id, "caption id");
+    assert(typeof caption.text === "string", `caption ${caption.id} text must be a string`);
+    validateReadCoordinates(caption, `caption ${caption.id}`);
+    return caption.id;
+  });
+  uniqueReadIds(snapshot.timeline.clips, "timeline occurrence", (clip) => {
+    requireString(clip.id, "occurrence id");
+    requireString(clip.name, `occurrence ${clip.id} name`);
+    assert(Number.isInteger(clip.track), `occurrence ${clip.id} track must be an integer`);
+    validateReadCoordinates(clip, `occurrence ${clip.id}`);
+    if (clip.mediaId !== undefined) assert(mediaIds.has(clip.mediaId), `occurrence ${clip.id} references missing media`);
+    const storyElement = snapshot.timeline.storyElements.find(({ id }) => id === clip.id);
+    assert(storyElementIds.has(clip.id) && storyElement, `occurrence ${clip.id} has no storyline relationship`);
+    assert(storyElement.start === clip.start && storyElement.duration === clip.duration, `occurrence ${clip.id} does not match storyline coordinates`);
+    return clip.id;
+  });
+  return snapshot;
+}
+
+function validateReadCoordinates(value, field) {
+  requireFiniteNumber(value.start, `${field} start`);
+  requireFiniteNumber(value.duration, `${field} duration`);
+  assert(value.start >= 0, `${field} start must be non-negative`);
+  assert(value.duration >= 0, `${field} duration must be non-negative`);
+  validateReadRational(value.startTime, `${field} start time`);
+  validateReadRational(value.durationTime, `${field} duration time`);
+  assertReadRationalMatches(value.start, value.startTime, `${field} start`);
+  assertReadRationalMatches(value.duration, value.durationTime, `${field} duration`);
+}
+
+function validateReadRational(value, field) {
+  assert(value && /^-?\d+$/.test(value.value) && /^\d+$/.test(value.timescale), `${field} must use an integer value and positive timescale`);
+  assert(BigInt(value.timescale) > 0n, `${field} must use a positive timescale`);
+  const seconds = Number(value.value) / Number(value.timescale);
+  assert(Number.isFinite(seconds), `${field} must represent a finite time`);
+}
+
+function assertReadRationalMatches(actual, rational, field) {
+  const expected = Number(rational.value) / Number(rational.timescale);
+  assert(Math.abs(actual - expected) <= Math.max(1e-9, Math.abs(actual) * 1e-12), `${field} time does not match seconds`);
+}
+
+function uniqueReadIds(values, kind, validate) {
+  const ids = new Set();
+  for (const value of values) {
+    assert(value && typeof value === "object" && !Array.isArray(value), `${kind} must be an object`);
+    const id = validate(value);
+    assert(!ids.has(id), `duplicate ${kind} id ${id}`);
+    ids.add(id);
+  }
+  return ids;
+}
+
+function requireReadArray(value, field) {
+  assert(Array.isArray(value), `${field} must be an array`);
+}
+
 function sanitizeEnvironment(environment) {
   const gitCommit = requireString(environment?.gitCommit, "Git commit");
   assert(/^[0-9a-f]{40}$/i.test(gitCommit), "Git commit must be a full SHA-1");

--- a/tests/integration/canonical-evidence.test.ts
+++ b/tests/integration/canonical-evidence.test.ts
@@ -8,7 +8,7 @@ test("canonical headed runner publishes the sanitized evidence contract", async 
   const runner = await readFile(join(process.cwd(), "scripts/final-cut-canonical-headed-e2e.mjs"), "utf8");
 
   assert.match(runner, /sanitizeCanonicalEvidence/);
-  assert.match(runner, /gitCommit/);
+  assert.match(runner, /evidenceEnvironment\(root\)/);
   assert.match(runner, /editStatus: transaction\.status/);
   assert.match(runner, /JSON\.stringify\(evidence, null, 2\)/);
 });

--- a/tests/integration/canonical-evidence.test.ts
+++ b/tests/integration/canonical-evidence.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 import { join } from "node:path";
-import { sanitizeCanonicalEvidence } from "../../scripts/final-cut-evidence.mjs";
+import { sanitizeCanonicalEvidence, sanitizeCanonicalReadEvidence } from "../../scripts/final-cut-evidence.mjs";
 
 test("canonical headed runner publishes the sanitized evidence contract", async () => {
   const runner = await readFile(join(process.cwd(), "scripts/final-cut-canonical-headed-e2e.mjs"), "utf8");
@@ -10,6 +10,16 @@ test("canonical headed runner publishes the sanitized evidence contract", async 
   assert.match(runner, /sanitizeCanonicalEvidence/);
   assert.match(runner, /gitCommit/);
   assert.match(runner, /editStatus: transaction\.status/);
+  assert.match(runner, /JSON\.stringify\(evidence, null, 2\)/);
+});
+
+test("canonical headed read runner publishes a read-only sanitized evidence contract", async () => {
+  const runner = await readFile(join(process.cwd(), "scripts/final-cut-canonical-read-headed-e2e.mjs"), "utf8");
+
+  assert.match(runner, /sanitizeCanonicalReadEvidence/);
+  assert.match(runner, /project\.list/);
+  assert.match(runner, /project\.inspect/);
+  assert.doesNotMatch(runner, /timeline\.edit/);
   assert.match(runner, /JSON\.stringify\(evidence, null, 2\)/);
 });
 
@@ -229,6 +239,110 @@ test("canonical headed evidence rejects path-like malformed capability values", 
   );
 });
 
+test("canonical headed read evidence keeps snapshot shape proof while omitting private media data", () => {
+  const evidence = sanitizeCanonicalReadEvidence(readRun, {
+    framekitVersion: "0.1.0",
+    finalCutVersion: "10.7.1",
+    gitCommit: "0123456789abcdef0123456789abcdef01234567",
+    nodeVersion: "v22.15.0",
+    platform: "darwin",
+    architecture: "arm64",
+    osVersion: "Darwin Kernel Version 25.5.0",
+  });
+
+  assert.deepEqual(evidence, {
+    schemaVersion: 1,
+    evidenceType: "headed-native-canonical-read",
+    passed: true,
+    recordedAt: "2026-08-26T10:00:00.000Z",
+    environment: {
+      framekitVersion: "0.1.0",
+      finalCutVersion: "10.7.1",
+      gitCommit: "0123456789abcdef0123456789abcdef01234567",
+      nodeVersion: "v22.15.0",
+      platform: "darwin",
+      architecture: "arm64",
+      osVersion: "Darwin Kernel Version 25.5.0",
+    },
+    editor: {
+      name: "Final Cut Pro",
+      version: "10.7.1",
+      backend: "workflow-extension-ipc",
+    },
+    capabilities: {
+      editor: {
+        canonicalTimelineMode: "canonical-read",
+        projectRead: true,
+        timelineSnapshotRead: true,
+        timelineWrite: false,
+        timelineArtifactWrite: false,
+        readAfterWrite: false,
+        incrementalChanges: true,
+        rollback: false,
+        assetDiscovery: false,
+        liveStateRead: true,
+        playheadWrite: false,
+        frameCapture: false,
+        projectCatalogRead: true,
+        projectSelection: true,
+      },
+      analyzers: {
+        speechTranscribe: false,
+        speechVad: false,
+        audioLoudness: false,
+        visualTrack: false,
+      },
+    },
+    project: {
+      id: "final-cut:project:disposable",
+      name: "Framekit Canonical E2E",
+      sequenceId: "final-cut:sequence:disposable",
+    },
+    snapshot: {
+      revision: { id: "rev-10", sequence: 10, timestamp: "2026-08-26T10:00:01.000Z" },
+      timeline: {
+        id: "final-cut:sequence:disposable",
+        name: "Framekit Canonical E2E",
+        duration: 30,
+        durationTime: { value: "30", timescale: "1" },
+        clipCount: 1,
+        storyElementCount: 1,
+        markerCount: 0,
+        captionCount: 0,
+        exactCoordinateCounts: { clips: 1, storyElements: 1, markers: 0, captions: 0 },
+      },
+      mediaCount: 1,
+    },
+    sanitization: {
+      strategy: "allowlisted-summary",
+      omitted: ["media sources", "raw snapshots", "diagnostics"],
+    },
+  });
+
+  const serialized = JSON.stringify(evidence);
+  assert.equal(serialized.includes("/Users/private/secret-footage.mov"), false);
+  assert.equal(serialized.includes("do not publish this credential"), false);
+  assert.equal(serialized.includes("raw crash dump"), false);
+});
+
+test("canonical headed read evidence rejects a metadata-only bridge", () => {
+  const metadataOnlyRun = structuredClone(readRun);
+  metadataOnlyRun.capabilities.editor.canonicalTimelineMode = "metadata-only";
+
+  assert.throws(
+    () => sanitizeCanonicalReadEvidence(metadataOnlyRun, {
+      framekitVersion: "0.1.0",
+      finalCutVersion: "10.7.1",
+      gitCommit: "0123456789abcdef0123456789abcdef01234567",
+      nodeVersion: "v22.15.0",
+      platform: "darwin",
+      architecture: "arm64",
+      osVersion: "Darwin Kernel Version 25.5.0",
+    }),
+    /FINAL_CUT_E2E_EVIDENCE_INCOMPLETE: canonical-read or canonical-write capability is required/,
+  );
+});
+
 const baseRevision = (id: string, sequence: number, timestamp: string) => ({ id, sequence, timestamp });
 
 const rawRun = {
@@ -288,6 +402,80 @@ const rawRun = {
   restored: snapshot("Interview", baseRevision("rev-12", 12, "2026-08-26T10:00:03.000Z")),
   digests: { before: "before-digest", restored: "before-digest" },
   transactionId: "transaction-secret",
+};
+
+const readRun = {
+  passed: true,
+  recordedAt: "2026-08-26T10:00:00.000Z",
+  editor: { name: "Final Cut Pro", version: "10.7.1", backend: "workflow-extension-ipc" },
+  capabilities: {
+    editor: {
+      canonicalTimelineMode: "canonical-read",
+      projectRead: true,
+      timelineSnapshotRead: true,
+      timelineWrite: false,
+      timelineArtifactWrite: false,
+      readAfterWrite: false,
+      incrementalChanges: true,
+      rollback: false,
+      assetDiscovery: false,
+      liveStateRead: true,
+      playheadWrite: false,
+      frameCapture: false,
+      projectCatalogRead: true,
+      projectSelection: true,
+      secret: "do not publish this credential",
+    },
+    analyzers: { speechTranscribe: false, speechVad: false, audioLoudness: false, visualTrack: false },
+  },
+  project: {
+    id: "final-cut:project:disposable",
+    name: "Framekit Canonical E2E",
+    sequenceId: "final-cut:sequence:disposable",
+  },
+  catalog: {
+    activeProjectId: "final-cut:project:disposable",
+    activeSequenceId: "final-cut:sequence:disposable",
+  },
+  snapshot: {
+    projectId: "final-cut:project:disposable",
+    projectName: "Framekit Canonical E2E",
+    timeline: {
+      id: "final-cut:sequence:disposable",
+      name: "Framekit Canonical E2E",
+      duration: 30,
+      durationTime: { value: "30", timescale: "1" },
+      clips: [{
+        id: "final-cut:occurrence:one",
+        mediaId: "final-cut:media:one",
+        name: "Interview",
+        start: 0,
+        duration: 30,
+        track: 0,
+        startTime: { value: "0", timescale: "1" },
+        durationTime: { value: "30", timescale: "1" },
+      }],
+      storyElements: [{
+        id: "final-cut:occurrence:one",
+        kind: "asset-clip",
+        start: 0,
+        duration: 30,
+        startTime: { value: "0", timescale: "1" },
+        durationTime: { value: "30", timescale: "1" },
+        lane: 0,
+        mediaId: "final-cut:media:one",
+      }],
+      markers: [],
+      captions: [],
+    },
+    media: [{
+      mediaId: "final-cut:media:one",
+      source: "/Users/private/secret-footage.mov",
+      mediaKind: "video",
+      duration: 30,
+    }],
+    revision: baseRevision("rev-10", 10, "2026-08-26T10:00:01.000Z"),
+  },
 };
 
 function snapshot(name: string, revision: { id: string; sequence: number; timestamp: string }) {

--- a/tests/integration/canonical-live.test.ts
+++ b/tests/integration/canonical-live.test.ts
@@ -608,6 +608,39 @@ test("live canonical snapshots require exact coordinates for every supported ele
   );
 });
 
+test("live canonical snapshots require a non-empty story element kind", async () => {
+  const malformed = structuredClone(canonicalSnapshot);
+  malformed.timeline.storyElements[0]!.kind = "";
+  const adapter = new FinalCutLiveAdapter({
+    request: async (request: FinalCutLiveRequest): Promise<FinalCutLiveResponse> => ({
+      version: 1,
+      id: request.id,
+      ok: true,
+      result: {
+        identity: { name: "Final Cut Pro", version: "test", backend: "canonical-live-ipc" },
+        capabilities: canonicalReadCapabilities,
+        ...(request.method === "snapshot" ? { snapshot: malformed } : {}),
+        ...(request.method === "projects" ? {
+          catalog: {
+            projects: [{
+              id: canonicalSnapshot.projectId,
+              name: canonicalSnapshot.projectName,
+              sequences: [{ id: canonicalSnapshot.timeline.id, name: canonicalSnapshot.timeline.name }],
+            }],
+            activeProjectId: canonicalSnapshot.projectId,
+            activeSequenceId: canonicalSnapshot.timeline.id,
+          },
+        } : {}),
+      },
+    }),
+  });
+
+  await assert.rejects(
+    adapter.readProject(),
+    /FINAL_CUT_LIVE_PROTOCOL: story element final-cut:occurrence:one kind must be a non-empty string/,
+  );
+});
+
 test("live canonical snapshots reject inconsistent rational convenience values", async () => {
   const malformed = structuredClone(canonicalSnapshot);
   malformed.timeline.clips[0]!.durationTime = { value: "1", timescale: "1" };

--- a/tests/integration/canonical-live.test.ts
+++ b/tests/integration/canonical-live.test.ts
@@ -155,8 +155,26 @@ const canonicalSnapshot: ProjectSnapshot = {
       },
     ],
     storyElements: [
-      { id: "final-cut:occurrence:one", kind: "asset-clip", start: 0, duration: 4, lane: 0, mediaId: "final-cut:media:shared" },
-      { id: "final-cut:occurrence:two", kind: "asset-clip", start: 4, duration: 4, lane: 1, mediaId: "final-cut:media:shared" },
+      {
+        id: "final-cut:occurrence:one",
+        kind: "asset-clip",
+        start: 0,
+        duration: 4,
+        startTime: { value: "0", timescale: "24000" },
+        durationTime: { value: "96000", timescale: "24000" },
+        lane: 0,
+        mediaId: "final-cut:media:shared",
+      },
+      {
+        id: "final-cut:occurrence:two",
+        kind: "asset-clip",
+        start: 4,
+        duration: 4,
+        startTime: { value: "96000", timescale: "24000" },
+        durationTime: { value: "96000", timescale: "24000" },
+        lane: 1,
+        mediaId: "final-cut:media:shared",
+      },
     ],
     markers: [],
     captions: [],
@@ -566,6 +584,78 @@ test("live canonical snapshots fail closed on duplicate occurrence identities", 
   });
 
   await assert.rejects(adapter.readProject(), /FINAL_CUT_LIVE_PROTOCOL: duplicate timeline occurrence id/);
+});
+
+test("live canonical snapshots require exact coordinates for every supported element", async () => {
+  const malformed = structuredClone(canonicalSnapshot);
+  delete malformed.timeline.storyElements[0]!.startTime;
+  const adapter = new FinalCutLiveAdapter({
+    request: async (request: FinalCutLiveRequest): Promise<FinalCutLiveResponse> => ({
+      version: 1,
+      id: request.id,
+      ok: true,
+      result: {
+        identity: { name: "Final Cut Pro", version: "test", backend: "canonical-live-ipc" },
+        capabilities: canonicalReadCapabilities,
+        ...(request.method === "snapshot" ? { snapshot: malformed } : {}),
+      },
+    }),
+  });
+
+  await assert.rejects(
+    adapter.readProject(),
+    /FINAL_CUT_LIVE_PROTOCOL: story element final-cut:occurrence:one start time must use an integer value and positive timescale/,
+  );
+});
+
+test("live canonical snapshots reject inconsistent rational convenience values", async () => {
+  const malformed = structuredClone(canonicalSnapshot);
+  malformed.timeline.clips[0]!.durationTime = { value: "1", timescale: "1" };
+  const adapter = new FinalCutLiveAdapter({
+    request: async (request: FinalCutLiveRequest): Promise<FinalCutLiveResponse> => ({
+      version: 1,
+      id: request.id,
+      ok: true,
+      result: {
+        identity: { name: "Final Cut Pro", version: "test", backend: "canonical-live-ipc" },
+        capabilities: canonicalReadCapabilities,
+        ...(request.method === "snapshot" ? { snapshot: malformed } : {}),
+      },
+    }),
+  });
+
+  await assert.rejects(
+    adapter.readProject(),
+    /FINAL_CUT_LIVE_PROTOCOL: occurrence final-cut:occurrence:one duration time does not match seconds/,
+  );
+});
+
+test("live canonical snapshots require valid media references and caption coordinates", async () => {
+  const malformed = structuredClone(canonicalSnapshot);
+  malformed.media[0]!.source = "";
+  malformed.timeline.captions = [{
+    id: "caption-1",
+    start: 1,
+    duration: 1,
+    text: "Caption",
+  }];
+  const adapter = new FinalCutLiveAdapter({
+    request: async (request: FinalCutLiveRequest): Promise<FinalCutLiveResponse> => ({
+      version: 1,
+      id: request.id,
+      ok: true,
+      result: {
+        identity: { name: "Final Cut Pro", version: "test", backend: "canonical-live-ipc" },
+        capabilities: canonicalReadCapabilities,
+        ...(request.method === "snapshot" ? { snapshot: malformed } : {}),
+      },
+    }),
+  });
+
+  await assert.rejects(
+    adapter.readProject(),
+    /FINAL_CUT_LIVE_PROTOCOL: media final-cut:media:shared source must be a non-empty string/,
+  );
 });
 
 test("live canonical snapshots fail closed when the active target does not match", async () => {

--- a/tests/integration/canonical-live.test.ts
+++ b/tests/integration/canonical-live.test.ts
@@ -689,6 +689,12 @@ test("live canonical snapshots require valid media references and caption coordi
     adapter.readProject(),
     /FINAL_CUT_LIVE_PROTOCOL: media final-cut:media:shared source must be a non-empty string/,
   );
+
+  malformed.media[0]!.source = canonicalSnapshot.media[0]!.source;
+  await assert.rejects(
+    adapter.readProject(),
+    /FINAL_CUT_LIVE_PROTOCOL: caption caption-1 start time must use an integer value and positive timescale/,
+  );
 });
 
 test("live canonical snapshots fail closed when the active target does not match", async () => {

--- a/tests/integration/phase1.test.ts
+++ b/tests/integration/phase1.test.ts
@@ -261,6 +261,41 @@ test("FCPXML preserves heterogeneous spine order and distinct clip occurrences",
   assert.ok(xml.indexOf('name="Second use"') < xml.indexOf("<transition"));
 });
 
+test("FCPXML preserves connected story elements with exact parent-relative coordinates", async () => {
+  const directory = await mkdtemp(join(os.tmpdir(), "framekit-fcpxml-connected-"));
+  const path = join(directory, "project.fcpxml");
+  await writeFile(path, `<?xml version="1.0"?><fcpxml><resources>
+    <asset id="r1" src="file:///primary.mov" />
+    <asset id="r2" src="file:///connected.mov" />
+  </resources><library><event><project uid="project-connected" name="Connected"><sequence uid="sequence-connected" duration="8s"><spine>
+    <asset-clip id="primary" ref="r1" offset="1/3s" duration="7s">
+      <asset-clip id="connected" ref="r2" offset="2/3s" duration="3s" lane="1" />
+      <title id="connected-title" offset="5/3s" duration="1s" lane="2" name="Connected title" />
+    </asset-clip>
+    <marker id="marker-1" start="7s" duration="0s" value="End" />
+  </spine></sequence></project></event></library></fcpxml>`);
+
+  const snapshot = await new FcpxmlDocumentAdapter(path).readProject();
+
+  assert.deepEqual(snapshot.timeline.storyElements.map(({ id, kind, start, duration, lane }) => ({
+    id,
+    kind,
+    start,
+    duration,
+    lane,
+  })), [
+    { id: "primary", kind: "asset-clip", start: 1 / 3, duration: 7, lane: undefined },
+    { id: "connected", kind: "asset-clip", start: 1, duration: 3, lane: 1 },
+    { id: "connected-title", kind: "title", start: 2, duration: 1, lane: 2 },
+  ]);
+  assert.deepEqual(snapshot.timeline.clips.map(({ id, startTime, durationTime }) => ({ id, startTime, durationTime })), [
+    { id: "primary", startTime: { value: "1", timescale: "3" }, durationTime: { value: "7", timescale: "1" } },
+    { id: "connected", startTime: { value: "1", timescale: "1" }, durationTime: { value: "3", timescale: "1" } },
+  ]);
+  assert.deepEqual(snapshot.timeline.storyElements[1]?.startTime, { value: "1", timescale: "1" });
+  assert.deepEqual(snapshot.timeline.storyElements[2]?.startTime, { value: "2", timescale: "1" });
+});
+
 test("Final Cut session composes document snapshot and live state providers", async () => {
   const directory = await mkdtemp(join(os.tmpdir(), "framekit-fcpxml-session-"));
   const path = join(directory, "project.fcpxml");

--- a/tests/integration/phase1.test.ts
+++ b/tests/integration/phase1.test.ts
@@ -296,6 +296,26 @@ test("FCPXML preserves connected story elements with exact parent-relative coord
   assert.deepEqual(snapshot.timeline.storyElements[2]?.startTime, { value: "2", timescale: "1" });
 });
 
+test("FCPXML separates asset source starts from timeline offsets", async () => {
+  const directory = await mkdtemp(join(os.tmpdir(), "framekit-fcpxml-source-start-"));
+  const path = join(directory, "project.fcpxml");
+  await writeFile(path, `<?xml version="1.0"?><fcpxml><resources>
+    <asset id="r1" src="file:///trimmed.mov" />
+  </resources><library><event><project uid="project-source-start" name="Source starts"><sequence uid="sequence-source-start"><spine>
+    <asset-clip id="trimmed" ref="r1" start="4s" duration="3s" />
+    <marker id="marker-source-start" start="2s" duration="0s" value="Marker" />
+    <caption id="caption-source-start" start="5s" duration="1s" text="Caption" />
+  </spine></sequence></project></event></library></fcpxml>`);
+
+  const snapshot = await new FcpxmlDocumentAdapter(path).readProject();
+
+  assert.equal(snapshot.timeline.duration, 3);
+  assert.deepEqual(snapshot.timeline.clips[0]?.startTime, { value: "0", timescale: "1" });
+  assert.equal(snapshot.timeline.clips[0]?.start, 0);
+  assert.equal(snapshot.timeline.markers[0]?.start, 2);
+  assert.equal(snapshot.timeline.captions[0]?.start, 5);
+});
+
 test("Final Cut session composes document snapshot and live state providers", async () => {
   const directory = await mkdtemp(join(os.tmpdir(), "framekit-fcpxml-session-"));
   const path = join(directory, "project.fcpxml");


### PR DESCRIPTION
## Summary

- Enforce fail-closed canonical snapshot validation for project identity, timeline coordinates, clips, story elements, markers, captions, media references, and revisions.
- Add a sanitized read-only headed evidence contract and runner that verifies active project and sequence targeting without mutation.
- Recursively enumerate connected FCPXML elements while preserving order, stable occurrence IDs, and exact parent-relative rational coordinates.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm run test` — 220 passed
- `pnpm run check:boundaries`
- `pnpm run xcode:check`
- `xcodebuild -project adapters/final-cut/swift-bridge/FinalCutWorkflowExtension/FramekitFinalCutWorkflow.xcodeproj -list`

The headed evidence command also fails closed as expected when `FRAMEKIT_FINAL_CUT_E2E_PROJECT` is not configured.

## Native boundary

The bundled Workflow Extension remains metadata-only. The current public Final Cut host surface does not expose complete clip, media, marker, and caption enumeration, so native canonical-read acceptance remains gated until an enumeration-capable bridge is available.

Refs #63

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Final Cut Pro timeline handling for nested elements, clips, markers, captions, lanes, and exact rational timing.
  * Added read-only canonical evidence validation with sanitized summaries and environment details.
  * Added a headed end-to-end workflow for verifying active projects, sequences, and timeline snapshots.

* **Bug Fixes**
  * Rejects malformed, non-finite, inconsistent, or incomplete timeline and media data.

* **Documentation**
  * Documented the canonical live evidence validation workflow and verification requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->