### PR TITLE
chore: run Renovate daily at 7am

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:best-practices"],
   "timezone": "Asia/Tokyo",
-  "schedule": ["before 9am on monday"],
+  "schedule": ["* 7 * * *"],
   "prConcurrentLimit": 5,
   "prHourlyLimit": 2,
   "packageRules": [


### PR DESCRIPTION
## Summary

- Run Renovate every day during the 07:00–07:59 Asia/Tokyo window.
- Replace the previous Monday-only schedule with Renovate cron syntax.

## Validation

- `pnpm run build`
- `pnpm run test` (380 passed)
- `pnpm run check:boundaries`
- `renovate-config-validator`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Dependency update checks now run daily at 7:00 AM Japan Standard Time instead of weekly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->