### PR TITLE
[Improvement] Make Framekit MCP workflow routing editor-first

### DIFF
--- a/adapters/final-cut/typescript/src/publisher.ts
+++ b/adapters/final-cut/typescript/src/publisher.ts
@@ -41,6 +41,10 @@ export class FinalCutProjectPublisher {
     this.waitMs = options.waitMs ?? 1_500;
   }
 
+  public isAvailable(): boolean {
+    return this.enabled;
+  }
+
   public async publishNewProject(sourceTransactionId: string): Promise<FinalCutProjectPublishResult> {
     if (!this.enabled) throw new Error("CAPABILITY_UNAVAILABLE: Final Cut project publishing is disabled; set FRAMEKIT_FINAL_CUT_NATIVE_WRITES=1");
     const source = await readFile(this.sourcePath, "utf8");

--- a/apps/mcp-server/src/routing.ts
+++ b/apps/mcp-server/src/routing.ts
@@ -132,7 +132,9 @@ export function resolveEditingRoute(
     };
   }
 
-  if (context.connection.state !== "ready") {
+  const offlineArtifactEdit = request.operation === "timeline.edit"
+    && context.editor?.capabilities.editor.timelineArtifactWrite === true;
+  if (context.connection.state !== "ready" && !offlineArtifactEdit) {
     return {
       operation: request.operation,
       status: "unavailable",

--- a/apps/mcp-server/src/routing.ts
+++ b/apps/mcp-server/src/routing.ts
@@ -46,7 +46,7 @@ export interface EditingRoute {
   reason: EditingRouteReason;
 }
 
-const EDITOR_FIRST_WORKFLOW = [
+export const EDITOR_FIRST_WORKFLOW = [
   "connection.status",
   "editor.inspect",
   "project.inspect",
@@ -58,6 +58,17 @@ const EDITOR_FIRST_WORKFLOW = [
   "edit.diff",
   "edit.verify",
 ];
+
+export const EDITOR_FIRST_MCP_INSTRUCTIONS = [
+  "Framekit uses an editor-first workflow for every editing request.",
+  "1. Call connection.status to establish whether the expected editor is connected.",
+  "2. Call editor.inspect to read the selected editor identity and capabilities.",
+  "3. Inspect the active project with project.inspect before selecting an editing path.",
+  "4. Call editing.route and use only a path whose required capabilities are advertised.",
+  "5. Resolve intent when needed, then preview before execute; never mutate on an unavailable capability.",
+  "6. Observe the result, then use edit.diff and edit.verify to confirm the change.",
+  "An external renderer is never an implicit substitute for a connected editor. Select fallback: external-renderer explicitly and report the structured reason returned by editing.route.",
+].join("\n");
 
 type Requirement = {
   label: string;

--- a/apps/mcp-server/src/routing.ts
+++ b/apps/mcp-server/src/routing.ts
@@ -1,0 +1,230 @@
+import type { EditorIdentity, RuntimeCapabilities } from "@framekit/runtime";
+
+export type EditingRouteOperation =
+  | "timeline.edit"
+  | "editor.native.edit"
+  | "timeline.publish.new-project"
+  | "timeline.export";
+
+export type EditingRouteFallback = "none" | "external-renderer";
+
+export interface EditingRouteRequest {
+  operation: EditingRouteOperation;
+  fallback?: EditingRouteFallback;
+}
+
+export interface EditorRoutingContext {
+  connection: {
+    state: string;
+    lastError?: { code: string; message: string };
+  };
+  editor?: {
+    identity: EditorIdentity;
+    capabilities: RuntimeCapabilities;
+  };
+  native?: Record<string, boolean>;
+}
+
+export interface EditingRouteReason {
+  code: "EDITOR_SELECTED" | "EDITOR_UNAVAILABLE" | "CAPABILITY_UNAVAILABLE" | "EXTERNAL_FALLBACK_SELECTED";
+  message: string;
+  connectionState: string;
+  cause?: {
+    code: string;
+    message: string;
+  };
+}
+
+export interface EditingRoute {
+  operation: EditingRouteOperation;
+  status: "editor-selected" | "external-fallback-selected" | "unavailable";
+  selectedPath: "editor" | "external-renderer" | "none";
+  requiredCapabilities: string[];
+  missingCapabilities: string[];
+  editor?: EditorIdentity;
+  workflow: string[];
+  reason: EditingRouteReason;
+}
+
+const EDITOR_FIRST_WORKFLOW = [
+  "connection.status",
+  "editor.inspect",
+  "project.inspect",
+  "editing.route",
+  "editing.intent.resolve",
+  "timeline.edit.preview",
+  "timeline.edit.execute",
+  "context.inspect",
+  "edit.diff",
+  "edit.verify",
+];
+
+type Requirement = {
+  label: string;
+  satisfied: (context: EditorRoutingContext) => boolean;
+};
+
+const operationRequirements: Record<EditingRouteOperation, Requirement[]> = {
+  "timeline.edit": [
+    editorRequirement("projectRead"),
+    editorRequirement("timelineSnapshotRead"),
+    {
+      label: "editor.timelineWrite|editor.timelineArtifactWrite",
+      satisfied: (context) => Boolean(
+        context.editor?.capabilities.editor.timelineWrite
+        || context.editor?.capabilities.editor.timelineArtifactWrite,
+      ),
+    },
+    editorRequirement("readAfterWrite"),
+    editorRequirement("rollback"),
+  ],
+  "editor.native.edit": [
+    nativeRequirement("selectionEdit"),
+    nativeRequirement("timelineFocus"),
+    nativeRequirement("undo"),
+  ],
+  "timeline.publish.new-project": [
+    editorRequirement("timelinePublishNewProject"),
+  ],
+  "timeline.export": [
+    editorRequirement("videoExport"),
+  ],
+};
+
+export function resolveEditingRoute(
+  request: EditingRouteRequest,
+  context: EditorRoutingContext,
+): EditingRoute {
+  const requirements = operationRequirements[request.operation];
+  const requiredCapabilities = requirements.map((requirement) => requirement.label);
+  const missingCapabilities = requirements
+    .filter((requirement) => !requirement.satisfied(context))
+    .map((requirement) => requirement.label);
+  const editor = context.editor?.identity;
+
+  if (request.fallback === "external-renderer") {
+    const cause = externalFallbackCause(context, missingCapabilities);
+    return {
+      operation: request.operation,
+      status: "external-fallback-selected",
+      selectedPath: "external-renderer",
+      requiredCapabilities,
+      missingCapabilities,
+      ...(editor ? { editor } : {}),
+      workflow: [...EDITOR_FIRST_WORKFLOW],
+      reason: {
+        code: "EXTERNAL_FALLBACK_SELECTED",
+        message: "The external renderer was selected explicitly; Framekit will not invoke it or bypass the editor silently.",
+        connectionState: context.connection.state,
+        cause,
+      },
+    };
+  }
+
+  if (context.connection.state !== "ready") {
+    return {
+      operation: request.operation,
+      status: "unavailable",
+      selectedPath: "none",
+      requiredCapabilities,
+      missingCapabilities,
+      ...(editor ? { editor } : {}),
+      workflow: [...EDITOR_FIRST_WORKFLOW],
+      reason: editorUnavailableReason(context, missingCapabilities),
+    };
+  }
+
+  if (missingCapabilities.length > 0 || !context.editor) {
+    return {
+      operation: request.operation,
+      status: "unavailable",
+      selectedPath: "none",
+      requiredCapabilities,
+      missingCapabilities,
+      ...(editor ? { editor } : {}),
+      workflow: [...EDITOR_FIRST_WORKFLOW],
+      reason: {
+        code: "CAPABILITY_UNAVAILABLE",
+        message: `The connected editor cannot satisfy ${request.operation}; no alternate editor path was selected.`,
+        connectionState: context.connection.state,
+      },
+    };
+  }
+
+  return {
+    operation: request.operation,
+    status: "editor-selected",
+    selectedPath: "editor",
+    requiredCapabilities,
+    missingCapabilities: [],
+    editor,
+    workflow: [...EDITOR_FIRST_WORKFLOW],
+    reason: {
+      code: "EDITOR_SELECTED",
+      message: "The connected editor satisfies the required capabilities; continue with the preview and execute contract.",
+      connectionState: context.connection.state,
+    },
+  };
+}
+
+function editorRequirement(capability: keyof RuntimeCapabilities["editor"]): Requirement {
+  return {
+    label: `editor.${capability}`,
+    satisfied: (context) => Boolean(context.editor?.capabilities.editor[capability]),
+  };
+}
+
+function nativeRequirement(capability: string): Requirement {
+  return {
+    label: `native.${capability}`,
+    satisfied: (context) => context.native?.[capability] === true,
+  };
+}
+
+function externalFallbackCause(
+  context: EditorRoutingContext,
+  missingCapabilities: string[],
+): NonNullable<EditingRouteReason["cause"]> {
+  if (context.connection.state !== "ready") {
+    return context.connection.lastError ?? {
+      code: "EDITOR_UNAVAILABLE",
+      message: `The expected editor is unavailable while the connection is ${context.connection.state}.`,
+    };
+  }
+  if (missingCapabilities.length > 0 || !context.editor) {
+    return {
+      code: "CAPABILITY_UNAVAILABLE",
+      message: "The connected editor does not advertise every capability required by this operation.",
+    };
+  }
+  return {
+    code: "USER_SELECTED_EXTERNAL_FALLBACK",
+    message: "The caller explicitly selected the external renderer even though the editor is available.",
+  };
+}
+
+function editorUnavailableReason(
+  context: EditorRoutingContext,
+  missingCapabilities: string[],
+): EditingRouteReason {
+  if (context.connection.state !== "ready") {
+    return {
+      code: "EDITOR_UNAVAILABLE",
+      message: `The expected editor is unavailable while the connection is ${context.connection.state}.`,
+      connectionState: context.connection.state,
+      ...(context.connection.lastError ? { cause: context.connection.lastError } : {}),
+    };
+  }
+  if (missingCapabilities.length > 0 || !context.editor) {
+    return {
+      code: "CAPABILITY_UNAVAILABLE",
+      message: "The connected editor does not advertise every capability required by this operation.",
+      connectionState: context.connection.state,
+    };
+  }
+  return {
+    code: "CAPABILITY_UNAVAILABLE",
+    message: "The connected editor does not advertise every capability required by this operation.",
+    connectionState: context.connection.state,
+  };
+}

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -237,7 +237,7 @@ export function createMcpServer(runtime: AgentVideoRuntime, options: McpServerOp
   }, async () => jsonResult(await connectionStatus(options)));
 
   server.registerTool("project.inspect", {
-    description: "Read the current canonical project snapshot.",
+    description: "Read the current canonical project snapshot before editing.route selects a capability-checked path.",
   }, async () => jsonResult(await runtime.inspectProject()));
 
   server.registerTool("project.list", {
@@ -609,7 +609,7 @@ export function createMcpServer(runtime: AgentVideoRuntime, options: McpServerOp
   });
 
   server.registerTool("timeline.edit", {
-    description: "Apply one supported edit and return read-after-write plus its diff.",
+    description: "Apply one supported edit after editing.route confirms the required capabilities; return read-after-write plus its diff.",
     inputSchema: editToolInputSchema,
   }, async (input) => jsonResult(await runtime.edit(editOperationSchema.parse(input))));
 
@@ -629,7 +629,7 @@ export function createMcpServer(runtime: AgentVideoRuntime, options: McpServerOp
   }, async ({ previewToken }) => jsonResult(await runtime.executeEdit(previewToken)));
 
   server.registerTool("timeline.edit.preview", {
-    description: "Validate and preview one ordered, atomic Basic Editing MVP workflow without mutating the project.",
+    description: "Validate and preview one ordered, atomic Basic Editing MVP workflow after editing.route confirms capabilities; do not mutate the project.",
     inputSchema: {
       baseRevision: revisionValueSchema,
       operations: workflowOperationsSchema,
@@ -637,7 +637,7 @@ export function createMcpServer(runtime: AgentVideoRuntime, options: McpServerOp
   }, async (request) => jsonResult(await runtime.previewEdit(request)));
 
   server.registerTool("timeline.edit.execute", {
-    description: "Execute one short-lived composite edit preview token exactly once and verify the transaction.",
+    description: "Execute one short-lived composite edit preview token exactly once after editing.route capability checks, then verify the transaction.",
     inputSchema: { previewToken: z.string().min(1) },
   }, async ({ previewToken }) => jsonResult(await runtime.executeEdit(previewToken)));
 

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -491,7 +491,7 @@ export function createMcpServer(runtime: AgentVideoRuntime, options: McpServerOp
     description: "Import the validated FCPXML artifact as a new Final Cut project without replacing the active project.",
     inputSchema: { transactionId: z.string().min(1) },
   }, async ({ transactionId }) => {
-    if (!options.projectPublisher) throw new Error("CAPABILITY_UNAVAILABLE: Final Cut project publishing requires FRAMEKIT_FCPXML_PATH and native writes");
+    if (!options.projectPublisher?.isAvailable()) throw new Error("CAPABILITY_UNAVAILABLE: Final Cut project publishing requires FRAMEKIT_FCPXML_PATH and native writes");
     const verification = await runtime.verifyTransaction(transactionId);
     if (!verification.passed) throw new Error(`FINAL_CUT_PUBLISH_VALIDATION_FAILED: source transaction ${transactionId} did not pass verification`);
     return jsonResult(await options.projectPublisher.publishNewProject(transactionId));
@@ -706,7 +706,7 @@ async function inspectMcpEditor(runtime: AgentVideoRuntime, options: McpServerOp
       ...inspected.capabilities,
       editor: {
         ...inspected.capabilities.editor,
-        timelinePublishNewProject: Boolean(options.projectPublisher),
+        timelinePublishNewProject: Boolean(options.projectPublisher?.isAvailable()),
         videoExport: Boolean(options.videoExporter?.isAvailable()),
       },
     },

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -275,16 +275,7 @@ export function createMcpServer(runtime: AgentVideoRuntime, options: McpServerOp
       fallback: z.enum(["none", "external-renderer"]).optional().default("none"),
     },
   }, async ({ operation, fallback }) => {
-    const connection = await connectionStatus(options);
-    if (connection.state !== "ready") {
-      return jsonResult(resolveEditingRoute({ operation, fallback }, { connection }));
-    }
-    const editor = await inspectMcpEditor(runtime, options);
-    const context: EditorRoutingContext = {
-      connection,
-      editor,
-      ...(options.nativeEditor ? { native: { ...options.nativeEditor.capabilities() } } : {}),
-    };
+    const context = await editingRouteContext(runtime, options);
     return jsonResult(resolveEditingRoute({ operation, fallback }, context));
   });
 
@@ -728,15 +719,26 @@ async function requireEditingRoute(
   options: McpServerOptions,
   operation: EditingRouteOperation,
 ): Promise<void> {
+  const route = resolveEditingRoute({ operation }, await editingRouteContext(runtime, options));
+  if (route.status !== "editor-selected") {
+    throw new Error(`${route.reason.code}: ${route.reason.message}`);
+  }
+}
+
+async function editingRouteContext(
+  runtime: AgentVideoRuntime,
+  options: McpServerOptions,
+): Promise<EditorRoutingContext> {
   const connection = await connectionStatus(options);
-  const editor = connection.state === "ready" ? await inspectMcpEditor(runtime, options) : undefined;
-  const context: EditorRoutingContext = {
+  let editor: Awaited<ReturnType<typeof inspectMcpEditor>> | undefined;
+  try {
+    editor = await inspectMcpEditor(runtime, options);
+  } catch {
+    editor = undefined;
+  }
+  return {
     connection,
     ...(editor ? { editor } : {}),
     ...(options.nativeEditor ? { native: { ...options.nativeEditor.capabilities() } } : {}),
   };
-  const route = resolveEditingRoute({ operation }, context);
-  if (route.status !== "editor-selected") {
-    throw new Error(`${route.reason.code}: ${route.reason.message}`);
-  }
 }

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -7,6 +7,11 @@ import type {
   FinalCutVideoExporter,
   NativeFinalCutEditor,
 } from "@framekit/final-cut";
+import {
+  EDITOR_FIRST_MCP_INSTRUCTIONS,
+  resolveEditingRoute,
+  type EditorRoutingContext,
+} from "./routing.js";
 
 const revisionValueSchema = z.object({
   id: z.string(),
@@ -203,8 +208,17 @@ function frameResult(value: TimelineFrameCapture) {
   };
 }
 
+export interface McpConnectionStatus {
+  state: string;
+  lastError?: { code: string; message: string };
+  editorDetected?: boolean;
+  extensionInstalled?: boolean;
+  socketPath?: string | null;
+  capabilities?: unknown;
+}
+
 export interface McpServerOptions {
-  connectionStatus?: () => unknown;
+  connectionStatus?: () => McpConnectionStatus | undefined | Promise<McpConnectionStatus | undefined>;
   nativeEditor?: NativeFinalCutEditor;
   disposableNative?: Pick<DisposableNativeEditWorkflow, "preview" | "execute" | "undo">;
   projectPublisher?: FinalCutProjectPublisher;
@@ -212,19 +226,15 @@ export interface McpServerOptions {
 }
 
 export function createMcpServer(runtime: AgentVideoRuntime, options: McpServerOptions = {}): McpServer {
-  const server = new McpServer({ name: "framekit", version: "0.1.0" });
+  const server = new McpServer(
+    { name: "framekit", version: "0.1.0" },
+    { instructions: EDITOR_FIRST_MCP_INSTRUCTIONS },
+  );
 
   server.registerTool("connection.status", {
-    description: "Read Framekit's Final Cut connection state, setup progress, and live capabilities.",
+    description: "Read Framekit's Final Cut connection state before editor-first capability discovery.",
     inputSchema: {},
-  }, async () => jsonResult(options.connectionStatus?.() ?? {
-    state: "ready",
-    editorDetected: false,
-    extensionInstalled: false,
-    socketPath: null,
-    capabilities: null,
-    lastError: null,
-  }));
+  }, async () => jsonResult(await connectionStatus(options)));
 
   server.registerTool("project.inspect", {
     description: "Read the current canonical project snapshot.",
@@ -244,27 +254,38 @@ export function createMcpServer(runtime: AgentVideoRuntime, options: McpServerOp
   }, async ({ projectId, sequenceId }) => jsonResult(await runtime.selectProject({ projectId, sequenceId })));
 
   server.registerTool("editor.inspect", {
-    description: "Read editor identity and machine-readable Phase 2 capabilities.",
-  }, async () => {
-    const inspected = await runtime.inspectEditor();
-    return jsonResult({
-      ...inspected,
-      capabilities: {
-        ...inspected.capabilities,
-        editor: {
-          ...inspected.capabilities.editor,
-          timelinePublishNewProject: Boolean(options.projectPublisher),
-          videoExport: Boolean(options.videoExporter?.isAvailable()),
-        },
-      },
-      ...(options.nativeEditor ? { native: options.nativeEditor.capabilities() } : {}),
-    });
-  });
+    description: "Read editor identity and machine-readable capabilities before selecting an editing path.",
+  }, async () => jsonResult(await inspectMcpEditor(runtime, options)));
 
   server.registerTool("editing.intent.resolve", {
     description: "Map a supported natural-language editing request to one explicit operation without executing it.",
     inputSchema: { request: z.string().trim().min(1) },
   }, async ({ request }) => jsonResult(resolveEditingIntent(request)));
+
+  server.registerTool("editing.route", {
+    description: "Resolve an editor-first path after capability checks; never bypass a connected editor, and require explicit external fallback selection.",
+    inputSchema: {
+      operation: z.enum([
+        "timeline.edit",
+        "editor.native.edit",
+        "timeline.publish.new-project",
+        "timeline.export",
+      ]),
+      fallback: z.enum(["none", "external-renderer"]).optional().default("none"),
+    },
+  }, async ({ operation, fallback }) => {
+    const connection = await connectionStatus(options);
+    if (connection.state !== "ready") {
+      return jsonResult(resolveEditingRoute({ operation, fallback }, { connection }));
+    }
+    const editor = await inspectMcpEditor(runtime, options);
+    const context: EditorRoutingContext = {
+      connection,
+      editor,
+      ...(options.nativeEditor ? { native: { ...options.nativeEditor.capabilities() } } : {}),
+    };
+    return jsonResult(resolveEditingRoute({ operation, fallback }, context));
+  });
 
   server.registerTool("editor.native.inspect", {
     description: "Inspect the active Final Cut selection/playhead before a native UI edit.",
@@ -664,4 +685,30 @@ async function resolveNativeTitleAsset(runtime: AgentVideoRuntime, assetId: stri
   if (!asset) throw new Error(`TITLE_ASSET_NOT_FOUND: installed title asset ${assetId} was not discovered`);
   if (asset.kind !== "title") throw new Error(`TITLE_ASSET_INCOMPATIBLE: ${assetId} is not an installed Final Cut title asset`);
   return asset;
+}
+
+async function connectionStatus(options: McpServerOptions): Promise<McpConnectionStatus> {
+  return await options.connectionStatus?.() ?? {
+    state: "ready",
+    editorDetected: false,
+    extensionInstalled: false,
+    socketPath: null,
+    capabilities: null,
+  };
+}
+
+async function inspectMcpEditor(runtime: AgentVideoRuntime, options: McpServerOptions) {
+  const inspected = await runtime.inspectEditor();
+  return {
+    ...inspected,
+    capabilities: {
+      ...inspected.capabilities,
+      editor: {
+        ...inspected.capabilities.editor,
+        timelinePublishNewProject: Boolean(options.projectPublisher),
+        videoExport: Boolean(options.videoExporter?.isAvailable()),
+      },
+    },
+    ...(options.nativeEditor ? { native: options.nativeEditor.capabilities() } : {}),
+  };
 }

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -11,6 +11,7 @@ import {
   EDITOR_FIRST_MCP_INSTRUCTIONS,
   resolveEditingRoute,
   type EditorRoutingContext,
+  type EditingRouteOperation,
 } from "./routing.js";
 
 const revisionValueSchema = z.object({
@@ -611,7 +612,10 @@ export function createMcpServer(runtime: AgentVideoRuntime, options: McpServerOp
   server.registerTool("timeline.edit", {
     description: "Apply one supported edit after editing.route confirms the required capabilities; return read-after-write plus its diff.",
     inputSchema: editToolInputSchema,
-  }, async (input) => jsonResult(await runtime.edit(editOperationSchema.parse(input))));
+  }, async (input) => {
+    await requireEditingRoute(runtime, options, "timeline.edit");
+    return jsonResult(await runtime.edit(editOperationSchema.parse(input)));
+  });
 
   server.registerTool("music.add", {
     description: "Preview adding a searched or imported music bed with placement, gain, and fades; execute the returned token with music.add.execute.",
@@ -634,12 +638,18 @@ export function createMcpServer(runtime: AgentVideoRuntime, options: McpServerOp
       baseRevision: revisionValueSchema,
       operations: workflowOperationsSchema,
     },
-  }, async (request) => jsonResult(await runtime.previewEdit(request)));
+  }, async (request) => {
+    await requireEditingRoute(runtime, options, "timeline.edit");
+    return jsonResult(await runtime.previewEdit(request));
+  });
 
   server.registerTool("timeline.edit.execute", {
     description: "Execute one short-lived composite edit preview token exactly once after editing.route capability checks, then verify the transaction.",
     inputSchema: { previewToken: z.string().min(1) },
-  }, async ({ previewToken }) => jsonResult(await runtime.executeEdit(previewToken)));
+  }, async ({ previewToken }) => {
+    await requireEditingRoute(runtime, options, "timeline.edit");
+    return jsonResult(await runtime.executeEdit(previewToken));
+  });
 
   server.registerTool("speech.analyze", {
     description: "Analyze speech words and filler markers for one media item.",
@@ -711,4 +721,22 @@ async function inspectMcpEditor(runtime: AgentVideoRuntime, options: McpServerOp
     },
     ...(options.nativeEditor ? { native: options.nativeEditor.capabilities() } : {}),
   };
+}
+
+async function requireEditingRoute(
+  runtime: AgentVideoRuntime,
+  options: McpServerOptions,
+  operation: EditingRouteOperation,
+): Promise<void> {
+  const connection = await connectionStatus(options);
+  const editor = connection.state === "ready" ? await inspectMcpEditor(runtime, options) : undefined;
+  const context: EditorRoutingContext = {
+    connection,
+    ...(editor ? { editor } : {}),
+    ...(options.nativeEditor ? { native: { ...options.nativeEditor.capabilities() } } : {}),
+  };
+  const route = resolveEditingRoute({ operation }, context);
+  if (route.status !== "editor-selected") {
+    throw new Error(`${route.reason.code}: ${route.reason.message}`);
+  }
 }

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -4,6 +4,22 @@ Framekit exposes the runtime through a local MCP stdio server. MCP is an
 adapter around the runtime; editor-specific behavior belongs in adapters and
 the native bridge.
 
+## Editor-first workflow
+
+Framekit follows an editor-first policy for editing requests. Call
+`connection.status`, then `editor.inspect`, then `project.inspect` before
+choosing a path. Use `editing.route` to check the selected operation against
+the editor's advertised capabilities, and stop with `CAPABILITY_UNAVAILABLE`
+when the editor cannot safely satisfy it. Continue with the operation's
+preview and execute tools, then observe the result with `edit.diff` and
+`edit.verify`.
+
+An external renderer is never an implicit substitute for the connected editor.
+Pass `fallback: "external-renderer"` to `editing.route` only when external
+processing is explicitly selected or authorized. The route response reports
+`EXTERNAL_FALLBACK_SELECTED` and its structured cause; the MCP server does not
+invoke the external renderer.
+
 - [Protocol](./protocol.md): live Final Cut IPC framing and request methods.
 - [Tools](./tools.md): MCP tool names, inputs, and behavior.
 - [Capabilities and errors](./capabilities-and-errors.md): fail-closed rules.

--- a/docs/mcp/capabilities-and-errors.md
+++ b/docs/mcp/capabilities-and-errors.md
@@ -1,5 +1,32 @@
 # Capabilities and Errors
 
+## Editor-first routing
+
+Before selecting an editing path, call `connection.status`, `editor.inspect`,
+and `project.inspect` in that order, then call `editing.route` with the
+intended operation. The route checks the operation's required capabilities
+against the selected backend. A connected editor that cannot satisfy the
+operation returns `CAPABILITY_UNAVAILABLE`; it is not silently replaced by an
+external renderer.
+
+The route result is structured for deterministic handling:
+
+```json
+{
+  "status": "external-fallback-selected",
+  "selectedPath": "external-renderer",
+  "missingCapabilities": ["editor.timelineSnapshotRead"],
+  "reason": {
+    "code": "EXTERNAL_FALLBACK_SELECTED",
+    "cause": { "code": "CAPABILITY_UNAVAILABLE" }
+  }
+}
+```
+
+`external-renderer` is returned only when the caller explicitly selects
+`fallback: "external-renderer"` or authorizes that fallback. The MCP server
+reports why it was selected but does not invoke an external rendering pipeline.
+
 Capabilities are machine-readable and backend-specific. A live-only Workflow
 Extension reports:
 

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -1,5 +1,28 @@
 # MCP Tools
 
+## Editor-first routing
+
+For an editing request, follow this order:
+
+1. Call `connection.status` to establish whether the expected editor is
+   connected.
+2. Call `editor.inspect` to read the editor identity and advertised
+   capabilities.
+3. Call `project.inspect` to capture the active project and revision.
+4. Call `editing.route` with the intended operation. Select only a path whose
+   required capabilities are available.
+5. Resolve the request with `editing.intent.resolve` when needed, then call
+   the operation-specific `preview` and `execute` tools.
+6. Observe the result and call `edit.diff` and `edit.verify`.
+
+`editing.route` is read-only. It returns `CAPABILITY_UNAVAILABLE` when the
+connected editor cannot satisfy the requested operation. It selects an
+`external-renderer` path only when the caller explicitly passes
+`fallback: "external-renderer"`; the response includes
+`EXTERNAL_FALLBACK_SELECTED` and a structured cause. A connected editor is
+never silently bypassed, and Framekit does not execute external rendering from
+this routing tool.
+
 ## Common runtime tools
 
 | Tool | Purpose | Backend notes |
@@ -7,6 +30,7 @@
 | `connection.status` | Framekit Final Cut setup and connection state | Available during live setup and reconnect |
 | `editor.inspect` | Editor identity and capabilities | Available when a backend is selected |
 | `editing.intent.resolve` | Map one supported natural-language request to an explicit operation and affected range | Read-only; ambiguous requests return clarification and no operation; resolved destructive requests set `previewRequired` |
+| `editing.route` | Select an editor-first operation path after connection and capability checks | Read-only; fails closed when the editor is unavailable or insufficient; external rendering requires explicit `fallback: "external-renderer"` |
 | `editor.native.inspect` | Active native Final Cut selection/playhead and UI focus diagnostics | Requires native writes opt-in and Accessibility permission |
 | `editor.native.focus` | Activate Final Cut and focus the timeline without editing | Bounded retry; returns focus diagnostics on failure |
 | `editor.native.edit` | Selection-scoped native Final Cut edit | Requires native writes opt-in and Final Cut frontmost |

--- a/tests/integration/editor-first-routing.test.ts
+++ b/tests/integration/editor-first-routing.test.ts
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 import type { RuntimeCapabilities } from "@framekit/runtime";
 import { AgentVideoRuntime } from "@framekit/runtime";
 import { InMemoryEditorAdapter } from "@framekit/testkit";
@@ -205,6 +208,33 @@ test("MCP routing reports unavailable editors and explicit external fallback rea
   } finally {
     await client.close();
     await server.close();
+  }
+});
+
+test("MCP documentation describes one consistent editor-first policy", async () => {
+  const repository = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+  const [overview, tools, errors] = await Promise.all([
+    readFile(resolve(repository, "docs/mcp/README.md"), "utf8"),
+    readFile(resolve(repository, "docs/mcp/tools.md"), "utf8"),
+    readFile(resolve(repository, "docs/mcp/capabilities-and-errors.md"), "utf8"),
+  ]);
+
+  for (const content of [overview, tools, errors]) {
+    assert.match(content, /editor-first/i);
+    assert.match(content, /editing\.route/);
+    assert.match(content, /external-renderer/);
+    assert.match(content, /CAPABILITY_UNAVAILABLE/);
+  }
+  for (const [before, after] of [
+    ["connection.status", "editor.inspect"],
+    ["editor.inspect", "project.inspect"],
+    ["project.inspect", "editing.route"],
+    ["editing.route", "preview"],
+    ["preview", "execute"],
+    ["execute", "edit.diff"],
+    ["edit.diff", "edit.verify"],
+  ]) {
+    assert.ok(tools.indexOf(before) < tools.indexOf(after), `${before} must precede ${after}`);
   }
 });
 

--- a/tests/integration/editor-first-routing.test.ts
+++ b/tests/integration/editor-first-routing.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { RuntimeCapabilities } from "@framekit/runtime";
+import { AgentVideoRuntime } from "@framekit/runtime";
+import { InMemoryEditorAdapter } from "@framekit/testkit";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createMcpServer } from "../../apps/mcp-server/src/server.js";
 import { resolveEditingRoute, type EditorRoutingContext } from "../../apps/mcp-server/src/routing.js";
 
 const canonicalCapabilities: RuntimeCapabilities = {
@@ -113,3 +118,100 @@ test("explicit external selection is reported even when the editor is ready", ()
   assert.equal(route.selectedPath, "external-renderer");
   assert.equal(route.reason.cause?.code, "USER_SELECTED_EXTERNAL_FALLBACK");
 });
+
+test("MCP exposes editor-first instructions, descriptions, and routing decisions", async () => {
+  const server = createMcpServer(new AgentVideoRuntime(new InMemoryEditorAdapter({
+    projectId: "project-1",
+    projectName: "Routing Fixture",
+    timelineId: "timeline-1",
+    timelineName: "Main Edit",
+    clips: [],
+  })));
+  const client = new Client({ name: "editor-first-routing-test", version: "0.1.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  try {
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+
+    const instructions = client.getInstructions();
+    assert.ok(instructions);
+    for (const step of [
+      "connection.status",
+      "editor.inspect",
+      "project.inspect",
+      "editing.route",
+      "preview",
+      "execute",
+      "edit.diff",
+      "edit.verify",
+    ]) assert.ok(instructions.includes(step), `missing ${step} from MCP instructions`);
+    assert.ok(instructions.indexOf("connection.status") < instructions.indexOf("editor.inspect"));
+    assert.ok(instructions.indexOf("editor.inspect") < instructions.indexOf("project.inspect"));
+
+    const tools = await client.listTools();
+    const routeTool = tools.tools.find((tool) => tool.name === "editing.route");
+    assert.ok(routeTool);
+    assert.match(routeTool.description ?? "", /capabilit/i);
+    assert.match(routeTool.description ?? "", /external/i);
+    assert.deepEqual(Object.keys(routeTool.inputSchema.properties ?? {}).sort(), ["fallback", "operation"]);
+
+    const route = JSON.parse(textFrom(await client.callTool({
+      name: "editing.route",
+      arguments: { operation: "timeline.edit" },
+    })));
+    assert.equal(route.status, "editor-selected");
+    assert.equal(route.selectedPath, "editor");
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
+
+test("MCP routing reports unavailable editors and explicit external fallback reasons", async () => {
+  const runtime = new AgentVideoRuntime(new InMemoryEditorAdapter({
+    projectId: "project-1",
+    projectName: "Routing Fixture",
+    timelineId: "timeline-1",
+    timelineName: "Main Edit",
+    clips: [],
+  }));
+  const server = createMcpServer(runtime, {
+    connectionStatus: () => ({
+      state: "unavailable",
+      lastError: { code: "FINAL_CUT_HEADLESS_SOCKET_UNAVAILABLE", message: "socket missing" },
+    }),
+  });
+  const client = new Client({ name: "editor-first-fallback-test", version: "0.1.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  try {
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+
+    const unavailable = JSON.parse(textFrom(await client.callTool({
+      name: "editing.route",
+      arguments: { operation: "timeline.edit" },
+    })));
+    assert.equal(unavailable.status, "unavailable");
+    assert.equal(unavailable.selectedPath, "none");
+    assert.equal(unavailable.reason.code, "EDITOR_UNAVAILABLE");
+
+    const fallback = JSON.parse(textFrom(await client.callTool({
+      name: "editing.route",
+      arguments: { operation: "timeline.edit", fallback: "external-renderer" },
+    })));
+    assert.equal(fallback.status, "external-fallback-selected");
+    assert.equal(fallback.reason.code, "EXTERNAL_FALLBACK_SELECTED");
+    assert.equal(fallback.reason.cause.code, "FINAL_CUT_HEADLESS_SOCKET_UNAVAILABLE");
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
+
+function textFrom(result: unknown): string {
+  const content = (result as { content?: unknown }).content;
+  assert.ok(Array.isArray(content));
+  const first = content[0] as { text?: unknown } | undefined;
+  assert.equal(typeof first?.text, "string");
+  return first.text as string;
+}

--- a/tests/integration/editor-first-routing.test.ts
+++ b/tests/integration/editor-first-routing.test.ts
@@ -5,6 +5,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 import type { RuntimeCapabilities } from "@framekit/runtime";
 import { AgentVideoRuntime } from "@framekit/runtime";
+import { FinalCutProjectPublisher } from "@framekit/final-cut";
 import { InMemoryEditorAdapter } from "@framekit/testkit";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
@@ -211,6 +212,102 @@ test("MCP routing reports unavailable editors and explicit external fallback rea
     assert.equal(fallback.status, "external-fallback-selected");
     assert.equal(fallback.reason.code, "EXTERNAL_FALLBACK_SELECTED");
     assert.equal(fallback.reason.cause.code, "FINAL_CUT_HEADLESS_SOCKET_UNAVAILABLE");
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
+
+test("MCP edit handlers fail closed without a successful current route", async () => {
+  const runtime = new AgentVideoRuntime(new InMemoryEditorAdapter({
+    projectId: "project-1",
+    projectName: "Routing Fixture",
+    timelineId: "timeline-1",
+    timelineName: "Main Edit",
+    clips: [],
+  }));
+  const server = createMcpServer(runtime, {
+    connectionStatus: () => ({
+      state: "unavailable",
+      lastError: { code: "FINAL_CUT_HEADLESS_SOCKET_UNAVAILABLE", message: "socket missing" },
+    }),
+  });
+  const client = new Client({ name: "editor-first-handler-test", version: "0.1.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  try {
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+    const before = await runtime.inspectProject();
+    const route = JSON.parse(textFrom(await client.callTool({
+      name: "editing.route",
+      arguments: { operation: "timeline.edit" },
+    })));
+    assert.equal(route.status, "unavailable");
+
+    const results = await Promise.all([
+      client.callTool({
+        name: "timeline.edit",
+        arguments: { type: "rename-clip", clipId: "missing", name: "Should not run" },
+      }),
+      client.callTool({
+        name: "timeline.edit.preview",
+        arguments: {
+          baseRevision: before.revision,
+          operations: [{ type: "rename-clip", clipId: "missing", name: "Should not run" }],
+        },
+      }),
+      client.callTool({
+        name: "timeline.edit.execute",
+        arguments: { previewToken: "preview-unavailable" },
+      }),
+    ]);
+
+    for (const result of results) {
+      assert.equal(result.isError, true);
+      assert.match(textFrom(result), /EDITOR_UNAVAILABLE/);
+    }
+    assert.deepEqual(await runtime.inspectProject(), before);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
+
+test("MCP does not advertise or invoke disabled project publishing", async () => {
+  const runtime = new AgentVideoRuntime(new InMemoryEditorAdapter({
+    projectId: "project-1",
+    projectName: "Routing Fixture",
+    timelineId: "timeline-1",
+    timelineName: "Main Edit",
+    clips: [],
+  }));
+  const server = createMcpServer(runtime, {
+    projectPublisher: new FinalCutProjectPublisher({
+      enabled: false,
+      sourcePath: "/tmp/disabled-project.fcpxml",
+    }),
+  });
+  const client = new Client({ name: "publisher-capability-test", version: "0.1.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  try {
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+    const editor = JSON.parse(textFrom(await client.callTool({ name: "editor.inspect", arguments: {} })));
+    assert.equal(editor.capabilities.editor.timelinePublishNewProject, false);
+
+    const route = JSON.parse(textFrom(await client.callTool({
+      name: "editing.route",
+      arguments: { operation: "timeline.publish.new-project" },
+    })));
+    assert.equal(route.status, "unavailable");
+    assert.equal(route.reason.code, "CAPABILITY_UNAVAILABLE");
+
+    const publish = await client.callTool({
+      name: "timeline.publish.new-project",
+      arguments: { transactionId: "missing-transaction" },
+    });
+    assert.equal(publish.isError, true);
+    assert.match(textFrom(publish), /CAPABILITY_UNAVAILABLE/);
   } finally {
     await client.close();
     await server.close();

--- a/tests/integration/editor-first-routing.test.ts
+++ b/tests/integration/editor-first-routing.test.ts
@@ -212,6 +212,6 @@ function textFrom(result: unknown): string {
   const content = (result as { content?: unknown }).content;
   assert.ok(Array.isArray(content));
   const first = content[0] as { text?: unknown } | undefined;
-  assert.equal(typeof first?.text, "string");
+  if (!first || typeof first.text !== "string") throw new Error("MCP result has no text content");
   return first.text as string;
 }

--- a/tests/integration/editor-first-routing.test.ts
+++ b/tests/integration/editor-first-routing.test.ts
@@ -97,6 +97,24 @@ test("routing reports missing capabilities before choosing an editing path", () 
   ]);
 });
 
+test("routing permits an advertised artifact editor without a live connection", () => {
+  const capabilities = structuredClone(canonicalCapabilities);
+  capabilities.editor.timelineWrite = false;
+  capabilities.editor.timelineArtifactWrite = true;
+
+  const route = resolveEditingRoute({ operation: "timeline.edit" }, context({
+    connection: { state: "disconnected" },
+    editor: {
+      identity: { name: "FCPXML Document", version: "FCPXML", backend: "fcpxml-document" },
+      capabilities,
+    },
+  }));
+
+  assert.equal(route.status, "editor-selected");
+  assert.equal(route.selectedPath, "editor");
+  assert.equal(route.reason.connectionState, "disconnected");
+});
+
 test("routing only selects an external renderer when explicitly requested", () => {
   const route = resolveEditingRoute(
     { operation: "timeline.edit", fallback: "external-renderer" },

--- a/tests/integration/editor-first-routing.test.ts
+++ b/tests/integration/editor-first-routing.test.ts
@@ -157,6 +157,12 @@ test("MCP exposes editor-first instructions, descriptions, and routing decisions
     assert.match(routeTool.description ?? "", /capabilit/i);
     assert.match(routeTool.description ?? "", /external/i);
     assert.deepEqual(Object.keys(routeTool.inputSchema.properties ?? {}).sort(), ["fallback", "operation"]);
+    for (const name of ["project.inspect", "timeline.edit", "timeline.edit.preview", "timeline.edit.execute"]) {
+      const tool = tools.tools.find((candidate) => candidate.name === name);
+      assert.ok(tool, `${name} must be registered`);
+      assert.match(tool.description ?? "", /editing\.route/);
+      assert.match(tool.description ?? "", /capabilit/i);
+    }
 
     const route = JSON.parse(textFrom(await client.callTool({
       name: "editing.route",

--- a/tests/integration/editor-first-routing.test.ts
+++ b/tests/integration/editor-first-routing.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { RuntimeCapabilities } from "@framekit/runtime";
+import { resolveEditingRoute, type EditorRoutingContext } from "../../apps/mcp-server/src/routing.js";
+
+const canonicalCapabilities: RuntimeCapabilities = {
+  editor: {
+    projectRead: true,
+    timelineSnapshotRead: true,
+    timelineWrite: true,
+    timelineArtifactWrite: false,
+    readAfterWrite: true,
+    incrementalChanges: true,
+    rollback: true,
+    assetDiscovery: true,
+    liveStateRead: false,
+    playheadWrite: false,
+    frameCapture: false,
+  },
+  analyzers: {
+    speechTranscribe: false,
+    speechVad: false,
+    audioLoudness: false,
+    visualTrack: false,
+  },
+};
+
+function context(overrides: Partial<EditorRoutingContext> = {}): EditorRoutingContext {
+  return {
+    connection: { state: "ready" },
+    editor: {
+      identity: { name: "Fixture Editor", version: "test", backend: "fixture" },
+      capabilities: canonicalCapabilities,
+    },
+    ...overrides,
+  };
+}
+
+test("routing selects the connected editor when required capabilities are available", () => {
+  const route = resolveEditingRoute({ operation: "timeline.edit" }, context());
+
+  assert.equal(route.status, "editor-selected");
+  assert.equal(route.selectedPath, "editor");
+  assert.deepEqual(route.missingCapabilities, []);
+  assert.deepEqual(route.editor, {
+    name: "Fixture Editor",
+    version: "test",
+    backend: "fixture",
+  });
+  assert.ok(route.requiredCapabilities.includes("editor.timelineSnapshotRead"));
+  assert.ok(route.requiredCapabilities.includes("editor.timelineWrite|editor.timelineArtifactWrite"));
+});
+
+test("routing fails closed when the expected editor is unavailable", () => {
+  const route = resolveEditingRoute({ operation: "timeline.edit" }, context({
+    connection: {
+      state: "unavailable",
+      lastError: { code: "FINAL_CUT_HEADLESS_SOCKET_UNAVAILABLE", message: "socket missing" },
+    },
+  }));
+
+  assert.equal(route.status, "unavailable");
+  assert.equal(route.selectedPath, "none");
+  assert.equal(route.reason.code, "EDITOR_UNAVAILABLE");
+  assert.equal(route.reason.connectionState, "unavailable");
+  assert.equal(route.reason.cause?.code, "FINAL_CUT_HEADLESS_SOCKET_UNAVAILABLE");
+});
+
+test("routing reports missing capabilities before choosing an editing path", () => {
+  const capabilities = structuredClone(canonicalCapabilities);
+  capabilities.editor.timelineSnapshotRead = false;
+  capabilities.editor.timelineWrite = false;
+  capabilities.editor.timelineArtifactWrite = false;
+
+  const route = resolveEditingRoute({ operation: "timeline.edit" }, context({
+    editor: {
+      identity: { name: "Final Cut Pro", version: "10.7", backend: "workflow-extension-ipc" },
+      capabilities,
+    },
+  }));
+
+  assert.equal(route.status, "unavailable");
+  assert.equal(route.selectedPath, "none");
+  assert.equal(route.reason.code, "CAPABILITY_UNAVAILABLE");
+  assert.deepEqual(route.missingCapabilities, [
+    "editor.timelineSnapshotRead",
+    "editor.timelineWrite|editor.timelineArtifactWrite",
+  ]);
+});
+
+test("routing only selects an external renderer when explicitly requested", () => {
+  const route = resolveEditingRoute(
+    { operation: "timeline.edit", fallback: "external-renderer" },
+    context({
+      connection: { state: "unavailable" },
+    }),
+  );
+
+  assert.equal(route.status, "external-fallback-selected");
+  assert.equal(route.selectedPath, "external-renderer");
+  assert.equal(route.reason.code, "EXTERNAL_FALLBACK_SELECTED");
+  assert.equal(route.reason.cause?.code, "EDITOR_UNAVAILABLE");
+  assert.match(route.reason.message, /explicit/i);
+});
+
+test("explicit external selection is reported even when the editor is ready", () => {
+  const route = resolveEditingRoute(
+    { operation: "timeline.edit", fallback: "external-renderer" },
+    context(),
+  );
+
+  assert.equal(route.status, "external-fallback-selected");
+  assert.equal(route.selectedPath, "external-renderer");
+  assert.equal(route.reason.cause?.code, "USER_SELECTED_EXTERNAL_FALLBACK");
+});

--- a/tests/integration/mcp.test.ts
+++ b/tests/integration/mcp.test.ts
@@ -40,6 +40,7 @@ test("Phase 0 exposes read/write/diff through MCP stdio", async () => {
         "edit.undo",
         "edit.verify",
         "editing.intent.resolve",
+        "editing.route",
         "editor.assets",
         "editor.inspect",
         "editor.live.changes",


### PR DESCRIPTION
Closes #90

## Summary
- Add an editor-first routing resolver for edit, publish, and export workflows.
- Fail closed for unavailable editors and missing capabilities.
- Require explicit external-renderer fallback and report its selection.
- Align MCP instructions, tool descriptions, schemas, and documentation.

## TDD
- Added deterministic routing, MCP contract, and documentation consistency tests first.
- Implemented the resolver and MCP integration until the tests passed.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm run test` — 300/300 passed
- `pnpm run check:boundaries`
- `git diff --check origin/main...HEAD`
- Headless Final Cut probe correctly reported unavailable without a socket; no native files changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added editor-first routing for timeline editing, native editing, publishing, and export workflows.
  * Added capability-aware `editing.route` and non-mutating `editing.duration.plan` tools.
  * Added explicit external-renderer fallback selection and publishing availability reporting.
  * Enabled eligible timeline edits without a live connection.

* **Bug Fixes**
  * Prevented automatic external rendering when capabilities are unavailable.
  * Improved connection, capability, and routing error details.

* **Documentation**
  * Documented routing, capability checks, preview, execution, duration planning, and result verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->