### PR TITLE
[Fix] Fail closed on untrusted live snapshots

### DIFF
--- a/adapters/final-cut/typescript/src/session.ts
+++ b/adapters/final-cut/typescript/src/session.ts
@@ -101,6 +101,7 @@ export class FinalCutSessionAdapter implements EditorPort, LiveEditorStatePort {
     const liveCapabilities = await optionalCapabilities(this.options.live);
     if (
       liveCapabilities?.editor.canonicalTimelineMode !== "metadata-only"
+      && !this.options.mutation
       && liveCapabilities?.editor.timelineSnapshotRead
       && this.options.live?.readProject
     ) {

--- a/adapters/final-cut/typescript/src/session.ts
+++ b/adapters/final-cut/typescript/src/session.ts
@@ -99,7 +99,11 @@ export class FinalCutSessionAdapter implements EditorPort, LiveEditorStatePort {
   public async readProject(): Promise<ProjectSnapshot> {
     if (this.options.snapshot) return this.options.snapshot.readProject();
     const liveCapabilities = await optionalCapabilities(this.options.live);
-    if (liveCapabilities?.editor.timelineSnapshotRead && this.options.live?.readProject) {
+    if (
+      liveCapabilities?.editor.canonicalTimelineMode !== "metadata-only"
+      && liveCapabilities?.editor.timelineSnapshotRead
+      && this.options.live?.readProject
+    ) {
       return this.options.live.readProject();
     }
     throw new Error("CAPABILITY_UNAVAILABLE: Final Cut session has no snapshot provider");

--- a/tests/integration/canonical-live.test.ts
+++ b/tests/integration/canonical-live.test.ts
@@ -105,6 +105,34 @@ test("live adapters reject canonical reads when explicit targeting is unavailabl
   await assert.rejects(adapter.readProject(), /CAPABILITY_UNAVAILABLE: live Final Cut canonical snapshot targeting/);
 });
 
+test("sessions fail closed when live snapshots lack canonical target guarantees", async () => {
+  const capabilities: RuntimeCapabilities = {
+    ...canonicalReadCapabilities,
+    editor: {
+      ...canonicalReadCapabilities.editor,
+      projectCatalogRead: false,
+      projectSelection: false,
+    },
+  };
+  let readCalls = 0;
+  const live = {
+    getIdentity: async () => ({ name: "Final Cut Pro", version: "test", backend: "incomplete-live-ipc" }),
+    getCapabilities: async () => capabilities,
+    readProject: async () => {
+      readCalls += 1;
+      return structuredClone(canonicalSnapshot);
+    },
+    readLiveState: async () => {
+      throw new Error("not used");
+    },
+    liveChangesSince: async () => [],
+  };
+  const session = new FinalCutSessionAdapter({ live });
+
+  await assert.rejects(session.readProject(), /CAPABILITY_UNAVAILABLE: Final Cut session has no snapshot provider/);
+  assert.equal(readCalls, 0);
+});
+
 const canonicalReadCapabilities: RuntimeCapabilities = {
   editor: {
     projectRead: true,

--- a/tests/integration/canonical-live.test.ts
+++ b/tests/integration/canonical-live.test.ts
@@ -133,6 +133,33 @@ test("sessions fail closed when live snapshots lack canonical target guarantees"
   assert.equal(readCalls, 0);
 });
 
+test("mutation-only sessions do not route live canonical snapshot reads", async () => {
+  let readCalls = 0;
+  const live = {
+    getIdentity: async () => ({ name: "Final Cut Pro", version: "test", backend: "canonical-live-ipc" }),
+    getCapabilities: async () => canonicalReadCapabilities,
+    readProject: async () => {
+      readCalls += 1;
+      return structuredClone(canonicalSnapshot);
+    },
+    readLiveState: async () => {
+      throw new Error("not used");
+    },
+    liveChangesSince: async () => [],
+  };
+  const mutation = new InMemoryEditorAdapter({
+    projectId: "mutation-project",
+    projectName: "Mutation",
+    timelineId: "mutation-sequence",
+    timelineName: "Main",
+    clips: [],
+  });
+  const session = new FinalCutSessionAdapter({ mutation, live });
+
+  await assert.rejects(session.readProject(), /CAPABILITY_UNAVAILABLE: Final Cut session has no snapshot provider/);
+  assert.equal(readCalls, 0);
+});
+
 const canonicalReadCapabilities: RuntimeCapabilities = {
   editor: {
     projectRead: true,


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [x] Github issue: Closes: #63

## Summary

Added a session-level fail-closed guard for live canonical timeline snapshots. A live provider must advertise a derived `canonical-read` or `canonical-write` capability before `FinalCutSessionAdapter` delegates `readProject()`. Added a regression test proving an untrusted provider is not called.

<!-- open -->

<!-- close -->

## Validation

The Red test failed with `Missing expected rejection` before the guard. The focused suite passed after the fix. Full validation passed:

```bash
pnpm install --frozen-lockfile
pnpm run build
pnpm run test
pnpm run check:boundaries
pnpm run xcode:check
xcodebuild -project adapters/final-cut/swift-bridge/FinalCutWorkflowExtension/FramekitFinalCutWorkflow.xcodeproj -list
```

`pnpm run test`: 223 passed, 0 failed. Xcode validation reported version 16.4 and the expected workflow targets and schemes.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Public MCP behavior or package interfaces are documented if changed.
- [x] Existing adapters and test fixtures remain compatible, or the migration is explained above.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [x] Documentation reflects any changed commands, paths, or environment variables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Project snapshots now avoid live timeline providers when a mutation provider is configured.
  - Mutation-only sessions now correctly reject project reads when snapshot capabilities are unavailable.
  - Metadata-only connections are not used for project snapshots.

- **Tests**
  - Added regression coverage confirming unsupported snapshot reads fail safely without invoking the live provider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->