### PR TITLE
Release for v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [v0.1.2](https://github.com/morshoto/framekit/compare/v0.1.1...v0.1.2) - 2026-08-30
+
+- chore: run Renovate daily at 7am by @morshoto in https://github.com/morshoto/framekit/pull/106
+- ci: preserve default-branch CodeQL analyses by @morshoto in https://github.com/morshoto/framekit/pull/111
+- [Fix] Fail closed on untrusted live snapshots by @morshoto in https://github.com/morshoto/framekit/pull/112
+- [Improvement] Harden sanitized headed evidence digests by @morshoto in https://github.com/morshoto/framekit/pull/113
+- fix: guard npm release publishing by @morshoto in https://github.com/morshoto/framekit/pull/114
+- fix: preserve partial filler analysis ranges by @morshoto in https://github.com/morshoto/framekit/pull/117
+- chore(deps): lock file maintenance by @renovate[bot] in https://github.com/morshoto/framekit/pull/116
+- chore: enable Renovate automerge for safe updates by @morshoto in https://github.com/morshoto/framekit/pull/120
+- feat: add deterministic filler safe cuts by @morshoto in https://github.com/morshoto/framekit/pull/118
+- feat: add v0.0.3 speech editing release gate by @morshoto in https://github.com/morshoto/framekit/pull/119
+- ci: restore reliable Swift CodeQL coverage by @morshoto in https://github.com/morshoto/framekit/pull/115
+
 ## [v0.1.1](https://github.com/morshoto/framekit/compare/v0.1.0...v0.1.1) - 2026-08-30
 
 - chore: automate npm and GitHub releases by @morshoto in https://github.com/morshoto/framekit/pull/84

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@morshoto/framekit",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "packageManager": "pnpm@11.10.0",
   "private": false,
   "type": "module",

--- a/plugins/framekit/.codex-plugin/plugin.json
+++ b/plugins/framekit/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "framekit",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Connect Codex to Framekit's MCP tools for Final Cut Pro",
   "author": {
     "name": "Framekit Contributors",


### PR DESCRIPTION
This pull request is for the next release as v0.1.2 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.2 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.1" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* chore: run Renovate daily at 7am by @morshoto in https://github.com/morshoto/framekit/pull/106
* ci: preserve default-branch CodeQL analyses by @morshoto in https://github.com/morshoto/framekit/pull/111
* [Fix] Fail closed on untrusted live snapshots by @morshoto in https://github.com/morshoto/framekit/pull/112
* [Improvement] Harden sanitized headed evidence digests by @morshoto in https://github.com/morshoto/framekit/pull/113
* fix: guard npm release publishing by @morshoto in https://github.com/morshoto/framekit/pull/114
* fix: preserve partial filler analysis ranges by @morshoto in https://github.com/morshoto/framekit/pull/117
* chore(deps): lock file maintenance by @renovate[bot] in https://github.com/morshoto/framekit/pull/116
* chore: enable Renovate automerge for safe updates by @morshoto in https://github.com/morshoto/framekit/pull/120
* feat: add deterministic filler safe cuts by @morshoto in https://github.com/morshoto/framekit/pull/118
* feat: add v0.0.3 speech editing release gate by @morshoto in https://github.com/morshoto/framekit/pull/119
* ci: restore reliable Swift CodeQL coverage by @morshoto in https://github.com/morshoto/framekit/pull/115

## New Contributors
* @renovate[bot] made their first contribution in https://github.com/morshoto/framekit/pull/116

**Full Changelog**: https://github.com/morshoto/framekit/compare/v0.1.1...tagpr-from-v0.1.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the package and plugin to version 0.1.2.
  * Added release validation checks to the standard test and release workflows.

* **Documentation**
  * Added changelog details covering security analysis, publishing safeguards, snapshot hardening, speech editing gates, and dependency maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->