### PR TITLE
chore: automate npm and GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
     needs: tagpr
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
     steps:
       - name: Check out repository
@@ -55,10 +55,27 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: pnpm
 
+      - name: Set up npm Trusted Publishing
+        run: npm install --global npm@11.5.1
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Publish npm package
-        run: npm publish --provenance --access public
+        run: npm publish --access public
+
+      - name: Verify npm publication
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          RELEASE_TAG: ${{ needs.tagpr.outputs.tagpr-tag }}
+        run: |
+          set -eu
+          expected_version="${RELEASE_TAG#v}"
+          package_name="$(node -p "require('./package.json').name")"
+          published_version="$(npm view "${package_name}@${expected_version}" version)"
+          test "${published_version}" = "${expected_version}"
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.tagpr.outputs.tagpr-tag }}
+        run: gh release edit "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" --draft=false

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ Repository-local GitHub agent playbooks are documented in
 [`../.agents/README.md`](../.agents/README.md).
 
 - [Getting started](./getting-started.md): development setup, MCP, and Final Cut connection.
+- [Releasing](./releasing.md): npm Trusted Publishing and automated GitHub releases.
 - [PRD](./PRD.md): product goals and roadmap.
 - [Phase 0 and Phase 1 checklist](./phase-0-1-checklist.md): delivery gates,
   evidence, and current native Final Cut boundaries.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,46 @@
+# Releasing Framekit
+
+Framekit releases are created from `main` by the tagpr workflow in
+`.github/workflows/release.yml`.
+
+## One-time npm setup
+
+Configure npm Trusted Publishing for `@morshoto/framekit` with these values:
+
+- Provider: GitHub Actions
+- Organization or user: `morshoto`
+- Repository: `framekit`
+- Workflow filename: `release.yml`
+- Allowed action: `npm publish`
+
+The package metadata must keep its `repository.url` aligned with the GitHub
+repository. The workflow uses GitHub's OIDC identity and does not require an
+`NPM_TOKEN` repository secret.
+
+## Release flow
+
+1. Merge the tagpr release pull request into `main`.
+2. The `tagpr` job creates the version tag and a draft GitHub release with
+   generated notes.
+3. The `publish-npm` job installs npm 11.5.1, publishes the matching package,
+   and verifies the version on the public registry.
+4. Only after npm verification succeeds, the workflow publishes the GitHub
+   release and its notes.
+
+If npm publishing fails, the GitHub release remains a draft so the failure can
+be repaired without presenting an incomplete release as public.
+
+## Local validation
+
+Run the standard checks before merging a release pull request:
+
+```sh
+pnpm install --frozen-lockfile
+pnpm run build
+pnpm run test
+pnpm run check:boundaries
+npm pack --dry-run
+```
+
+The release workflow performs the registry and GitHub release steps on GitHub's
+hosted runner; OIDC authentication cannot be fully reproduced locally.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "private": false,
   "type": "module",
   "description": "Agentic video editing runtime and MCP server for Final Cut Pro",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/morshoto/framekit.git"
+  },
   "files": [
     "bin",
     "dist-package"

--- a/tests/integration/codex-plugin.test.ts
+++ b/tests/integration/codex-plugin.test.ts
@@ -118,12 +118,26 @@ test("tagpr releases publish the package consumed by the plugin", async () => {
   const tagpr = await readFile(resolve(repository, ".tagpr"), "utf8");
   assert.match(tagpr, /versionFile = package\.json,plugins\/framekit\/\.codex-plugin\/plugin\.json/);
 
+  const packageManifest = await readJson("package.json") as {
+    repository?: { type?: string; url?: string };
+  };
+  assert.deepEqual(packageManifest.repository, {
+    type: "git",
+    url: "https://github.com/morshoto/framekit.git",
+  });
+
   const workflow = await readFile(resolve(repository, ".github/workflows/release.yml"), "utf8");
   assert.match(workflow, /publish-npm:/);
   assert.match(workflow, /publish-npm:[\s\S]*?actions\/checkout@v4\s+with:\s+persist-credentials:\s+false/);
   assert.match(workflow, /needs:\s+tagpr/);
   assert.match(workflow, /needs\.tagpr\.outputs\.tagpr-tag != ''/);
   assert.match(workflow, /id-token:\s+write/);
-  assert.match(workflow, /npm publish --provenance --access public/);
-  assert.match(workflow, /NODE_AUTH_TOKEN:\s+\$\{\{ secrets\.NPM_TOKEN \}\}/);
+  assert.match(workflow, /npm install --global npm@11\.5\.1/);
+  assert.match(workflow, /npm publish --access public/);
+  assert.doesNotMatch(workflow, /NODE_AUTH_TOKEN:\s+\$\{\{ secrets\.NPM_TOKEN \}\}/);
+  assert.match(workflow, /gh release edit [\s\S]*--draft=false/);
+  assert.ok(
+    workflow.indexOf("Verify npm publication") < workflow.indexOf("Publish GitHub release"),
+    "the GitHub release must be published only after npm verification",
+  );
 });


### PR DESCRIPTION
## Summary

- Replace the missing long-lived NPM_TOKEN dependency with npm Trusted Publishing through GitHub Actions OIDC.
- Add repository metadata required for npm provenance.
- Verify the published npm version before promoting the tagpr GitHub release from draft to public.
- Document the one-time npm Trusted Publisher configuration and release flow.

Before the first release after merge, configure npm Trusted Publishing for `@morshoto/framekit` with user `morshoto`, repository `framekit`, workflow filename `release.yml`, and the `npm publish` action.

## Validation

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm run build`
- [x] `pnpm run test` — 287 passed
- [x] `pnpm run check:boundaries`
- [x] `npm pack --dry-run`
- [x] Release workflow contract test

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Existing package and plugin interfaces remain compatible.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific paths added.
- [x] Documentation reflects the changed release authentication and workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated package releases now publish to npm through Trusted Publishing.
  * GitHub releases are finalized after the published npm package is verified.
  * Package metadata now includes a public repository link.

* **Documentation**
  * Added release guidance covering setup, validation, publishing flow, and troubleshooting.
  * Added a link to the release documentation from the README.

* **Tests**
  * Expanded release checks to validate npm publishing and GitHub release sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->