### PR TITLE
Release for v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [v0.1.1](https://github.com/morshoto/framekit/compare/v0.1.0...v0.1.1) - 2026-08-30
+
+- chore: automate npm and GitHub releases by @morshoto in https://github.com/morshoto/framekit/pull/84
+- docs: improve README onboarding by @morshoto in https://github.com/morshoto/framekit/pull/93
+- chore: move PR labeling rules to YAML by @morshoto in https://github.com/morshoto/framekit/pull/94
+- refactor(runtime): split runtime responsibilities by @morshoto in https://github.com/morshoto/framekit/pull/95
+- feat: define editorial duration policy by @morshoto in https://github.com/morshoto/framekit/pull/96
+- [Improvement] Make Framekit MCP workflow routing editor-first by @morshoto in https://github.com/morshoto/framekit/pull/97
+- feat: add semantic media understanding by @morshoto in https://github.com/morshoto/framekit/pull/98
+- feat: expose operation-level capability discovery by @morshoto in https://github.com/morshoto/framekit/pull/99
+- feat: assert semantic verification outcomes by @morshoto in https://github.com/morshoto/framekit/pull/100
+- feat: add rough-cut project construction primitives by @morshoto in https://github.com/morshoto/framekit/pull/101
+- chore: issue tempalte tags by @morshoto in https://github.com/morshoto/framekit/pull/105
+- feat: separate artifact and live edits by @morshoto in https://github.com/morshoto/framekit/pull/102
+
 ## [v0.1.0](https://github.com/morshoto/framekit/commits/v0.1.0) - 2026-08-30
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@morshoto/framekit",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "packageManager": "pnpm@11.10.0",
   "private": false,
   "type": "module",

--- a/plugins/framekit/.codex-plugin/plugin.json
+++ b/plugins/framekit/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "framekit",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Connect Codex to Framekit's MCP tools for Final Cut Pro",
   "author": {
     "name": "Framekit Contributors",


### PR DESCRIPTION
This pull request is for the next release as v0.1.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* chore: automate npm and GitHub releases by @morshoto in https://github.com/morshoto/framekit/pull/84
* docs: improve README onboarding by @morshoto in https://github.com/morshoto/framekit/pull/93
* chore: move PR labeling rules to YAML by @morshoto in https://github.com/morshoto/framekit/pull/94
* refactor(runtime): split runtime responsibilities by @morshoto in https://github.com/morshoto/framekit/pull/95
* feat: define editorial duration policy by @morshoto in https://github.com/morshoto/framekit/pull/96
* [Improvement] Make Framekit MCP workflow routing editor-first by @morshoto in https://github.com/morshoto/framekit/pull/97
* feat: add semantic media understanding by @morshoto in https://github.com/morshoto/framekit/pull/98
* feat: expose operation-level capability discovery by @morshoto in https://github.com/morshoto/framekit/pull/99
* feat: assert semantic verification outcomes by @morshoto in https://github.com/morshoto/framekit/pull/100
* feat: add rough-cut project construction primitives by @morshoto in https://github.com/morshoto/framekit/pull/101
* chore: issue tempalte tags by @morshoto in https://github.com/morshoto/framekit/pull/105
* feat: separate artifact and live edits by @morshoto in https://github.com/morshoto/framekit/pull/102


**Full Changelog**: https://github.com/morshoto/framekit/compare/v0.1.0...tagpr-from-v0.1.0