### PR TITLE
docs: improve README onboarding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to Framekit
 
-For first-time setup, including installation of the local pre-commit hook, see
-[`CONTRIBUTOR.md`](CONTRIBUTOR.md).
+For first-time setup, install the local pre-commit hook with
+`pnpm run hooks:install` after installing dependencies.
 
 ## Development setup
 
@@ -15,6 +15,7 @@ Install dependencies and run the standard checks:
 
 ```sh
 pnpm install --frozen-lockfile
+pnpm run hooks:install
 pnpm run build
 pnpm run test
 pnpm run check:boundaries

--- a/README.md
+++ b/README.md
@@ -3,45 +3,59 @@
 </div>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/Swift-5.9%2B-F05138?logo=swift&logoColor=white" alt="Swift 5.9 or newer" />
-  <img src="https://img.shields.io/badge/Python-3.13-3776AB?logo=python&logoColor=white" alt="Python 3.13" />
-  <img src="https://img.shields.io/badge/platform-Apple%20Silicon%20macOS-000000?logo=apple&logoColor=white" alt="Apple Silicon macOS" />
+  <img src="https://img.shields.io/badge/Node.js-20%2B-339933?logo=node.js&logoColor=white" alt="Node.js 20 or newer" />
+  <img src="https://img.shields.io/badge/pnpm-11.10.0-F69220?logo=pnpm&logoColor=white" alt="pnpm 11.10.0" />
+  <img src="https://img.shields.io/badge/Final%20Cut%20Pro-macOS-000000?logo=apple&logoColor=white" alt="Final Cut Pro on macOS" />
   <a href="https://discord.gg/Dmp8FSF4vg"><img src="https://img.shields.io/badge/Discord-Join%20Chat-5865F2?logo=discord&logoColor=white" alt="Join the Framekit Discord" /></a>
 </p>
 
 # Framekit
 
-Agentic video editing runtime. 
+Agentic video editing runtime and MCP server for Final Cut Pro.
 
-## Installation
+## Get started
 
-Requirements:
+For repository development, you need:
+
+- Node.js 20 or newer;
+- pnpm 11.10.0;
+- Xcode 16.4 and the macOS 15.5 SDK for native Final Cut work.
+
+The Xcode requirement is only needed for the native Workflow Extension. For the
+pinned Node and shell toolchain, enter the optional Nix shell first:
+
+```sh
+nix develop ./nix
+```
+
+From the repository root, install dependencies and run the deterministic checks:
 
 ```sh
 pnpm install --frozen-lockfile
 pnpm run hooks:install
-pnpm run test
 pnpm run build
+pnpm run test
+pnpm run check:boundaries
 ```
 
-## Quick Start
+## Try the local MCP server
 
-The reproducible Node shell and native toolchain contract live under [`nix/`](nix/). Enter it with `nix develop ./nix`, then run `pnpm run xcode:check` before building the Final Cut Workflow Extension.
-
-## MCP server
-
-The local MCP server uses the deterministic in-memory Phase 2 fixture:
+The local MCP server uses a deterministic in-memory fixture and communicates over
+stdio. Start it from the repository root and connect it to an MCP client:
 
 ```sh
 pnpm run mcp
 ```
 
-The default `.env.example` starts the Diffusers visual service without the optional music stack. `Cmd-D` toggles Developer Mode and `Cmd-F` toggles the borderless exhibition presentation.
+See the [MCP tools](./docs/mcp/tools.md) and [MCP documentation](./docs/mcp/README.md)
+for the tool inventory and live-backend setup.
 
 ## Connect Codex to Final Cut
 
-Install the signed Framekit Workflow Extension from the latest release, then
-configure the Framekit marketplace once:
+The Codex plugin provides the MCP integration; the Final Cut Workflow Extension
+is installed separately. Download a signed extension from a
+[Framekit GitHub release](https://github.com/morshoto/framekit/releases) when a
+release asset is available, then configure the Framekit marketplace once:
 
 ```sh
 codex plugin marketplace add morshoto/framekit
