### PR TITLE
fix: preserve partial filler analysis ranges

### DIFF
--- a/packages/runtime/src/editing/filler-removal-service.ts
+++ b/packages/runtime/src/editing/filler-removal-service.ts
@@ -38,7 +38,6 @@ export class FillerRemovalService {
     await this.assertCapabilities();
     const selectedRange = validateFillerSelection(request.range);
     const candidates: FillerRemovalTarget[] = [];
-    const expectedWordsByClip = new Map<string, SpeechWord[]>();
     const analysisRangesByClip = new Map<string, TimeRange>();
     const selectedClips = before.timeline.clips.filter((clip) =>
       clip.mediaId && rangesOverlap(clip.start, clip.start + clip.duration, selectedRange.start, selectedRange.end),
@@ -60,7 +59,6 @@ export class FillerRemovalService {
       };
       if (localRange.end <= localRange.start) continue;
       const speech = await this.options.speechAnalyzer!.analyze({ project: before, media }, localRange);
-      expectedWordsByClip.set(clip.id, structuredClone(speech.words));
       analysisRangesByClip.set(clip.id, structuredClone(localRange));
       for (const candidate of planFillerRemoval(speech.words, localRange, request)) {
         candidates.push({
@@ -106,7 +104,7 @@ export class FillerRemovalService {
       if (oldestToken === undefined) break;
       this.previews.delete(oldestToken);
     }
-    this.previews.set(previewToken, { preview, expectedWordsByClip, analysisRangesByClip });
+    this.previews.set(previewToken, { preview, analysisRangesByClip });
     return structuredClone(preview);
   }
 
@@ -212,17 +210,33 @@ export class FillerRemovalService {
       if (!media) throw new Error(`MEDIA_NOT_FOUND: ${beforeClip.mediaId}`);
       const analysisRange = record.analysisRangesByClip.get(clipId);
       if (!analysisRange) throw new Error(`ANALYSIS_FAILED: filler analysis range for clip ${clipId} is unavailable`);
+      const fillerCandidates = record.preview.candidates.filter((candidate) => candidate.clipId === clipId);
+      const deletes = fillerCandidates.map((candidate) => candidate.sourceRange);
       const postEditRange = translateRangeAfterDeletes(
         analysisRange,
-        record.preview.candidates
-          .filter((candidate) => candidate.clipId === clipId)
-          .map((candidate) => candidate.sourceRange),
+        deletes,
       );
       const speech = await this.options.speechAnalyzer!.analyze(
         { project: next, media },
         postEditRange,
       );
-      media.speech = speech;
+      const retainedWords = transaction.before.media
+        .find((candidate) => candidate.mediaId === beforeClip.mediaId)
+        ?.speech?.words ?? [];
+      const translatedRetainedWords = retainedWords
+        .filter((word) => !fillerCandidates.some((candidate) => sameSpeechWord(word, candidate.word)))
+        .map((word) => translateSpeechWordAfterDeletes(word, deletes));
+      media.speech = {
+        words: [
+          ...translatedRetainedWords.filter((word) => !rangesOverlap(
+            word.start,
+            word.end,
+            postEditRange.start,
+            postEditRange.end,
+          )),
+          ...speech.words.filter((word) => word.start >= postEditRange.start && word.end <= postEditRange.end),
+        ].sort((left, right) => left.start - right.start || left.end - right.end),
+      };
       media.analysisRevision = next.revision.id;
     }
     return next;
@@ -242,7 +256,6 @@ export class FillerRemovalService {
 
 interface FillerRemovalPreviewRecord {
   preview: FillerRemovalPreview;
-  expectedWordsByClip: Map<string, SpeechWord[]>;
   analysisRangesByClip: Map<string, TimeRange>;
 }
 
@@ -284,33 +297,41 @@ function translateBoundaryAfterDeletes(boundary: number, deletes: TimeRange[]): 
   return translated;
 }
 
+function translateSpeechWordAfterDeletes(word: SpeechWord, deletes: TimeRange[]): SpeechWord {
+  return {
+    ...word,
+    start: translateBoundaryAfterDeletes(word.start, deletes),
+    end: translateBoundaryAfterDeletes(word.end, deletes),
+  };
+}
+
 function verifyFillerSpeechContinuity(
   transaction: EditTransaction,
   record: FillerRemovalPreviewRecord,
 ): VerificationCheck {
-  for (const [clipId, beforeWords] of record.expectedWordsByClip) {
+  const clipIds = new Set(record.preview.candidates.map((candidate) => candidate.clipId));
+  for (const clipId of clipIds) {
     const beforeClip = transaction.before.timeline.clips.find((clip) => clip.id === clipId);
     const afterClip = transaction.attemptedAfter.timeline.clips.find((clip) => clip.id === clipId);
     const mediaId = beforeClip?.mediaId;
+    const beforeWords = mediaId
+      ? transaction.before.media.find((media) => media.mediaId === mediaId)?.speech?.words
+      : undefined;
     const actualWords = mediaId
       ? transaction.attemptedAfter.media.find((media) => media.mediaId === mediaId)?.speech?.words
       : undefined;
-    if (!beforeClip || !afterClip || !actualWords) {
+    if (!beforeClip || !afterClip || !beforeWords || !actualWords) {
       return {
         name: "filler-speech-continuity",
         passed: false,
-        detail: `post-edit speech analysis is unavailable for filler target clip ${clipId}`,
+        detail: `complete pre- and post-edit speech analysis is unavailable for filler target clip ${clipId}`,
       };
     }
     const candidates = record.preview.candidates.filter((candidate) => candidate.clipId === clipId);
+    const deletes = candidates.map((candidate) => candidate.sourceRange);
     const expectedWords = beforeWords
       .filter((word) => !candidates.some((candidate) => sameSpeechWord(candidate.word, word)))
-      .map((word) => {
-        const removedBefore = candidates
-          .filter((candidate) => candidate.sourceRange.end <= word.start)
-          .reduce((total, candidate) => total + (candidate.sourceRange.end - candidate.sourceRange.start), 0);
-        return { ...word, start: word.start - removedBefore, end: word.end - removedBefore };
-      });
+      .map((word) => translateSpeechWordAfterDeletes(word, deletes));
     if (expectedWords.length !== actualWords.length) {
       return {
         name: "filler-speech-continuity",

--- a/packages/runtime/src/editing/filler-removal-service.ts
+++ b/packages/runtime/src/editing/filler-removal-service.ts
@@ -39,6 +39,7 @@ export class FillerRemovalService {
     const selectedRange = validateFillerSelection(request.range);
     const candidates: FillerRemovalTarget[] = [];
     const expectedWordsByClip = new Map<string, SpeechWord[]>();
+    const analysisRangesByClip = new Map<string, TimeRange>();
     const selectedClips = before.timeline.clips.filter((clip) =>
       clip.mediaId && rangesOverlap(clip.start, clip.start + clip.duration, selectedRange.start, selectedRange.end),
     );
@@ -60,6 +61,7 @@ export class FillerRemovalService {
       if (localRange.end <= localRange.start) continue;
       const speech = await this.options.speechAnalyzer!.analyze({ project: before, media }, localRange);
       expectedWordsByClip.set(clip.id, structuredClone(speech.words));
+      analysisRangesByClip.set(clip.id, structuredClone(localRange));
       for (const candidate of planFillerRemoval(speech.words, localRange, request)) {
         candidates.push({
           ...candidate,
@@ -104,7 +106,7 @@ export class FillerRemovalService {
       if (oldestToken === undefined) break;
       this.previews.delete(oldestToken);
     }
-    this.previews.set(previewToken, { preview, expectedWordsByClip });
+    this.previews.set(previewToken, { preview, expectedWordsByClip, analysisRangesByClip });
     return structuredClone(preview);
   }
 
@@ -208,9 +210,17 @@ export class FillerRemovalService {
       }
       const media = next.media.find((candidate) => candidate.mediaId === beforeClip.mediaId);
       if (!media) throw new Error(`MEDIA_NOT_FOUND: ${beforeClip.mediaId}`);
+      const analysisRange = record.analysisRangesByClip.get(clipId);
+      if (!analysisRange) throw new Error(`ANALYSIS_FAILED: filler analysis range for clip ${clipId} is unavailable`);
+      const postEditRange = translateRangeAfterDeletes(
+        analysisRange,
+        record.preview.candidates
+          .filter((candidate) => candidate.clipId === clipId)
+          .map((candidate) => candidate.sourceRange),
+      );
       const speech = await this.options.speechAnalyzer!.analyze(
         { project: next, media },
-        { start: 0, end: afterClip.duration },
+        postEditRange,
       );
       media.speech = speech;
       media.analysisRevision = next.revision.id;
@@ -233,6 +243,7 @@ export class FillerRemovalService {
 interface FillerRemovalPreviewRecord {
   preview: FillerRemovalPreview;
   expectedWordsByClip: Map<string, SpeechWord[]>;
+  analysisRangesByClip: Map<string, TimeRange>;
 }
 
 function validateFillerSelection(range: TimeRange): TimeRange {
@@ -250,6 +261,27 @@ function validateFillerSelection(range: TimeRange): TimeRange {
 
 function rangesOverlap(leftStart: number, leftEnd: number, rightStart: number, rightEnd: number): boolean {
   return leftStart < rightEnd && leftEnd > rightStart;
+}
+
+function translateRangeAfterDeletes(range: TimeRange, deletes: TimeRange[]): TimeRange {
+  const orderedDeletes = [...deletes].sort((left, right) => left.start - right.start);
+  return {
+    start: translateBoundaryAfterDeletes(range.start, orderedDeletes),
+    end: translateBoundaryAfterDeletes(range.end, orderedDeletes),
+  };
+}
+
+function translateBoundaryAfterDeletes(boundary: number, deletes: TimeRange[]): number {
+  let translated = boundary;
+  let removed = 0;
+  for (const deletion of deletes) {
+    if (boundary <= deletion.start) break;
+    if (boundary < deletion.end) return deletion.start - removed;
+    const duration = deletion.end - deletion.start;
+    translated -= duration;
+    removed += duration;
+  }
+  return translated;
 }
 
 function verifyFillerSpeechContinuity(

--- a/tests/integration/filler-removal.test.ts
+++ b/tests/integration/filler-removal.test.ts
@@ -202,6 +202,11 @@ test("filler execution verifies a partial range in the middle of a longer clip",
   assert.equal(transaction.status, "VERIFIED");
   assert.equal(transaction.verification?.checks.some((check) => check.name === "filler-speech-continuity" && check.passed), true);
   assert.ok(Math.abs((transaction.after.timeline.clips[0]?.duration ?? 0) - 4.3) < 0.000001);
+  assert.deepEqual(transaction.after.media[0]?.speech?.words.map(({ text, start, end }) => ({ text, start, end })), [
+    { text: "before", start: 0.2, end: 0.5 },
+    { text: "what", start: 1.9, end: 2.3 },
+    { text: "after", start: 3.5, end: 3.8 },
+  ]);
   assert.equal(calls, 2);
 });
 

--- a/tests/integration/filler-removal.test.ts
+++ b/tests/integration/filler-removal.test.ts
@@ -155,6 +155,56 @@ test("filler execution reanalyzes continuity and returns a reversible verified t
   assert.equal(restored.timeline.clips[0]?.duration, 3);
 });
 
+test("filler execution verifies a partial range in the middle of a longer clip", async () => {
+  let calls = 0;
+  const beforeWords = [
+    { text: "before", start: 0.2, end: 0.5, confidence: 0.99 },
+    { text: "um", start: 1.4, end: 1.7, confidence: 0.98, filler: true },
+    { text: "what", start: 2.6, end: 3, confidence: 0.99 },
+    { text: "after", start: 4.2, end: 4.5, confidence: 0.99 },
+  ];
+  const analyzer: SpeechAnalyzer = {
+    analyze: async ({ project, media }, range) => {
+      calls += 1;
+      const words = calls === 1
+        ? beforeWords
+        : [
+          beforeWords[0]!,
+          { ...beforeWords[2]!, start: 1.9, end: 2.3 },
+          { ...beforeWords[3]!, start: 3.5, end: 3.8 },
+        ];
+      return {
+        words: words.filter((word) => !range || (word.start >= range.start && word.end <= range.end)),
+      };
+    },
+  };
+  const adapter = new InMemoryEditorAdapter({
+    projectId: "project-filler-partial",
+    projectName: "Partial Filler Fixture",
+    timelineId: "timeline-filler-partial",
+    timelineName: "Main Edit",
+    clips: [{ id: "clip-filler-partial", mediaId: "media-filler-partial", name: "Interview", start: 10, duration: 5, track: 0 }],
+    media: [{
+      mediaId: "media-filler-partial",
+      source: "interview-partial.wav",
+      speech: { words: beforeWords },
+    }],
+  });
+  const runtime = new AgentVideoRuntime(adapter, { speechAnalyzer: analyzer });
+  const before = await runtime.inspectProject();
+  const preview = await runtime.previewFillerRemoval({
+    baseRevision: before.revision,
+    range: { start: 11, end: 14 },
+  });
+
+  const transaction = await runtime.executeFillerRemoval(preview.previewToken);
+
+  assert.equal(transaction.status, "VERIFIED");
+  assert.equal(transaction.verification?.checks.some((check) => check.name === "filler-speech-continuity" && check.passed), true);
+  assert.ok(Math.abs((transaction.after.timeline.clips[0]?.duration ?? 0) - 4.3) < 0.000001);
+  assert.equal(calls, 2);
+});
+
 test("failed filler continuity verification restores the original timeline", async () => {
   const analyzer: SpeechAnalyzer = { analyze: async ({ media }) => structuredClone(media.speech!) };
   const { runtime } = createFillerRuntime(analyzer);


### PR DESCRIPTION
<!-- Title naming policy -->
<!-- `feat:`, `fix:`, `perf:`, `design:`, `chore:` -->

- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Refs #69

## Summary

Follow-up to PR #78 addressing two filler-removal continuity findings:

- Preserve the selected clip-local analysis range after ripple deletes so valid partial-range edits are not rolled back.
- Merge range-limited post-edit speech analysis with the retained transcript, translating words after deletes so speech outside the edited range is preserved.

Regression coverage removes a filler from the middle of a longer clip and verifies the complete transcript, including shifted trailing timings.

## Validation

```bash
pnpm install --frozen-lockfile
pnpm run build
pnpm exec tsx --test --test-concurrency=1 tests/integration/*.test.ts tests/evaluation/*.test.ts tests/filler-removal/*.test.ts tests/golden/*.test.ts
pnpm run check:boundaries
pnpm run xcode:check
xcodebuild -project adapters/final-cut/swift-bridge/FinalCutWorkflowExtension/FramekitFinalCutWorkflow.xcodeproj -list
```

The serialized full suite passed 381 tests. The focused filler-removal suite passed all 14 tests after the fixes.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [ ] Public MCP behavior or package interfaces are documented if changed.
- [x] Existing adapters and test fixtures remain compatible, or the migration is explained above.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [ ] Documentation reflects any changed commands, paths, or environment variables.
