### PR TITLE
feat: define editorial duration policy

### DIFF
--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -22,6 +22,27 @@ const rangeSchema = z.object({
   start: z.number().nonnegative(),
   end: z.number().positive(),
 });
+const durationRangeSchema = z.object({
+  startSeconds: z.number().finite().nonnegative(),
+  endSeconds: z.number().finite().positive(),
+});
+const durationPolicyInputSchema = z.object({
+  requestedDurationSeconds: z.number().finite().positive(),
+  footage: z.array(z.object({
+    id: z.string().trim().min(1),
+    durationSeconds: z.number().finite().positive(),
+    usableDurationSeconds: z.number().finite().positive().optional(),
+    usableRanges: z.array(durationRangeSchema).optional(),
+    reusable: z.boolean().optional(),
+  })),
+  constraint: z.enum(["hard", "soft"]).optional(),
+  permissions: z.object({
+    allowReuse: z.boolean().optional(),
+    allowSlowMotion: z.boolean().optional(),
+    allowGeneratedAssets: z.boolean().optional(),
+  }).optional(),
+  actualDurationSeconds: z.number().finite().nonnegative().optional(),
+});
 const markerSchema = z.object({
     id: z.string().min(1),
     start: z.number().nonnegative(),
@@ -265,6 +286,11 @@ export function createMcpServer(runtime: AgentVideoRuntime, options: McpServerOp
     description: "Map a supported natural-language editing request to one explicit operation without executing it.",
     inputSchema: { request: z.string().trim().min(1) },
   }, async ({ request }) => jsonResult(resolveEditingIntent(request)));
+
+  server.registerTool("editing.duration.plan", {
+    description: "Plan requested duration against unique footage and return explicit quality-preserving alternatives without editing.",
+    inputSchema: durationPolicyInputSchema,
+  }, async (request) => jsonResult(runtime.planDuration(request)));
 
   server.registerTool("editor.native.inspect", {
     description: "Inspect the active Final Cut selection/playhead before a native UI edit.",

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Repository-local GitHub agent playbooks are documented in
 - [SDD](./SDD.md): architecture and design contracts.
 - [Compatibility](./COMPATIBILITY.md): verified editor and toolchain support.
 - [MCP](./mcp/README.md): agent-facing protocol and tools.
+- [Rough-cut duration policy](./rough-cut/duration-policy.md): explicit duration tradeoffs and safety defaults.
 - [Tests](./tests/README.md): reproducible checks and evidence, including the [golden workflow corpus](./tests/golden-corpus.md) and [deterministic MCP evaluation](./tests/mcp-evaluation.md).
 - [Final Cut](./final-cut/README.md): native integration and operations.
 - [Native media insertion breakthrough](./final-cut/native-media-insertion-breakthrough.md):

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -6,6 +6,7 @@ the native bridge.
 
 - [Protocol](./protocol.md): live Final Cut IPC framing and request methods.
 - [Tools](./tools.md): MCP tool names, inputs, and behavior.
+- [Rough-cut duration policy](../rough-cut/duration-policy.md): explicit duration tradeoffs for planning workflows.
 - [Capabilities and errors](./capabilities-and-errors.md): fail-closed rules.
 - [Final Cut live backend](./final-cut-live.md): selecting and probing it.
 

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -7,6 +7,7 @@
 | `connection.status` | Framekit Final Cut setup and connection state | Available during live setup and reconnect |
 | `editor.inspect` | Editor identity and capabilities | Available when a backend is selected |
 | `editing.intent.resolve` | Map one supported natural-language request to an explicit operation and affected range | Read-only; ambiguous requests return clarification and no operation; resolved destructive requests set `previewRequired` |
+| `editing.duration.plan` | Compare requested duration with usable footage and return explicit editorial alternatives | Read-only; ambiguous duration requests default to a soft constraint; reuse, slow motion, and generated assets are never implicit |
 | `editor.native.inspect` | Active native Final Cut selection/playhead and UI focus diagnostics | Requires native writes opt-in and Accessibility permission |
 | `editor.native.focus` | Activate Final Cut and focus the timeline without editing | Bounded retry; returns focus diagnostics on failure |
 | `editor.native.edit` | Selection-scoped native Final Cut edit | Requires native writes opt-in and Final Cut frontmost |
@@ -58,6 +59,22 @@
 | `edit.diff` | Transaction diff | Fixture/FCPXML transaction path or a canonical-capable live Final Cut bridge |
 | `edit.verify` | Verification results | Fixture/FCPXML transaction path or a canonical-capable live Final Cut bridge |
 | `edit.undo` | Restore a transaction | Fixture/FCPXML transaction path or a canonical-capable live Final Cut bridge |
+
+## Duration planning
+
+`editing.duration.plan` is a read-only planning tool for rough-cut workflows.
+It accepts `requestedDurationSeconds`, a footage inventory with optional usable
+ranges and reusable flags, an optional `hard` or `soft` constraint, and explicit
+permissions for reuse, slow motion, or generated assets. Ambiguous duration
+requests default to a soft constraint. The response identifies the selected
+action, available unique and reusable footage, any reused source ranges, every
+alternative and tradeoff, and `durationReport` with
+`requestedDurationSeconds`, `achievableDurationSeconds`, and
+`actualDurationSeconds`.
+
+The tool never edits the timeline and never silently duplicates, stretches, or
+generates material. Call it before a rough-cut plan or `timeline.edit.preview`,
+then require confirmation for any alternative that changes source treatment.
 
 ## Live Final Cut tools
 

--- a/docs/rough-cut/duration-policy.md
+++ b/docs/rough-cut/duration-policy.md
@@ -1,0 +1,41 @@
+# Rough-cut duration policy
+
+Status: implemented policy contract for issue #87.
+
+The duration planner runs before a rough-cut shot plan chooses timing. It sums
+each source's usable ranges once as `uniqueDurationSeconds` and separately
+reports the amount marked `reusable`. A source is never repeated merely because
+the requested duration is longer than the unique footage.
+
+## Constraint policy
+
+Callers may classify a requested duration as `hard` or `soft`. Ambiguous duration requests default to soft. A soft constraint recommends delivering a shorter
+strong edit when unique footage is insufficient. A hard constraint remains
+unmet unless the plan explicitly selects an allowed alternative or requests
+additional footage.
+
+The planner never silently loops or slows footage. Reuse is represented by
+explicit `reusedRanges` containing the source ID, source range, and occurrence
+number. Slow motion and generated/interstitial assets remain alternatives that
+require confirmation, even when the caller permits them. Generated assets are
+not permitted by default.
+
+## Alternatives and reporting
+
+An insufficient-footage plan lists the tradeoffs for:
+
+- a shorter strong edit;
+- intentional reuse of selected B-roll;
+- editorially appropriate slow motion;
+- requesting additional footage; and
+- generated or interstitial assets when explicitly allowed.
+
+Every plan and final result reports requested, achievable, and actual durations.
+The planning response uses `actualDurationSeconds: null` until an observed
+result is supplied. `editing.duration.plan` is read-only and can be called by
+MCP clients before `timeline.edit.preview` or a future rough-cut constructor.
+
+For a ten-minute request backed by four minutes of usable footage, the default
+result is a four-minute shorter strong edit, with the other choices visible as
+explicit alternatives and the missing six minutes reported as an unmet
+duration constraint.

--- a/packages/runtime/src/application/duration-policy-service.ts
+++ b/packages/runtime/src/application/duration-policy-service.ts
@@ -1,0 +1,8 @@
+import type { DurationPolicyPlan, DurationPolicyRequest } from "../domain/duration.js";
+import { planDurationPolicy } from "../editing/duration-policy.js";
+
+export class DurationPolicyService {
+  public plan(request: DurationPolicyRequest): DurationPolicyPlan {
+    return planDurationPolicy(request);
+  }
+}

--- a/packages/runtime/src/domain/duration.ts
+++ b/packages/runtime/src/domain/duration.ts
@@ -1,0 +1,86 @@
+export type DurationConstraint = "hard" | "soft";
+
+export type DurationPolicyAction =
+  | "deliver-exact-duration"
+  | "deliver-shorter-strong-edit"
+  | "reuse-selected-b-roll"
+  | "request-additional-footage";
+
+export type DurationAlternativeKind =
+  | "deliver-shorter-strong-edit"
+  | "reuse-selected-b-roll"
+  | "slow-motion"
+  | "request-additional-footage"
+  | "generated-interstitial";
+
+export type DurationAlternativeStatus =
+  | "recommended"
+  | "available"
+  | "requires-confirmation"
+  | "not-permitted";
+
+export interface DurationRange {
+  startSeconds: number;
+  endSeconds: number;
+}
+
+export interface DurationPolicyFootage {
+  id: string;
+  durationSeconds: number;
+  usableDurationSeconds?: number;
+  usableRanges?: DurationRange[];
+  reusable?: boolean;
+}
+
+export interface DurationPolicyPermissions {
+  allowReuse?: boolean;
+  allowSlowMotion?: boolean;
+  allowGeneratedAssets?: boolean;
+}
+
+export interface DurationPolicyRequest {
+  requestedDurationSeconds: number;
+  footage: DurationPolicyFootage[];
+  constraint?: DurationConstraint;
+  permissions?: DurationPolicyPermissions;
+  actualDurationSeconds?: number;
+}
+
+export interface DurationRangeUse {
+  footageId: string;
+  sourceRange: DurationRange;
+  occurrence: number;
+}
+
+export interface DurationPolicyAlternative {
+  kind: DurationAlternativeKind;
+  status: DurationAlternativeStatus;
+  resultingDurationSeconds: number | null;
+  tradeoffs: string[];
+  confirmationRequired?: string;
+  reusedRanges?: DurationRangeUse[];
+}
+
+export interface DurationPolicyPlan {
+  policy: {
+    constraint: DurationConstraint;
+    constraintWasExplicit: boolean;
+  };
+  requestedDurationSeconds: number;
+  availableFootage: {
+    uniqueDurationSeconds: number;
+    reusableDurationSeconds: number;
+  };
+  achievableDurationSeconds: number;
+  actualDurationSeconds: number | null;
+  durationReport: {
+    requestedDurationSeconds: number;
+    achievableDurationSeconds: number;
+    actualDurationSeconds: number | null;
+  };
+  selectedAction: DurationPolicyAction;
+  reusedRanges: DurationRangeUse[];
+  unmetConstraints: string[];
+  confirmationRequired: string[];
+  alternatives: DurationPolicyAlternative[];
+}

--- a/packages/runtime/src/domain/index.ts
+++ b/packages/runtime/src/domain/index.ts
@@ -7,3 +7,4 @@ export * from "./diff.js";
 export * from "./capabilities.js";
 export * from "./ports.js";
 export * from "./verification.js";
+export * from "./duration.js";

--- a/packages/runtime/src/editing/duration-policy.ts
+++ b/packages/runtime/src/editing/duration-policy.ts
@@ -39,7 +39,7 @@ export function planDurationPolicy(request: DurationPolicyRequest): DurationPoli
   const achievableDurationSeconds = selectedAction === "reuse-selected-b-roll"
     ? request.requestedDurationSeconds
     : uniqueDurationSeconds;
-  const unmetConstraints = insufficient
+  const unmetConstraints = insufficient && selectedAction !== "reuse-selected-b-roll"
     ? ["Requested duration exceeds unique usable footage"]
     : [];
   if (constraint === "hard" && insufficient && selectedAction !== "reuse-selected-b-roll") {

--- a/packages/runtime/src/editing/duration-policy.ts
+++ b/packages/runtime/src/editing/duration-policy.ts
@@ -1,6 +1,4 @@
 import type {
-  DurationAlternativeKind,
-  DurationAlternativeStatus,
   DurationPolicyFootage,
   DurationPolicyPlan,
   DurationPolicyRequest,
@@ -133,14 +131,18 @@ function buildAlternatives(input: {
 }
 
 function normalizeFootage(item: DurationPolicyFootage): NormalizedFootage {
-  const usableRanges = item.usableRanges?.map((range) => ({ ...range })) ?? [{
+  const usableRanges = item.usableRanges?.map((range) => ({ ...range })).sort((left, right) => left.startSeconds - right.startSeconds) ?? [{
     startSeconds: 0,
     endSeconds: item.usableDurationSeconds ?? item.durationSeconds,
   }];
-  for (const range of usableRanges) {
+  for (const [index, range] of usableRanges.entries()) {
     if (!Number.isFinite(range.startSeconds) || !Number.isFinite(range.endSeconds)
       || range.startSeconds < 0 || range.endSeconds <= range.startSeconds || range.endSeconds > item.durationSeconds) {
       throw new Error(`INVALID_DURATION_FOOTAGE: invalid usable range for ${item.id}`);
+    }
+    const previous = usableRanges[index - 1];
+    if (previous && range.startSeconds < previous.endSeconds) {
+      throw new Error(`INVALID_DURATION_FOOTAGE: usable ranges overlap for ${item.id}`);
     }
   }
   const usableDurationSeconds = sum(usableRanges.map((range) => range.endSeconds - range.startSeconds));
@@ -186,10 +188,16 @@ function validateRequest(request: DurationPolicyRequest): void {
     && (!Number.isFinite(request.actualDurationSeconds) || request.actualDurationSeconds < 0)) {
     throw new Error("INVALID_DURATION_POLICY: actual duration must be non-negative");
   }
+  const footageIds = new Set<string>();
   for (const item of request.footage) {
+    const normalizedId = item.id.trim();
     if (!item.id.trim() || !Number.isFinite(item.durationSeconds) || item.durationSeconds <= 0) {
       throw new Error("INVALID_DURATION_FOOTAGE: id and positive duration are required");
     }
+    if (footageIds.has(normalizedId)) {
+      throw new Error(`INVALID_DURATION_FOOTAGE: duplicate footage id ${normalizedId}`);
+    }
+    footageIds.add(normalizedId);
     if (item.usableDurationSeconds !== undefined
       && (!Number.isFinite(item.usableDurationSeconds) || item.usableDurationSeconds <= 0
         || item.usableDurationSeconds > item.durationSeconds)) {
@@ -201,5 +209,3 @@ function validateRequest(request: DurationPolicyRequest): void {
 function sum(values: number[]): number {
   return values.reduce((total, value) => total + value, 0);
 }
-
-export type { DurationAlternativeKind, DurationAlternativeStatus, DurationRange };

--- a/packages/runtime/src/editing/duration-policy.ts
+++ b/packages/runtime/src/editing/duration-policy.ts
@@ -34,9 +34,9 @@ export function planDurationPolicy(request: DurationPolicyRequest): DurationPoli
   const reusedRanges = selectedAction === "reuse-selected-b-roll"
     ? buildReusePlan(footage, request.requestedDurationSeconds - uniqueDurationSeconds)
     : [];
-  const achievableDurationSeconds = selectedAction === "reuse-selected-b-roll"
-    ? request.requestedDurationSeconds
-    : uniqueDurationSeconds;
+  const achievableDurationSeconds = insufficient && selectedAction !== "reuse-selected-b-roll"
+    ? uniqueDurationSeconds
+    : request.requestedDurationSeconds;
   const unmetConstraints = insufficient && selectedAction !== "reuse-selected-b-roll"
     ? ["Requested duration exceeds unique usable footage"]
     : [];

--- a/packages/runtime/src/editing/duration-policy.ts
+++ b/packages/runtime/src/editing/duration-policy.ts
@@ -1,0 +1,205 @@
+import type {
+  DurationAlternativeKind,
+  DurationAlternativeStatus,
+  DurationPolicyFootage,
+  DurationPolicyPlan,
+  DurationPolicyRequest,
+  DurationRange,
+  DurationRangeUse,
+} from "../domain/duration.js";
+
+interface NormalizedFootage extends DurationPolicyFootage {
+  usableRanges: DurationRange[];
+  usableDurationSeconds: number;
+}
+
+const REQUEST_MORE_FOOTAGE = "Provide additional footage or confirm an explicit duration tradeoff";
+
+/** Create an explicit, deterministic duration plan without mutating an editor. */
+export function planDurationPolicy(request: DurationPolicyRequest): DurationPolicyPlan {
+  validateRequest(request);
+  const footage = request.footage.map(normalizeFootage);
+  const uniqueDurationSeconds = sum(footage.map((item) => item.usableDurationSeconds));
+  const reusableDurationSeconds = sum(
+    footage.filter((item) => item.reusable).map((item) => item.usableDurationSeconds),
+  );
+  const constraint = request.constraint ?? "soft";
+  const insufficient = request.requestedDurationSeconds > uniqueDurationSeconds;
+  const canReuse = request.permissions?.allowReuse === true && reusableDurationSeconds > 0;
+  const selectedAction = !insufficient
+    ? "deliver-exact-duration"
+    : constraint === "hard" && canReuse
+      ? "reuse-selected-b-roll"
+      : constraint === "hard"
+        ? "request-additional-footage"
+        : "deliver-shorter-strong-edit";
+  const reusedRanges = selectedAction === "reuse-selected-b-roll"
+    ? buildReusePlan(footage, request.requestedDurationSeconds - uniqueDurationSeconds)
+    : [];
+  const achievableDurationSeconds = selectedAction === "reuse-selected-b-roll"
+    ? request.requestedDurationSeconds
+    : uniqueDurationSeconds;
+  const unmetConstraints = insufficient
+    ? ["Requested duration exceeds unique usable footage"]
+    : [];
+  if (constraint === "hard" && insufficient && selectedAction !== "reuse-selected-b-roll") {
+    unmetConstraints.push("Hard duration constraint cannot be met with the selected footage");
+  }
+  const alternatives = insufficient
+    ? buildAlternatives({
+      request,
+      footage,
+      uniqueDurationSeconds,
+      reusableDurationSeconds,
+      recommendedAction: selectedAction,
+    })
+    : [];
+  const actualDurationSeconds = request.actualDurationSeconds ?? null;
+  const confirmationRequired = selectedAction === "request-additional-footage"
+    ? [REQUEST_MORE_FOOTAGE]
+    : [];
+  return {
+    policy: {
+      constraint,
+      constraintWasExplicit: request.constraint !== undefined,
+    },
+    requestedDurationSeconds: request.requestedDurationSeconds,
+    availableFootage: {
+      uniqueDurationSeconds,
+      reusableDurationSeconds,
+    },
+    achievableDurationSeconds,
+    actualDurationSeconds,
+    durationReport: {
+      requestedDurationSeconds: request.requestedDurationSeconds,
+      achievableDurationSeconds,
+      actualDurationSeconds,
+    },
+    selectedAction,
+    reusedRanges,
+    unmetConstraints,
+    confirmationRequired,
+    alternatives,
+  };
+}
+
+function buildAlternatives(input: {
+  request: DurationPolicyRequest;
+  footage: NormalizedFootage[];
+  uniqueDurationSeconds: number;
+  reusableDurationSeconds: number;
+  recommendedAction: DurationPolicyPlan["selectedAction"];
+}): DurationPolicyPlan["alternatives"] {
+  const { request, footage, uniqueDurationSeconds, reusableDurationSeconds, recommendedAction } = input;
+  const reuseRanges = reusableDurationSeconds > 0
+    ? buildReusePlan(footage, request.requestedDurationSeconds - uniqueDurationSeconds)
+    : [];
+  return [
+    {
+      kind: "deliver-shorter-strong-edit",
+      status: recommendedAction === "deliver-shorter-strong-edit" ? "recommended" : "available",
+      resultingDurationSeconds: uniqueDurationSeconds,
+      tradeoffs: ["Preserves the strongest unique footage", "Does not satisfy the requested duration"],
+    },
+    {
+      kind: "reuse-selected-b-roll",
+      status: request.permissions?.allowReuse && reusableDurationSeconds > 0 ? "available" : "requires-confirmation",
+      resultingDurationSeconds: reuseRanges.length > 0 ? request.requestedDurationSeconds : null,
+      tradeoffs: ["Meets the requested duration", "Repeats only the explicitly identified B-roll ranges"],
+      ...(reuseRanges.length > 0 ? { reusedRanges: reuseRanges } : {}),
+      ...(request.permissions?.allowReuse !== true ? { confirmationRequired: "Confirm intentional B-roll reuse" } : {}),
+    },
+    {
+      kind: "slow-motion",
+      status: "requires-confirmation",
+      resultingDurationSeconds: request.requestedDurationSeconds,
+      tradeoffs: ["May preserve coverage without adding footage", "Can harm motion quality or editorial pacing"],
+      confirmationRequired: "Confirm which footage is editorially appropriate for slow motion",
+    },
+    {
+      kind: "request-additional-footage",
+      status: "available",
+      resultingDurationSeconds: request.requestedDurationSeconds,
+      tradeoffs: ["Preserves natural playback speed and unique coverage", "Requires more source material"],
+    },
+    {
+      kind: "generated-interstitial",
+      status: request.permissions?.allowGeneratedAssets === true ? "requires-confirmation" : "not-permitted",
+      resultingDurationSeconds: request.requestedDurationSeconds,
+      tradeoffs: ["Can fill the remaining duration", "Introduces generated or external content"],
+      confirmationRequired: "Confirm generated or interstitial assets are allowed",
+    },
+  ];
+}
+
+function normalizeFootage(item: DurationPolicyFootage): NormalizedFootage {
+  const usableRanges = item.usableRanges?.map((range) => ({ ...range })) ?? [{
+    startSeconds: 0,
+    endSeconds: item.usableDurationSeconds ?? item.durationSeconds,
+  }];
+  for (const range of usableRanges) {
+    if (!Number.isFinite(range.startSeconds) || !Number.isFinite(range.endSeconds)
+      || range.startSeconds < 0 || range.endSeconds <= range.startSeconds || range.endSeconds > item.durationSeconds) {
+      throw new Error(`INVALID_DURATION_FOOTAGE: invalid usable range for ${item.id}`);
+    }
+  }
+  const usableDurationSeconds = sum(usableRanges.map((range) => range.endSeconds - range.startSeconds));
+  return { ...item, usableRanges, usableDurationSeconds };
+}
+
+function buildReusePlan(footage: NormalizedFootage[], requestedAdditionalSeconds: number): DurationRangeUse[] {
+  if (requestedAdditionalSeconds <= 0) return [];
+  const reusable = footage.filter((item) => item.reusable);
+  const result: DurationRangeUse[] = [];
+  let remaining = requestedAdditionalSeconds;
+  let occurrence = 1;
+  while (remaining > 0 && reusable.length > 0) {
+    let addedThisPass = 0;
+    for (const item of reusable) {
+      for (const range of item.usableRanges) {
+        if (remaining <= 0) break;
+        const length = range.endSeconds - range.startSeconds;
+        const selectedLength = Math.min(length, remaining);
+        result.push({
+          footageId: item.id,
+          sourceRange: {
+            startSeconds: range.startSeconds,
+            endSeconds: range.startSeconds + selectedLength,
+          },
+          occurrence,
+        });
+        remaining -= selectedLength;
+        addedThisPass += selectedLength;
+      }
+    }
+    if (addedThisPass === 0) break;
+    occurrence += 1;
+  }
+  return result;
+}
+
+function validateRequest(request: DurationPolicyRequest): void {
+  if (!Number.isFinite(request.requestedDurationSeconds) || request.requestedDurationSeconds <= 0) {
+    throw new Error("INVALID_DURATION_POLICY: requested duration must be positive");
+  }
+  if (request.actualDurationSeconds !== undefined
+    && (!Number.isFinite(request.actualDurationSeconds) || request.actualDurationSeconds < 0)) {
+    throw new Error("INVALID_DURATION_POLICY: actual duration must be non-negative");
+  }
+  for (const item of request.footage) {
+    if (!item.id.trim() || !Number.isFinite(item.durationSeconds) || item.durationSeconds <= 0) {
+      throw new Error("INVALID_DURATION_FOOTAGE: id and positive duration are required");
+    }
+    if (item.usableDurationSeconds !== undefined
+      && (!Number.isFinite(item.usableDurationSeconds) || item.usableDurationSeconds <= 0
+        || item.usableDurationSeconds > item.durationSeconds)) {
+      throw new Error(`INVALID_DURATION_FOOTAGE: usable duration exceeds source duration for ${item.id}`);
+    }
+  }
+}
+
+function sum(values: number[]): number {
+  return values.reduce((total, value) => total + value, 0);
+}
+
+export type { DurationAlternativeKind, DurationAlternativeStatus, DurationRange };

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -3,6 +3,7 @@ export * from "./runtime.js";
 export * from "./timeline/snapshot-diff.js";
 export * from "./verification/verification.js";
 export * from "./editing/intent.js";
+export * from "./editing/duration-policy.js";
 export * from "./capabilities.js";
 export * from "./timeline/snapshot-digest.js";
 export * from "./speech/filler-removal.js";

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -26,6 +26,8 @@ import type {
   TimeRange,
   VerificationPolicy,
   VisualAnalysis,
+  DurationPolicyPlan,
+  DurationPolicyRequest,
 } from "./domain/index.js";
 import type { FillerRemovalPreview, FillerRemovalRequest } from "./speech/filler-removal.js";
 import { DefaultVerificationEngine } from "./verification/verification.js";
@@ -37,6 +39,7 @@ import { MusicService } from "./editing/music-service.js";
 import { ProjectService } from "./application/project-service.js";
 import type { RuntimeOptions } from "./application/runtime-options.js";
 import { TransactionStore } from "./application/transaction-store.js";
+import { DurationPolicyService } from "./application/duration-policy-service.js";
 
 /** Stable runtime façade exposed to the MCP server and editor adapters. */
 export class AgentVideoRuntime {
@@ -46,6 +49,7 @@ export class AgentVideoRuntime {
   private readonly edits: EditService;
   private readonly music: MusicService;
   private readonly fillerRemoval: FillerRemovalService;
+  private readonly durationPolicy: DurationPolicyService;
 
   public constructor(
     adapter: EditorPort,
@@ -60,6 +64,7 @@ export class AgentVideoRuntime {
     this.edits = new EditService(adapter, this.projects, this.media, verificationEngine, options, transactions);
     this.music = new MusicService(this.projects, this.edits);
     this.fillerRemoval = new FillerRemovalService(adapter, this.projects, verificationEngine, options, transactions);
+    this.durationPolicy = new DurationPolicyService();
   }
 
   public async inspectProject(): Promise<ProjectSnapshot> {
@@ -148,6 +153,10 @@ export class AgentVideoRuntime {
 
   public async understandMedia(mediaId: string): Promise<MediaUnderstanding> {
     return this.media.understandMedia(mediaId);
+  }
+
+  public planDuration(request: DurationPolicyRequest): DurationPolicyPlan {
+    return this.durationPolicy.plan(request);
   }
 
   public async inspectMedia(mediaId: string): Promise<MediaContext> {

--- a/tests/integration/duration-policy.test.ts
+++ b/tests/integration/duration-policy.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { planDurationPolicy } from "@framekit/runtime";
+import { AgentVideoRuntime, planDurationPolicy } from "@framekit/runtime";
+import { InMemoryEditorAdapter } from "@framekit/testkit";
 
 test("duration planning recommends a shorter strong edit for ten minutes of requested time and four minutes of footage", () => {
   const plan = planDurationPolicy({
@@ -71,4 +72,24 @@ test("duration planning never silently selects slow motion or generated assets",
   assert.deepEqual(plan.reusedRanges, []);
   assert.equal(plan.alternatives.find((alternative) => alternative.kind === "slow-motion")?.status, "requires-confirmation");
   assert.equal(plan.alternatives.find((alternative) => alternative.kind === "generated-interstitial")?.status, "requires-confirmation");
+});
+
+test("runtime duration planning is read-only and reports the observed actual duration", async () => {
+  const runtime = new AgentVideoRuntime(new InMemoryEditorAdapter({
+    projectId: "duration-policy-project",
+    projectName: "Duration Policy Fixture",
+    timelineId: "duration-policy-timeline",
+    timelineName: "Main Edit",
+    clips: [{ id: "clip-1", name: "Footage", start: 0, duration: 120, track: 1 }],
+  }));
+  const before = await runtime.inspectProject();
+
+  const plan = runtime.planDuration({
+    requestedDurationSeconds: 180,
+    actualDurationSeconds: 120,
+    footage: [{ id: "footage", durationSeconds: 120 }],
+  });
+
+  assert.equal(plan.durationReport.actualDurationSeconds, 120);
+  assert.deepEqual(await runtime.inspectProject(), before);
 });

--- a/tests/integration/duration-policy.test.ts
+++ b/tests/integration/duration-policy.test.ts
@@ -25,3 +25,50 @@ test("duration planning recommends a shorter strong edit for ten minutes of requ
   assert.ok(plan.alternatives.some((alternative) => alternative.kind === "request-additional-footage"));
   assert.deepEqual(plan.reusedRanges, []);
 });
+
+test("hard duration planning uses explicitly permitted B-roll reuse and reports its source range", () => {
+  const plan = planDurationPolicy({
+    requestedDurationSeconds: 300,
+    constraint: "hard",
+    permissions: { allowReuse: true },
+    footage: [
+      {
+        id: "b-roll",
+        durationSeconds: 120,
+        usableRanges: [{ startSeconds: 0, endSeconds: 120 }],
+        reusable: true,
+      },
+      { id: "interview", durationSeconds: 60 },
+    ],
+    actualDurationSeconds: 300,
+  });
+
+  assert.equal(plan.selectedAction, "reuse-selected-b-roll");
+  assert.equal(plan.availableFootage.uniqueDurationSeconds, 180);
+  assert.equal(plan.availableFootage.reusableDurationSeconds, 120);
+  assert.equal(plan.achievableDurationSeconds, 300);
+  assert.deepEqual(plan.reusedRanges, [{
+    footageId: "b-roll",
+    sourceRange: { startSeconds: 0, endSeconds: 120 },
+    occurrence: 1,
+  }]);
+  assert.deepEqual(plan.unmetConstraints, []);
+  assert.deepEqual(plan.durationReport, {
+    requestedDurationSeconds: 300,
+    achievableDurationSeconds: 300,
+    actualDurationSeconds: 300,
+  });
+});
+
+test("duration planning never silently selects slow motion or generated assets", () => {
+  const plan = planDurationPolicy({
+    requestedDurationSeconds: 300,
+    permissions: { allowSlowMotion: true, allowGeneratedAssets: true },
+    footage: [{ id: "footage", durationSeconds: 180 }],
+  });
+
+  assert.equal(plan.selectedAction, "deliver-shorter-strong-edit");
+  assert.deepEqual(plan.reusedRanges, []);
+  assert.equal(plan.alternatives.find((alternative) => alternative.kind === "slow-motion")?.status, "requires-confirmation");
+  assert.equal(plan.alternatives.find((alternative) => alternative.kind === "generated-interstitial")?.status, "requires-confirmation");
+});

--- a/tests/integration/duration-policy.test.ts
+++ b/tests/integration/duration-policy.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { planDurationPolicy } from "@framekit/runtime";
+
+test("duration planning recommends a shorter strong edit for ten minutes of requested time and four minutes of footage", () => {
+  const plan = planDurationPolicy({
+    requestedDurationSeconds: 10 * 60,
+    footage: [{
+      id: "usable-footage",
+      durationSeconds: 4 * 60,
+    }],
+  });
+
+  assert.equal(plan.policy.constraint, "soft");
+  assert.equal(plan.availableFootage.uniqueDurationSeconds, 4 * 60);
+  assert.equal(plan.availableFootage.reusableDurationSeconds, 0);
+  assert.equal(plan.achievableDurationSeconds, 4 * 60);
+  assert.equal(plan.selectedAction, "deliver-shorter-strong-edit");
+  assert.deepEqual(plan.durationReport, {
+    requestedDurationSeconds: 10 * 60,
+    achievableDurationSeconds: 4 * 60,
+    actualDurationSeconds: null,
+  });
+  assert.equal(plan.unmetConstraints[0], "Requested duration exceeds unique usable footage");
+  assert.ok(plan.alternatives.some((alternative) => alternative.kind === "request-additional-footage"));
+  assert.deepEqual(plan.reusedRanges, []);
+});

--- a/tests/integration/duration-policy.test.ts
+++ b/tests/integration/duration-policy.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
 import test from "node:test";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
@@ -130,4 +132,16 @@ test("MCP exposes an explicit duration planning contract", async () => {
     await client.close();
     await server.close();
   }
+});
+
+test("MCP and rough-cut documentation describe the same duration policy", async () => {
+  const mcpDocumentation = await readFile(resolve("docs/mcp/tools.md"), "utf8");
+  const roughCutDocumentation = await readFile(resolve("docs/rough-cut/duration-policy.md"), "utf8");
+
+  assert.match(mcpDocumentation, /editing\.duration\.plan/);
+  assert.match(mcpDocumentation, /soft constraint/i);
+  assert.match(mcpDocumentation, /actualDurationSeconds/);
+  assert.match(roughCutDocumentation, /ambiguous duration requests default to soft/i);
+  assert.match(roughCutDocumentation, /never silently loops or slows/i);
+  assert.match(roughCutDocumentation, /requested.*achievable.*actual/i);
 });

--- a/tests/integration/duration-policy.test.ts
+++ b/tests/integration/duration-policy.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { AgentVideoRuntime, planDurationPolicy } from "@framekit/runtime";
 import { InMemoryEditorAdapter } from "@framekit/testkit";
+import { createMcpServer } from "../../apps/mcp-server/src/server.js";
 
 test("duration planning recommends a shorter strong edit for ten minutes of requested time and four minutes of footage", () => {
   const plan = planDurationPolicy({
@@ -92,4 +95,39 @@ test("runtime duration planning is read-only and reports the observed actual dur
 
   assert.equal(plan.durationReport.actualDurationSeconds, 120);
   assert.deepEqual(await runtime.inspectProject(), before);
+});
+
+test("MCP exposes an explicit duration planning contract", async () => {
+  const runtime = new AgentVideoRuntime(new InMemoryEditorAdapter({
+    projectId: "mcp-duration-policy-project",
+    projectName: "MCP Duration Policy Fixture",
+    timelineId: "mcp-duration-policy-timeline",
+    timelineName: "Main Edit",
+    clips: [],
+  }));
+  const server = createMcpServer(runtime);
+  const client = new Client({ name: "duration-policy-mcp-test", version: "0.1.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  try {
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+    const tools = await client.listTools();
+    const tool = tools.tools.find((candidate) => candidate.name === "editing.duration.plan");
+    assert.ok(tool);
+    assert.deepEqual(tool.inputSchema.required, ["requestedDurationSeconds", "footage"]);
+
+    const result = await client.callTool({
+      name: "editing.duration.plan",
+      arguments: {
+        requestedDurationSeconds: 600,
+        footage: [{ id: "footage", durationSeconds: 240 }],
+      },
+    });
+    assert.equal(result.isError, undefined);
+    const content = result.content as Array<{ type?: string; text?: string }>;
+    assert.equal(JSON.parse(content[0]!.text!).selectedAction, "deliver-shorter-strong-edit");
+  } finally {
+    await client.close();
+    await server.close();
+  }
 });

--- a/tests/integration/duration-policy.test.ts
+++ b/tests/integration/duration-policy.test.ts
@@ -79,6 +79,46 @@ test("duration planning never silently selects slow motion or generated assets",
   assert.equal(plan.alternatives.find((alternative) => alternative.kind === "generated-interstitial")?.status, "requires-confirmation");
 });
 
+test("duration planning counts disjoint usable ranges once and rejects overlapping or duplicate footage", () => {
+  const plan = planDurationPolicy({
+    requestedDurationSeconds: 120,
+    footage: [{
+      id: "interview",
+      durationSeconds: 90,
+      usableRanges: [
+        { startSeconds: 0, endSeconds: 30 },
+        { startSeconds: 60, endSeconds: 90 },
+      ],
+    }],
+  });
+  assert.equal(plan.availableFootage.uniqueDurationSeconds, 60);
+
+  assert.throws(
+    () => planDurationPolicy({
+      requestedDurationSeconds: 120,
+      footage: [{
+        id: "overlap",
+        durationSeconds: 90,
+        usableRanges: [
+          { startSeconds: 0, endSeconds: 45 },
+          { startSeconds: 30, endSeconds: 60 },
+        ],
+      }],
+    }),
+    /INVALID_DURATION_FOOTAGE: usable ranges overlap for overlap/,
+  );
+  assert.throws(
+    () => planDurationPolicy({
+      requestedDurationSeconds: 120,
+      footage: [
+        { id: "duplicate", durationSeconds: 60 },
+        { id: "duplicate", durationSeconds: 60 },
+      ],
+    }),
+    /INVALID_DURATION_FOOTAGE: duplicate footage id duplicate/,
+  );
+});
+
 test("runtime duration planning is read-only and reports the observed actual duration", async () => {
   const runtime = new AgentVideoRuntime(new InMemoryEditorAdapter({
     projectId: "duration-policy-project",

--- a/tests/integration/duration-policy.test.ts
+++ b/tests/integration/duration-policy.test.ts
@@ -32,6 +32,18 @@ test("duration planning recommends a shorter strong edit for ten minutes of requ
   assert.deepEqual(plan.reusedRanges, []);
 });
 
+test("duration planning reports the requested duration when footage is abundant", () => {
+  const plan = planDurationPolicy({
+    requestedDurationSeconds: 60,
+    footage: [{ id: "abundant-footage", durationSeconds: 120 }],
+  });
+
+  assert.equal(plan.selectedAction, "deliver-exact-duration");
+  assert.equal(plan.availableFootage.uniqueDurationSeconds, 120);
+  assert.equal(plan.achievableDurationSeconds, 60);
+  assert.equal(plan.durationReport.achievableDurationSeconds, 60);
+});
+
 test("hard duration planning uses explicitly permitted B-roll reuse and reports its source range", () => {
   const plan = planDurationPolicy({
     requestedDurationSeconds: 300,

--- a/tests/integration/mcp.test.ts
+++ b/tests/integration/mcp.test.ts
@@ -39,6 +39,7 @@ test("Phase 0 exposes read/write/diff through MCP stdio", async () => {
         "edit.diff",
         "edit.undo",
         "edit.verify",
+        "editing.duration.plan",
         "editing.intent.resolve",
         "editor.assets",
         "editor.inspect",


### PR DESCRIPTION
## Summary
- Add deterministic runtime duration-policy planning for soft and hard constraints.
- Expose planning through the MCP tool editing.duration.plan.
- Document unique/reusable footage, explicit alternatives, and requested/achievable/actual reporting.

## TDD and validation
- Added focused tests before each implementation step and committed each step.
- pnpm install --frozen-lockfile
- pnpm run build
- pnpm run test (299 passing)
- pnpm run check:boundaries

Closes #87

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added read-only duration planning for rough-cut workflows.
  - Plans requested and achievable durations using available footage and permitted reuse or alternatives.
  - Reports unmet constraints, confirmations, duration ranges, and recommended actions.
  - Validates duration requests and footage ranges before planning.
  - Exposed the `editing.duration.plan` MCP tool.

- **Documentation**
  - Added duration-planning guidance covering constraints, tradeoffs, reuse, and alternatives.

- **Tests**
  - Added coverage for planning, validation, MCP exposure, and read-only behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->