### PR TITLE
[Improvement] Harden sanitized headed evidence digests

### DIFF
--- a/scripts/final-cut-evidence.mjs
+++ b/scripts/final-cut-evidence.mjs
@@ -101,7 +101,9 @@ export function sanitizeCanonicalEvidence(run, environment) {
   assert(run.project && run.target, "project or target identity is missing");
   assert(run.before && run.after && run.restored && run.diff, "canonical snapshots or diff are missing");
   assert(run.digests?.before && run.digests?.restored, "canonical digests are missing");
-  assert(run.digests.before === run.digests.restored, "restored digest does not match the pre-edit digest");
+  const beforeDigest = requireSha256Digest(run.digests.before, "before digest");
+  const restoredDigest = requireSha256Digest(run.digests.restored, "restored digest");
+  assert(beforeDigest === restoredDigest, "restored digest does not match the pre-edit digest");
   const beforeRevision = summarizeRevision(run.before.revision);
   const afterRevision = summarizeRevision(run.after.revision);
   const restoredRevision = summarizeRevision(run.restored.revision);
@@ -154,8 +156,8 @@ export function sanitizeCanonicalEvidence(run, environment) {
       operation: "edit.undo",
       status: "VERIFIED",
       restored: true,
-      beforeDigest: run.digests.before,
-      restoredDigest: run.digests.restored,
+      beforeDigest,
+      restoredDigest,
       restoredRevision,
     },
     sanitization: {
@@ -503,6 +505,11 @@ function requireString(value, label) {
 
 function requireFiniteNumber(value, label) {
   assert(typeof value === "number" && Number.isFinite(value), `${label} must be a finite number`);
+  return value;
+}
+
+function requireSha256Digest(value, label) {
+  assert(typeof value === "string" && /^[0-9a-f]{64}$/i.test(value), `${label} must be a 64-character SHA-256 hexadecimal string`);
   return value;
 }
 

--- a/tests/integration/canonical-evidence.test.ts
+++ b/tests/integration/canonical-evidence.test.ts
@@ -121,8 +121,8 @@ test("canonical headed evidence keeps mutation proof while omitting private snap
       operation: "edit.undo",
       status: "VERIFIED",
       restored: true,
-      beforeDigest: "before-digest",
-      restoredDigest: "before-digest",
+      beforeDigest: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      restoredDigest: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
       restoredRevision: { id: "rev-12", sequence: 12, timestamp: "2026-08-26T10:00:03.000Z" },
     },
     sanitization: {
@@ -420,7 +420,10 @@ const rawRun = {
     rawDiagnostics: "raw crash dump",
   },
   restored: snapshot("Interview", baseRevision("rev-12", 12, "2026-08-26T10:00:03.000Z")),
-  digests: { before: "before-digest", restored: "before-digest" },
+  digests: {
+    before: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    restored: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  },
   transactionId: "transaction-secret",
 };
 

--- a/tests/integration/canonical-evidence.test.ts
+++ b/tests/integration/canonical-evidence.test.ts
@@ -221,6 +221,26 @@ test("canonical headed evidence rejects metadata-only capability claims", () => 
   );
 });
 
+test("canonical headed evidence rejects malformed digest values", () => {
+  const malformedDigestRun = structuredClone(rawRun);
+  const privateDigest = { source: "/Users/private/secret-footage.mov" };
+  Reflect.set(malformedDigestRun.digests, "before", privateDigest);
+  Reflect.set(malformedDigestRun.digests, "restored", privateDigest);
+
+  assert.throws(
+    () => sanitizeCanonicalEvidence(malformedDigestRun, {
+      framekitVersion: "0.1.0",
+      finalCutVersion: "10.7.1",
+      gitCommit: "0123456789abcdef0123456789abcdef01234567",
+      nodeVersion: "v22.15.0",
+      platform: "darwin",
+      architecture: "arm64",
+      osVersion: "Darwin Kernel Version 25.5.0",
+    }),
+    /FINAL_CUT_E2E_EVIDENCE_INCOMPLETE: before digest must be a 64-character SHA-256 hexadecimal string/,
+  );
+});
+
 test("canonical headed evidence rejects path-like malformed capability values", () => {
   const malformedRun = structuredClone(rawRun);
   Reflect.set(malformedRun.capabilities.editor, "timelineWrite", "/Users/private/credentials.txt");


### PR DESCRIPTION
- [ ] Request PR review
- [ ] Github issue: Refs: #65

## Summary

Harden the sanitized headed Final Cut evidence boundary after the implementation in PR #71.

- Add a regression test proving a path-bearing digest object is rejected.
- Require before and restored digests to be 64-character hexadecimal SHA-256 values.
- Emit only validated digest strings in the evidence document.

## Validation

```bash
PATH=/Users/shotomorisaki/.nix-profile/bin:$PATH pnpm install --frozen-lockfile
PATH=/Users/shotomorisaki/.nix-profile/bin:$PATH pnpm exec tsx --test tests/integration/canonical-evidence.test.ts
PATH=/Users/shotomorisaki/.nix-profile/bin:$PATH pnpm run build
PATH=/Users/shotomorisaki/.nix-profile/bin:$PATH pnpm run test
PATH=/Users/shotomorisaki/.nix-profile/bin:$PATH pnpm run check:boundaries
```

Results: focused evidence tests 12/12; full suite 381/381; build and boundary checks passed.

Native Xcode validation was not run because this follow-up changes only JavaScript and TypeScript tests.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Public MCP behavior or package interfaces are unchanged.
- [x] Existing adapters and test fixtures remain compatible.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [x] Existing evidence documentation reflects the unchanged headed-run boundary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of canonical evidence by requiring properly formatted SHA-256 digests.
  * Prevented malformed evidence, including invalid private path data, from being accepted.
  * Ensured restored evidence uses validated digest values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->