### PR TITLE
feat: categorize release notes from PR titles

### DIFF
--- a/.github/labels/labels.json
+++ b/.github/labels/labels.json
@@ -60,6 +60,46 @@
     "description": "Requests a minor SemVer release bump, such as v0.0.1 to v0.1.0."
   },
   {
+    "name": "Release: Features",
+    "color": "A2EEEF",
+    "description": "Release-note category for feat and feature PRs."
+  },
+  {
+    "name": "Release: Fixes",
+    "color": "B60205",
+    "description": "Release-note category for fix, bug, and revert PRs."
+  },
+  {
+    "name": "Release: Improvements",
+    "color": "F9D0C4",
+    "description": "Release-note category for refactor, improvement, and style PRs."
+  },
+  {
+    "name": "Release: Performance",
+    "color": "FBCA04",
+    "description": "Release-note category for perf PRs."
+  },
+  {
+    "name": "Release: Documentation",
+    "color": "0052CC",
+    "description": "Release-note category for docs PRs."
+  },
+  {
+    "name": "Release: Tests",
+    "color": "0E8A16",
+    "description": "Release-note category for test PRs."
+  },
+  {
+    "name": "Release: Chores",
+    "color": "D4C5F9",
+    "description": "Release-note category for chore, build, and CI PRs."
+  },
+  {
+    "name": "Release: Design",
+    "color": "FEF2C0",
+    "description": "Release-note category for design PRs."
+  },
+  {
     "name": "Close: Duplicate",
     "color": "D4C5F9",
     "description": ""

--- a/.github/labels/labels.json
+++ b/.github/labels/labels.json
@@ -60,46 +60,6 @@
     "description": "Requests a minor SemVer release bump, such as v0.0.1 to v0.1.0."
   },
   {
-    "name": "Release: Features",
-    "color": "A2EEEF",
-    "description": "Release-note category for feat and feature PRs."
-  },
-  {
-    "name": "Release: Fixes",
-    "color": "B60205",
-    "description": "Release-note category for fix, bug, and revert PRs."
-  },
-  {
-    "name": "Release: Improvements",
-    "color": "F9D0C4",
-    "description": "Release-note category for refactor, improvement, and style PRs."
-  },
-  {
-    "name": "Release: Performance",
-    "color": "FBCA04",
-    "description": "Release-note category for perf PRs."
-  },
-  {
-    "name": "Release: Documentation",
-    "color": "0052CC",
-    "description": "Release-note category for docs PRs."
-  },
-  {
-    "name": "Release: Tests",
-    "color": "0E8A16",
-    "description": "Release-note category for test PRs."
-  },
-  {
-    "name": "Release: Chores",
-    "color": "D4C5F9",
-    "description": "Release-note category for chore, build, and CI PRs."
-  },
-  {
-    "name": "Release: Design",
-    "color": "FEF2C0",
-    "description": "Release-note category for design PRs."
-  },
-  {
     "name": "Close: Duplicate",
     "color": "D4C5F9",
     "description": ""

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,6 @@
 <!-- Title naming policy -->
-<!-- `feat:`, `fix:`, `perf:`, `design:`, `chore:` -->
+<!-- Release categories are derived from the title prefix. -->
+<!-- `feat:`, `fix:`, `perf:`, `refactor:`, `docs:`, `test:`, `design:`, `chore:` -->
 
 - [ ] Request PR review
 - [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,3 +2,31 @@ changelog:
   exclude:
     labels:
       - tagpr
+  categories:
+    - title: Features
+      labels:
+        - 'Release: Features'
+    - title: Fixes
+      labels:
+        - 'Release: Fixes'
+    - title: Improvements
+      labels:
+        - 'Release: Improvements'
+    - title: Performance
+      labels:
+        - 'Release: Performance'
+    - title: Documentation
+      labels:
+        - 'Release: Documentation'
+    - title: Tests
+      labels:
+        - 'Release: Tests'
+    - title: Chores
+      labels:
+        - 'Release: Chores'
+    - title: Design
+      labels:
+        - 'Release: Design'
+    - title: Other Changes
+      labels:
+        - '*'

--- a/.github/scripts/assign_labels.py
+++ b/.github/scripts/assign_labels.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Apply pull-request labels from the branch name and changed files."""
+"""Apply pull-request labels from the title, branch name, and changed files."""
 
 from __future__ import annotations
 
@@ -11,13 +11,61 @@ from collections.abc import Iterable
 from typing import Any
 
 
+RELEASE_CATEGORY_BY_TITLE_KIND = {
+    "feat": "Release: Features",
+    "feature": "Release: Features",
+    "fix": "Release: Fixes",
+    "bug": "Release: Fixes",
+    "revert": "Release: Fixes",
+    "refactor": "Release: Improvements",
+    "improvement": "Release: Improvements",
+    "style": "Release: Improvements",
+    "perf": "Release: Performance",
+    "docs": "Release: Documentation",
+    "doc": "Release: Documentation",
+    "test": "Release: Tests",
+    "chore": "Release: Chores",
+    "build": "Release: Chores",
+    "ci": "Release: Chores",
+    "design": "Release: Design",
+}
+
+
+def release_category_label(pull_request_title: str) -> str | None:
+    """Return a release-note label for a conventional or legacy title prefix."""
+
+    conventional_match = re.match(
+        r"^\s*(?P<kind>feat|feature|fix|bug|revert|refactor|style|perf|docs|doc|test|chore|build|ci|design)"
+        r"(?:\([^)]*\))?!?:",
+        pull_request_title,
+        re.IGNORECASE,
+    )
+    if conventional_match:
+        return RELEASE_CATEGORY_BY_TITLE_KIND[conventional_match.group("kind").lower()]
+
+    bracket_match = re.match(r"^\s*\[\s*(?P<kind>[^]]+?)\s*\]", pull_request_title)
+    if bracket_match:
+        kind = bracket_match.group("kind").strip().lower()
+        return RELEASE_CATEGORY_BY_TITLE_KIND.get(kind)
+
+    return None
+
+
 def has_suffix(filename: str, suffixes: set[str]) -> bool:
     lower_name = filename.lower()
     return any(lower_name.endswith(suffix) for suffix in suffixes)
 
 
-def labels_for_pull_request(head_ref: str, changed_files: Iterable[str]) -> set[str]:
+def labels_for_pull_request(
+    head_ref: str,
+    changed_files: Iterable[str],
+    pull_request_title: str = "",
+) -> set[str]:
     labels: set[str] = set()
+
+    release_label = release_category_label(pull_request_title)
+    if release_label:
+        labels.add(release_label)
 
     if re.match(r"^(hotfix|fix)", head_ref):
         labels.add("Problem: Bug")
@@ -94,8 +142,9 @@ def main() -> None:
     repository = os.environ["REPOSITORY"]
     pr_number = os.environ["PR_NUMBER"]
     head_ref = os.environ["HEAD_REF"]
+    pull_request_title = os.environ.get("PR_TITLE", "")
     changed_files = changed_files_for_pull_request(token, repository, pr_number)
-    labels = labels_for_pull_request(head_ref, changed_files)
+    labels = labels_for_pull_request(head_ref, changed_files, pull_request_title)
 
     if not labels:
         print("No labels matched.")

--- a/.github/scripts/test_assign_labels.py
+++ b/.github/scripts/test_assign_labels.py
@@ -26,6 +26,33 @@ class AssignLabelsTest(unittest.TestCase):
         self.assertEqual(labels_for_pull_request("fix/socket", []), {"Problem: Bug"})
         self.assertEqual(labels_for_pull_request("refactor/runtime", []), {"Type: Improvement"})
 
+    def test_conventional_title_adds_release_category(self) -> None:
+        self.assertEqual(
+            labels_for_pull_request("branch", [], "feat(runtime)!: add a capability"),
+            {"Release: Features"},
+        )
+        self.assertEqual(
+            labels_for_pull_request("branch", [], "fix: reject invalid input"),
+            {"Release: Fixes"},
+        )
+        self.assertEqual(
+            labels_for_pull_request("branch", [], "chore: update automation"),
+            {"Release: Chores"},
+        )
+
+    def test_legacy_bracket_title_adds_release_category(self) -> None:
+        self.assertEqual(
+            labels_for_pull_request("branch", [], "[Improvement] harden validation"),
+            {"Release: Improvements"},
+        )
+        self.assertEqual(
+            labels_for_pull_request("branch", [], "[Bug] fix overlay detection"),
+            {"Release: Fixes"},
+        )
+
+    def test_unprefixed_title_has_no_release_category(self) -> None:
+        self.assertEqual(labels_for_pull_request("branch", [], "Update the README"), set())
+
     def test_unmatched_changes_do_not_create_labels(self) -> None:
         self.assertEqual(labels_for_pull_request("chore/cleanup", ["package.json"]), set())
 

--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
     assign-label:
+        needs: sync-labels
         if: ${{ github.event_name == 'pull_request' }}
         permissions:
             contents: read
@@ -25,6 +26,7 @@ jobs:
                   REPOSITORY: ${{ github.repository }}
                   PR_NUMBER: ${{ github.event.pull_request.number }}
                   HEAD_REF: ${{ github.event.pull_request.head.ref }}
+                  PR_TITLE: ${{ github.event.pull_request.title }}
               run: python3 .github/scripts/assign_labels.py
 
     sync-labels:


### PR DESCRIPTION
## Summary

- Add GitHub release-note categories for features, fixes, improvements, performance, documentation, tests, chores, and design.
- Derive one release-note category label from conventional PR title prefixes.
- Support legacy `[Feature]`, `[Bug]`, and `[Improvement]` title forms.
- Ensure synced labels exist before PR label assignment runs.
- Document the title-prefix release category policy.

Unprefixed PR titles remain under `Other Changes` rather than being guessed.

## Validation

- `pnpm run build`
- `pnpm run test` (273 passed)
- `pnpm run check:boundaries`
- `python3 .github/scripts/test_assign_labels.py` (6 passed)
- JSON/YAML parsing
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated release-category labels based on pull request title prefixes.
  * Added release changelog sections for features, fixes, improvements, performance, documentation, tests, chores, design, and other changes.
  * Added standardized labels with clear category descriptions and colors.

* **Documentation**
  * Updated pull request title guidance to include `test:` and `docs:` prefixes.

* **Tests**
  * Added coverage for conventional, legacy bracketed, and unprefixed pull request titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->