### PR TITLE
fix: guard npm release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,12 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Validate release package
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          RELEASE_TAG: ${{ needs.tagpr.outputs.tagpr-tag }}
+        run: node scripts/validate-release-contract.mjs
+
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
         with:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -13,6 +13,17 @@ Configure npm Trusted Publishing for `@morshoto/framekit` with these values:
 - Workflow filename: `release.yml`
 - Allowed action: `npm publish`
 
+The same trust relationship can be configured from an authenticated npm CLI
+session after the package exists on the registry:
+
+```sh
+npm trust github @morshoto/framekit \
+  --repo morshoto/framekit \
+  --file release.yml \
+  --allow-publish \
+  --yes
+```
+
 The package metadata must keep its `repository.url` aligned with the GitHub
 repository. The workflow uses GitHub's OIDC identity and does not require an
 `NPM_TOKEN` repository secret.

--- a/scripts/validate-release-contract.d.mts
+++ b/scripts/validate-release-contract.d.mts
@@ -1,0 +1,11 @@
+export interface ReleasePackageManifest {
+  version?: unknown;
+  [key: string]: unknown;
+}
+
+export interface ReleaseContractInput {
+  packageManifest: ReleasePackageManifest;
+  releaseTag?: string;
+}
+
+export function validateReleaseContract(input: ReleaseContractInput): void;

--- a/scripts/validate-release-contract.d.mts
+++ b/scripts/validate-release-contract.d.mts
@@ -1,7 +1,7 @@
 export interface ReleasePackageManifest {
   version?: unknown;
   private?: unknown;
-  repository?: { url?: unknown };
+  repository?: { type?: unknown; url?: unknown };
   publishConfig?: { access?: unknown };
   [key: string]: unknown;
 }

--- a/scripts/validate-release-contract.d.mts
+++ b/scripts/validate-release-contract.d.mts
@@ -1,11 +1,15 @@
 export interface ReleasePackageManifest {
   version?: unknown;
+  private?: unknown;
+  repository?: { url?: unknown };
+  publishConfig?: { access?: unknown };
   [key: string]: unknown;
 }
 
 export interface ReleaseContractInput {
   packageManifest: ReleasePackageManifest;
   releaseTag?: string;
+  githubRepository?: string;
 }
 
 export function validateReleaseContract(input: ReleaseContractInput): void;

--- a/scripts/validate-release-contract.mjs
+++ b/scripts/validate-release-contract.mjs
@@ -2,15 +2,26 @@ import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { resolve } from "node:path";
 
-export function validateReleaseContract({ packageManifest, releaseTag }) {
+const expectedRepository = "morshoto/framekit";
+const expectedRepositoryUrl = `https://github.com/${expectedRepository}.git`;
+
+export function validateReleaseContract({ packageManifest, releaseTag, githubRepository }) {
+  const failures = [];
   const expectedVersion = typeof releaseTag === "string" && releaseTag.startsWith("v")
     ? releaseTag.slice(1)
     : "";
 
   if (!expectedVersion || packageManifest?.version !== expectedVersion) {
-    throw new Error(
-      `RELEASE_CONTRACT_INVALID: package version "${packageManifest?.version ?? ""}" does not match release tag "${releaseTag ?? ""}"`,
-    );
+    failures.push(`package version "${packageManifest?.version ?? ""}" does not match release tag "${releaseTag ?? ""}"`);
+  }
+  if (githubRepository !== expectedRepository || packageManifest?.repository?.url !== expectedRepositoryUrl) {
+    failures.push(`repository "${packageManifest?.repository?.url ?? ""}" does not match "${expectedRepositoryUrl}"`);
+  }
+  if (packageManifest?.private !== false || packageManifest?.publishConfig?.access !== "public") {
+    failures.push("package must be public");
+  }
+  if (failures.length > 0) {
+    throw new Error(`RELEASE_CONTRACT_INVALID: ${failures.join("; ")}`);
   }
 }
 
@@ -19,6 +30,7 @@ async function validateCheckedOutPackage() {
   validateReleaseContract({
     packageManifest,
     releaseTag: process.env.RELEASE_TAG,
+    githubRepository: process.env.GITHUB_REPOSITORY,
   });
   process.stdout.write(`Release contract valid for ${packageManifest.name}@${packageManifest.version}\n`);
 }

--- a/scripts/validate-release-contract.mjs
+++ b/scripts/validate-release-contract.mjs
@@ -1,0 +1,31 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+
+export function validateReleaseContract({ packageManifest, releaseTag }) {
+  const expectedVersion = typeof releaseTag === "string" && releaseTag.startsWith("v")
+    ? releaseTag.slice(1)
+    : "";
+
+  if (!expectedVersion || packageManifest?.version !== expectedVersion) {
+    throw new Error(
+      `RELEASE_CONTRACT_INVALID: package version "${packageManifest?.version ?? ""}" does not match release tag "${releaseTag ?? ""}"`,
+    );
+  }
+}
+
+async function validateCheckedOutPackage() {
+  const packageManifest = JSON.parse(await readFile(resolve(process.cwd(), "package.json"), "utf8"));
+  validateReleaseContract({
+    packageManifest,
+    releaseTag: process.env.RELEASE_TAG,
+  });
+  process.stdout.write(`Release contract valid for ${packageManifest.name}@${packageManifest.version}\n`);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  validateCheckedOutPackage().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/tests/integration/release-workflow.test.ts
+++ b/tests/integration/release-workflow.test.ts
@@ -36,3 +36,37 @@ test("release preflight rejects a tag that differs from package version", async 
     /version .* does not match release tag/i,
   );
 });
