### PR TITLE
ci: preserve default-branch CodeQL analyses

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,8 @@ permissions:
 
 concurrency:
   group: codeql-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Keep active default-branch scans intact; supersede stale PR scans.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   analyze:

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Repository-local GitHub agent playbooks are documented in
 
 - [Getting started](./getting-started.md): development setup, MCP, and Final Cut connection.
 - [Releasing](./releasing.md): npm Trusted Publishing and automated GitHub releases.
+- [CodeQL workflow operations](./ci/codeql.md): concurrency and analysis verification.
 - [PRD](./PRD.md): product goals and roadmap.
 - [Test matrix](./tests/test-matrix.md): delivery scope and evidence by backend.
 - [SDD](./SDD.md): architecture and design contracts.

--- a/docs/ci/codeql.md
+++ b/docs/ci/codeql.md
@@ -18,6 +18,27 @@ historical analyses, or change the configured security rules and query suites.
 
 ## Verification
 
+Status: Verified for the pull-request merge ref; post-merge `main` validation is pending.
+
+Last verified: 2026-08-31 (Asia/Tokyo; 2026-08-30 UTC)
+
+Environment: GitHub Actions, CodeQL v4, `javascript-typescript` on `ubuntu-latest`.
+
+Scope: PR #111 merge-ref workflow run and its code-scanning analysis; the resulting
+default-branch behavior still requires a post-merge run.
+
+Expected result: The workflow completes successfully, and its analysis has a
+nonzero `rules_count` with no unsuccessful-execution error.
+
+Actual evidence: Workflow run `33315229687` completed successfully. Analysis
+`1694210133` for `refs/pull/111/merge` reported `rules_count: 87`,
+`results_count: 0`, and an empty `error`. The existing `main` history still
+contains two zero-rule unsuccessful records; this change does not delete them.
+
+Limitations: The PR merge-ref run cannot prove the post-merge `main` behavior.
+After merge, trigger closely spaced `main` runs and inspect their workflow
+conclusions and analyses API records.
+
 After closely spaced workflow triggers, inspect both workflow conclusions and
 the code-scanning analyses API. A healthy `main` analysis has a nonzero
 `rules_count` and no unsuccessful-execution error:

--- a/docs/ci/codeql.md
+++ b/docs/ci/codeql.md
@@ -1,0 +1,31 @@
+# CodeQL workflow operations
+
+The CodeQL workflow uses one concurrency group per workflow and Git reference.
+GitHub keeps at most one run running and one run pending in each group.
+
+## Cancellation policy
+
+Default-branch pushes, scheduled scans, and manual scans queue behind an active
+run. They do not cancel an active default-branch analysis, so a routine burst of
+commits cannot interrupt CodeQL while it is publishing its analysis record.
+
+Pull-request scans cancel an older active scan for the same pull request when a
+newer pull-request event arrives. This bounds work for obsolete pull-request
+commits while leaving different pull requests independent.
+
+The policy intentionally does not suppress genuine CodeQL failures, delete
+historical analyses, or change the configured security rules and query suites.
+
+## Verification
+
+After closely spaced workflow triggers, inspect both workflow conclusions and
+the code-scanning analyses API. A healthy `main` analysis has a nonzero
+`rules_count` and no unsuccessful-execution error:
+
+```sh
+gh run list --workflow codeql.yml --limit 20
+gh api 'repos/morshoto/framekit/code-scanning/analyses?ref=refs%2Fheads%2Fmain&per_page=20'
+```
+
+Cancelled pull-request runs are expected when a newer commit supersedes them.
+An unsuccessful zero-rule analysis for `main` is not an expected result.

--- a/tests/integration/codeql-workflow.test.ts
+++ b/tests/integration/codeql-workflow.test.ts
@@ -34,3 +34,19 @@ test("CodeQL concurrency policy is documented for operators", async () => {
   assert.match(documentation, /one.*running.*one.*pending/i);
   assert.match(documentation, /code-scanning analyses API/i);
 });
+
+test("CodeQL verification documentation records operational metadata", async () => {
+  const documentation = await readRepositoryFile("docs/ci/codeql.md");
+
+  for (const expected of [
+    /^Status:\s+.+$/im,
+    /^Last verified:\s+\d{4}-\d{2}-\d{2}/im,
+    /^Environment:\s+.+$/im,
+    /^Scope:\s+.+$/im,
+    /^Expected result:\s+.+$/im,
+    /^Actual evidence:\s+.+$/im,
+    /^Limitations:\s+.+$/im,
+  ]) {
+    assert.match(documentation, expected);
+  }
+});

--- a/tests/integration/codeql-workflow.test.ts
+++ b/tests/integration/codeql-workflow.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repository = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+async function readRepositoryFile(relativePath: string): Promise<string> {
+  return readFile(resolve(repository, relativePath), "utf8");
+}
+
+test("CodeQL keeps default-branch runs from being cancelled", async () => {
+  const workflow = await readRepositoryFile(".github/workflows/codeql.yml");
+
+  assert.match(workflow, /push:\s+branches:\s+- main/);
+  assert.match(workflow, /group:\s+codeql-\$\{\{ github\.workflow \}\}-\$\{\{ github\.ref \}\}/);
+  assert.match(workflow, /cancel-in-progress:\s+\$\{\{ github\.event_name == 'pull_request' \}\}/);
+});
+
+test("CodeQL still supersedes obsolete pull-request runs", async () => {
+  const workflow = await readRepositoryFile(".github/workflows/codeql.yml");
+
+  assert.match(workflow, /pull_request:\s+branches:\s+- main/);
+  assert.match(workflow, /types:\s+- opened\s+- synchronize\s+- reopened/);
+  assert.match(workflow, /github\.event_name == 'pull_request'/);
+});
+
+test("CodeQL concurrency policy is documented for operators", async () => {
+  const documentation = await readRepositoryFile("docs/ci/codeql.md");
+
+  assert.match(documentation, /default-branch.*queue/i);
+  assert.match(documentation, /pull-request.*cancel/i);
+  assert.match(documentation, /one.*running.*one.*pending/i);
+  assert.match(documentation, /code-scanning analyses API/i);
+});


### PR DESCRIPTION

- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [x] Github issue: Closes: #104

## Summary

Updated CodeQL concurrency so default-branch, scheduled, and manual scans do not cancel an active analysis. Pull-request scans still cancel obsolete runs for the same pull request, keeping supersession bounded.

Added deterministic workflow-policy tests and operator documentation covering the queue/cancellation policy and Code Scanning API verification.

## Validation

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm run build`
- [x] `pnpm run test` — 383 passed
- [x] `pnpm run check:boundaries`
- [x] Focused CodeQL workflow tests — 3 passed
- [ ] Native Xcode validation — not applicable; no native files changed

The current live API baseline has a newest healthy main analysis with 87 rules and two historical zero-rule unsuccessful records. Post-change consecutive-run verification will occur after GitHub executes this workflow.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] No public MCP behavior or package interface changed.
- [x] Existing adapters and test fixtures remain compatible.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [x] Documentation reflects the changed CodeQL behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added CodeQL operations guidance, verification metadata, and a README link to the documentation.

* **CI Improvements**
  * Updated CodeQL concurrency so outdated pull-request scans are cancelled without interrupting active default-branch scans.

* **Tests**
  * Added integration coverage for workflow triggers, concurrency behavior, documentation, and required verification details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->