@@ -56,12 +70,23 @@ existing Workflow Extension bridge and does not launch, activate, focus, or
 edit Final Cut through macOS UI automation. See the
 [first-run setup and capability boundaries](./docs/final-cut/installation.md).
 
+For local native development, use the checkout's CLI wrapper from the repository
+root:
+
+```sh
+pnpm run xcode:check
+bash adapters/final-cut/swift-bridge/FinalCutWorkflowExtension/build.sh
+pnpm run framekit -- connect finalcut --development
+```
+
 ## Further Docs
 
 - [Documentation index](./docs/README.md)
+- [Getting started](./docs/getting-started.md)
 - [Architecture](./docs/ARCHITECTURE.md)
 - [Clean Codex and Claude Code MCP validation](./docs/tests/clean-mcp-clients.md)
 
 ## Development
 
-Contributor setup, including the local pre-commit hook, is documented in [`CONTRIBUTOR.md`](CONTRIBUTOR.md).
+Contributor setup, repository layout, native checks, and the local pre-commit
+hook are documented in [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/adapters/final-cut/swift-bridge/FinalCutWorkflowExtension/README.md
+++ b/adapters/final-cut/swift-bridge/FinalCutWorkflowExtension/README.md
@@ -6,8 +6,9 @@ the Node MCP process must never attempt to load `ProExtensionHost` itself.
 
 ## Build with full Xcode
 
-Before opening the project, run `npm run xcode:check`. The checked-in native
-baseline is Xcode 16.4 with the macOS 15.5 SDK; see
+From the repository root, before opening the project, run
+`pnpm run xcode:check`. The checked-in native baseline is Xcode 16.4 with the
+macOS 15.5 SDK; see
 [`nix/xcode-version.json`](../../../../nix/xcode-version.json).
 
 The checked-in XcodeGen project supplies the container app, extension target,
@@ -30,7 +31,7 @@ The extension publishes a newline-delimited JSON protocol on
 Framekit connects with:
 
 ```sh
-FRAMEKIT_EDITOR=final-cut-live npm run mcp
+FRAMEKIT_EDITOR=final-cut-live pnpm run mcp
 ```
 
 Set `FRAMEKIT_FINAL_CUT_SOCKET` explicitly when using a non-default socket.
@@ -52,7 +53,8 @@ Project catalog and selection requests are not advertised by this bridge. The
 public host API exposes only the active sequence, so callers receive
 `CAPABILITY_UNAVAILABLE` rather than an inferred project browser.
 
-The local build is ad-hoc signed for development. `framekit connect finalcut`
+The local build is ad-hoc signed for development. From the repository root,
+`pnpm run framekit -- connect finalcut`
 installs the containing app into the user's Applications directory and
 activates Framekit through Final Cut's Extensions menu. Release artifacts must
 be Developer ID signed and notarized before distribution.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,8 +8,7 @@ Repository-local GitHub agent playbooks are documented in
 - [Getting started](./getting-started.md): development setup, MCP, and Final Cut connection.
 - [Releasing](./releasing.md): npm Trusted Publishing and automated GitHub releases.
 - [PRD](./PRD.md): product goals and roadmap.
-- [Phase 0 and Phase 1 checklist](./phase-0-1-checklist.md): delivery gates,
-  evidence, and current native Final Cut boundaries.
+- [Test matrix](./tests/test-matrix.md): delivery scope and evidence by backend.
 - [SDD](./SDD.md): architecture and design contracts.
 - [Compatibility](./COMPATIBILITY.md): verified editor and toolchain support.
 - [MCP](./mcp/README.md): agent-facing protocol and tools.

--- a/docs/final-cut/installation.md
+++ b/docs/final-cut/installation.md
@@ -2,16 +2,18 @@
 
 ## Toolchain
 
-Use the repository's Nix shell for Node and shell tooling:
+From the repository root, use the repository's Nix shell for Node and shell
+tooling:
 
 ```sh
 nix develop ./nix
 ```
 
-Xcode remains a host dependency. Confirm the selected version:
+Xcode remains a host dependency. Confirm the selected version from the
+repository root:
 
 ```sh
-npm run xcode:check
+pnpm run xcode:check
 ```
 
 The verified native baseline is Xcode 16.4 / build 16F6 with macOS SDK 15.5.
@@ -20,8 +22,10 @@ The verified native baseline is Xcode 16.4 / build 16F6 with macOS SDK 15.5.
 
 The Codex plugin installs the Framekit MCP integration, but it does not replace
 the Final Cut Workflow Extension. Install the signed extension application from
-the latest Framekit release before the first live session. The install is
-per-user and does not require administrator privileges.
+a [Framekit GitHub release](https://github.com/morshoto/framekit/releases)
+before the first live session. If a release has no extension asset, use the
+[development build](#development-build) below. The install is per-user and
+does not require administrator privileges.
 
 Configure the Framekit marketplace once:
 
@@ -72,7 +76,7 @@ bash adapters/final-cut/swift-bridge/FinalCutWorkflowExtension/build.sh
 Build and connect the generated development app through Framekit:
 
 ```sh
-framekit connect finalcut --development
+pnpm run framekit -- connect finalcut --development
 ```
 
 The explicit `connect` command may gracefully quit and reopen Final Cut Pro
@@ -93,7 +97,7 @@ in the live MCP session, provide an exported FCPXML file:
 ```sh
 FRAMEKIT_EDITOR=final-cut-live \
 FRAMEKIT_FCPXML_PATH=/absolute/path/to/project.fcpxml \
-framekit mcp --editor final-cut-live
+pnpm run framekit -- mcp --editor final-cut-live
 ```
 
 The FCPXML file is the managed artifact. Framekit does not automatically
@@ -110,7 +114,7 @@ Accessibility and Automation permission in System Settings:
 
 ```sh
 FRAMEKIT_FINAL_CUT_NATIVE_WRITES=1 \
-framekit mcp --editor final-cut-live
+pnpm run framekit -- mcp --editor final-cut-live
 ```
 
 The same opt-in enables `timeline.export`, provided `ffprobe` is available on

--- a/docs/final-cut/troubleshooting.md
+++ b/docs/final-cut/troubleshooting.md
@@ -1,11 +1,15 @@
 # Final Cut Pro Troubleshooting
 
+Commands using `pnpm` below assume a repository checkout and a shell running
+from its root. For a published installation, use the equivalent
+`npx -y @morshoto/framekit` command.
+
 ## Connection status
 
 Inspect the machine-readable setup state:
 
 ```sh
-framekit doctor finalcut --json
+pnpm run framekit -- doctor finalcut --json
 ```
 
 The MCP server exposes the same state through `connection.status`. It reports
@@ -20,14 +24,14 @@ The normal Framekit flow activates the extension automatically. First check:
 ls -l ~/Library/Containers/com.framekit.finalcut.workflow.extension/Data/framekit.sock
 ```
 
-If the socket is absent, run `framekit doctor finalcut --json`. If the state is
+If the socket is absent, run `pnpm run framekit -- doctor finalcut --json`. If the state is
 `needs-user-action`, follow the reported macOS permission or installation
 message. If the state is `unavailable` with `FINAL_CUT_LIVE_TIMEOUT`, use the
 explicit development connection flow, which reloads Final Cut after replacing
 the extension:
 
 ```sh
-framekit connect finalcut --development --json
+pnpm run framekit -- connect finalcut --development --json
 ```
 
 The command quits gracefully and reopens Final Cut only when it has replaced
@@ -60,7 +64,7 @@ with Accessibility and never closes it.
 
 ## Build or signing errors
 
-Run `npm run xcode:check`, verify that Xcode 16.4 is selected, rebuild, and
+Run `pnpm run xcode:check`, verify that Xcode 16.4 is selected, rebuild, and
 verify the installed app with `codesign --verify --deep --strict`.
 
 For release artifacts, set `FRAMEKIT_EXTENSION_APP_PATH` only when intentionally

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,8 +7,20 @@ discovery, and the Phase 1 Final Cut runtime.
 
 ## Development setup
 
-Install the JavaScript dependencies and run the deterministic checks from the
-repository root:
+Requirements:
+
+- Node.js 20 or newer;
+- pnpm 11.10.0;
+- Xcode 16.4 and the macOS 15.5 SDK for native Final Cut work.
+
+For the pinned Node and shell toolchain, enter the optional Nix shell first:
+
+```sh
+nix develop ./nix
+```
+
+Then install the JavaScript dependencies and run the deterministic checks from
+the repository root:
 
 ```sh
 pnpm install --frozen-lockfile
@@ -18,11 +30,9 @@ pnpm run build
 pnpm run check:boundaries
 ```
 
-The reproducible Node shell and native toolchain are provided by the
-repository's Nix shell:
+For native work, validate the host Xcode installation:
 
 ```sh
-nix develop ./nix
 pnpm run xcode:check
 ```
 
@@ -78,8 +88,11 @@ variable. The complete provider setup is documented in the
 
 ## Connect Codex to Final Cut
 
-Install the signed Framekit Workflow Extension from a Framekit release. Then
-add the Framekit marketplace once without cloning the repository:
+Install the signed Framekit Workflow Extension from a
+[Framekit GitHub release](https://github.com/morshoto/framekit/releases) when a
+release asset is available. If a release has no extension asset, follow the
+development build steps below. Then add the Framekit marketplace once without
+cloning the repository:
 
 ```sh
 codex plugin marketplace add morshoto/framekit
@@ -104,13 +117,13 @@ For normal repository development mode, build and connect the native extension
 with:
 
 ```sh
-framekit connect finalcut --development
+pnpm run framekit -- connect finalcut --development
 ```
 
 Inspect automatic setup and reconnect progress with:
 
 ```sh
-framekit doctor finalcut --json
+pnpm run framekit -- doctor finalcut --json
 ```
 
 The live bridge uses the per-user socket at

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -9,8 +9,9 @@ the native bridge.
 - [Capabilities and errors](./capabilities-and-errors.md): fail-closed rules.
 - [Final Cut live backend](./final-cut-live.md): selecting and probing it.
 
-The default `npm run mcp` configuration uses the deterministic in-memory
+The default `pnpm run mcp` configuration uses the deterministic in-memory
 fixture. Set `FRAMEKIT_EDITOR=final-cut-live` to select the live Final Cut
-backend, or use `framekit mcp --editor final-cut-live` to enable automatic
-connection setup. Add `FRAMEKIT_FCPXML_PATH` to enable the canonical document
-surface alongside live state.
+backend, or use `pnpm run framekit -- mcp --editor final-cut-live` to enable
+automatic connection setup from a development checkout. Add
+`FRAMEKIT_FCPXML_PATH` to enable the canonical document surface alongside live
+state.

--- a/docs/mcp/final-cut-live.md
+++ b/docs/mcp/final-cut-live.md
@@ -1,5 +1,9 @@
 # Selecting the Live Final Cut Backend
 
+Commands using `pnpm` below assume a repository checkout and a shell running
+from its root. End users should use the Codex plugin or the published `npx`
+commands shown in this guide.
+
 For end users, configure the Framekit marketplace once:
 
 ```sh
@@ -20,9 +24,10 @@ In normal (non-headless) mode, the Framekit MCP process automatically:
 - retries after Final Cut or extension restarts.
 
 It does not quit or reopen Final Cut automatically. The explicit
-`framekit connect finalcut` command is the recovery path when it has replaced
-the extension and Final Cut needs to reload the bundle; that command performs
-a graceful quit/reopen before activation.
+`connect finalcut` command is the recovery path when it has replaced the
+extension and Final Cut needs to reload the bundle; that command performs a
+graceful quit/reopen before activation. From a repository checkout, invoke it
+as `pnpm run framekit -- connect finalcut`.
 
 The registration above uses headless mode, so it skips that lifecycle recovery
 and only probes the existing socket.
@@ -31,7 +36,7 @@ The bundled Workflow Extension connection is metadata-only. Check setup progress
 tool `connection.status` or:
 
 ```sh
-framekit doctor finalcut --json
+pnpm run framekit -- doctor finalcut --json
 ```
 
 ## Headless mode
@@ -40,7 +45,7 @@ For repository development without the plugin, start the equivalent headless
 live server with:
 
 ```sh
-framekit mcp --editor final-cut-live --headless
+pnpm run framekit -- mcp --editor final-cut-live --headless
 ```
 
 Headless mode only probes the existing Workflow Extension socket. It does not
@@ -61,7 +66,7 @@ pnpm run test:final-cut-headless
 For a development checkout, use:
 
 ```sh
-framekit connect finalcut --development
+pnpm run framekit -- connect finalcut --development
 ```
 
 For a non-default socket:
@@ -69,7 +74,7 @@ For a non-default socket:
 ```sh
 FRAMEKIT_EDITOR=final-cut-live \
 FRAMEKIT_FINAL_CUT_SOCKET=/tmp/framekit-finalcut-custom.sock \
-npm run mcp
+pnpm run mcp
 ```
 
 The live backend reads active project/sequence metadata, playhead, selected
@@ -98,7 +103,7 @@ To enable selection-scoped native UI edits:
 
 ```sh
 FRAMEKIT_FINAL_CUT_NATIVE_WRITES=1 \
-framekit mcp --editor final-cut-live
+pnpm run framekit -- mcp --editor final-cut-live
 ```
 
 Grant Accessibility and Automation permission to the terminal or host running

--- a/docs/tests/final-cut-live-e2e.md
+++ b/docs/tests/final-cut-live-e2e.md
@@ -21,9 +21,9 @@ claiming that the open Final Cut timeline was mutated.
 ## Build and connect
 
 ```sh
-npm run xcode:check
+pnpm run xcode:check
 bash adapters/final-cut/swift-bridge/FinalCutWorkflowExtension/build.sh
-framekit connect finalcut --development --json
+pnpm run framekit -- connect finalcut --development --json
 ```
 
 The command detects or launches Final Cut, installs the development bundle into
@@ -40,7 +40,7 @@ ls -l ~/Library/Containers/com.framekit.finalcut.workflow.extension/Data/frameki
 Use the live backend through the standard Codex MCP registration:
 
 ```sh
-codex mcp add framekit -- framekit mcp --editor final-cut-live
+codex mcp add framekit -- pnpm run framekit -- mcp --editor final-cut-live
 ```
 
 The MCP `connection.status` tool should report `ready` before the live state
@@ -60,7 +60,7 @@ For canonical MCP coverage, start the server with:
 ```sh
 FRAMEKIT_EDITOR=final-cut-live \
 FRAMEKIT_FCPXML_PATH=/absolute/path/to/exported.fcpxml \
-framekit mcp --editor final-cut-live
+pnpm run framekit -- mcp --editor final-cut-live
 ```
 
 Then verify `project.inspect`, `timeline.inspect`, `context.inspect`,


### PR DESCRIPTION
## Summary
- replace stale root README setup content with accurate Node/pnpm/MCP onboarding
- repair broken documentation and contributor links
- document checkout CLI invocation, release extension fallback, and consistent pnpm commands

## Validation
- pnpm install --frozen-lockfile
- pnpm run build
- pnpm run test (287 passed)
- pnpm run check:boundaries
- pnpm run test:codex-plugin
- Markdown relative-link scan (60 files)
- pre-commit hook including xcode:check and xcodebuild -list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified required tools and platform prerequisites, including Node.js, pnpm, Xcode, macOS SDK, and optional Nix setup.
  * Updated installation and development instructions with consistent `pnpm` commands and validation steps.
  * Documented signed Workflow Extension releases, development-build fallbacks, and Codex integration.
  * Improved Final Cut connection, MCP, diagnostics, troubleshooting, and live workflow guidance.
  * Added Getting Started references and updated contributor setup instructions, including pre-commit hook installation.
  * Replaced outdated documentation navigation with a test matrix link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->