+
+test("release preflight rejects a package repository mismatch", async () => {
+  const { validateReleaseContract } = await import(validatorModulePath);
+  assert.throws(
+    () => validateReleaseContract({
+      packageManifest: {
+        ...canonicalManifest,
+        repository: {
+          type: "git",
+          url: "https://github.com/example/other-repo.git",
+        },
+      },
+      releaseTag: "v0.1.1",
+      githubRepository: "morshoto/framekit",
+    }),
+    /repository .* does not match/i,
+  );
+});
+
+test("release preflight rejects a package that is not publicly publishable", async () => {
+  const { validateReleaseContract } = await import(validatorModulePath);
+  assert.throws(
+    () => validateReleaseContract({
+      packageManifest: {
+        ...canonicalManifest,
+        private: true,
+        publishConfig: { access: "restricted" },
+      },
+      releaseTag: "v0.1.1",
+      githubRepository: "morshoto/framekit",
+    }),
+    /public/i,
+  );
+});

--- a/tests/integration/release-workflow.test.ts
+++ b/tests/integration/release-workflow.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const validatorModulePath = "../../scripts/validate-release-contract.mjs";
+
+const canonicalManifest = {
+  name: "@morshoto/framekit",
+  version: "0.1.1",
+  private: false,
+  repository: {
+    type: "git",
+    url: "https://github.com/morshoto/framekit.git",
+  },
+  publishConfig: {
+    access: "public",
+  },
+};
+
+test("release preflight accepts the canonical package and matching tag", async () => {
+  const { validateReleaseContract } = await import(validatorModulePath);
+  assert.doesNotThrow(() => validateReleaseContract({
+    packageManifest: canonicalManifest,
+    releaseTag: "v0.1.1",
+    githubRepository: "morshoto/framekit",
+  }));
+});
+
+test("release preflight rejects a tag that differs from package version", async () => {
+  const { validateReleaseContract } = await import(validatorModulePath);
+  assert.throws(
+    () => validateReleaseContract({
+      packageManifest: canonicalManifest,
+      releaseTag: "v0.1.2",
+      githubRepository: "morshoto/framekit",
+    }),
+    /version .* does not match release tag/i,
+  );
+});

--- a/tests/integration/release-workflow.test.ts
+++ b/tests/integration/release-workflow.test.ts
@@ -3,8 +3,8 @@ import { readFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import { validateReleaseContract } from "../../scripts/validate-release-contract.mjs";
 
-const validatorModulePath = "../../scripts/validate-release-contract.mjs";
 const repository = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 
 const canonicalManifest = {
@@ -20,8 +20,7 @@ const canonicalManifest = {
   },
 };
 
-test("release preflight accepts the canonical package and matching tag", async () => {
-  const { validateReleaseContract } = await import(validatorModulePath);
+test("release preflight accepts the canonical package and matching tag", () => {
   assert.doesNotThrow(() => validateReleaseContract({
     packageManifest: canonicalManifest,
     releaseTag: "v0.1.1",
@@ -29,8 +28,7 @@ test("release preflight accepts the canonical package and matching tag", async (
   }));
 });
 
-test("release preflight rejects a tag that differs from package version", async () => {
-  const { validateReleaseContract } = await import(validatorModulePath);
+test("release preflight rejects a tag that differs from package version", () => {
   assert.throws(
     () => validateReleaseContract({
       packageManifest: canonicalManifest,
@@ -41,8 +39,7 @@ test("release preflight rejects a tag that differs from package version", async 
   );
 });
 
-test("release preflight rejects a package repository mismatch", async () => {
-  const { validateReleaseContract } = await import(validatorModulePath);
+test("release preflight rejects a package repository mismatch", () => {
   assert.throws(
     () => validateReleaseContract({
       packageManifest: {
@@ -59,8 +56,7 @@ test("release preflight rejects a package repository mismatch", async () => {
   );
 });
 
-test("release preflight rejects a package that is not publicly publishable", async () => {
-  const { validateReleaseContract } = await import(validatorModulePath);
+test("release preflight rejects a package that is not publicly publishable", () => {
   assert.throws(
     () => validateReleaseContract({
       packageManifest: {

--- a/tests/integration/release-workflow.test.ts
+++ b/tests/integration/release-workflow.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 const validatorModulePath = "../../scripts/validate-release-contract.mjs";
+const repository = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 
 const canonicalManifest = {
   name: "@morshoto/framekit",
@@ -69,4 +73,24 @@ test("release preflight rejects a package that is not publicly publishable", asy
     }),
     /public/i,
   );
+});
+
+test("release workflow validates the package before publishing", async () => {
+  const workflow = await readFile(resolve(repository, ".github/workflows/release.yml"), "utf8");
+  const validation = workflow.indexOf("node scripts/validate-release-contract.mjs");
+  const publication = workflow.indexOf("npm publish");
+
+  assert.notEqual(validation, -1);
+  assert.ok(validation < publication, "release validation must run before npm publish");
+  assert.match(workflow, /GITHUB_REPOSITORY: \$\{\{ github\.repository \}\}/);
+  assert.match(workflow, /RELEASE_TAG: \$\{\{ needs\.tagpr\.outputs\.tagpr-tag \}\}/);
+});
+
+test("release documentation provides the exact npm trust command", async () => {
+  const documentation = await readFile(resolve(repository, "docs/releasing.md"), "utf8");
+  assert.match(documentation, /npm trust github @morshoto\/framekit/);
+  assert.match(documentation, /--repo\s+morshoto\/framekit/);
+  assert.match(documentation, /--file\s+release\.yml/);
+  assert.match(documentation, /--allow-publish/);
+  assert.match(documentation, /--yes/);
 });


### PR DESCRIPTION
- [x] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #107

## Summary

Addresses #107 by adding a fail-closed release preflight and making npm Trusted Publishing setup reproducible.

- Validates the release tag against the checked-out package version.
- Validates the canonical GitHub repository and public package settings.
- Runs the preflight before dependency installation and npm publication.
- Documents the exact `npm trust github` configuration command.
- Adds focused contract tests covering the validator, workflow ordering, and documentation.

The live npm configuration remains an npm-account action. At validation time, npm still exposes only `0.1.0`; `0.1.1` is not yet published.

## Validation

The following passed:

```bash
pnpm install --frozen-lockfile
pnpm exec tsx --test tests/integration/release-workflow.test.ts
pnpm run build
pnpm run test
pnpm run check:boundaries
npm pack --dry-run
RELEASE_TAG=v0.1.1 GITHUB_REPOSITORY=morshoto/framekit node scripts/validate-release-contract.mjs
```

Full suite result: 386 tests passed. Package dry-run produced 57 files.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Public MCP behavior or package interfaces are documented if changed.
- [x] Existing adapters and test fixtures remain compatible, or the migration is explained above.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [x] Documentation reflects any changed commands, paths, or environment variables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added pre-release validation to confirm package metadata, version, repository, and public visibility before publishing.
  - Added npm Trusted Publishing setup guidance to the release documentation.

- **Bug Fixes**
  - Prevents releases with mismatched versions, repositories, or non-public package settings from being published.

- **Tests**
  - Added integration coverage for valid and invalid release configurations and publishing safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->