### PR TITLE
feat: add deterministic filler safe cuts

### DIFF
--- a/docs/architecture/filler-detection-safe-cuts.md
+++ b/docs/architecture/filler-detection-safe-cuts.md
@@ -27,23 +27,23 @@ evidence with `eligible: false`; this allows a later resolver to return a
 `SUGGESTED` decision without permitting automatic application.
 
 Candidate IDs are deterministic hashes of the preview ID, optional analysis
-revision, occurrence identity, word index, and source range. Repeating the same
-preview input produces the same ID; a different preview produces a different
-scope.
+revision, occurrence identity, and source range. Repeating the same candidate
+in an expanded or narrowed analysis window preserves its ID; a different
+preview produces a different scope.
 
 ## Safe-cut policy
 
 The resolver requires valid VAD evidence covering the candidate word. It rejects
-overlapping speech, malformed VAD ranges, ambiguous source-to-sequence mappings,
-and protected breath or laughter evidence. A following silence segment may be
-trimmed only when it exceeds the configured preserved pause; the resolver never
-selects arbitrary silence without evidence.
+overlapping speech, malformed VAD, silence, or protected ranges, ambiguous
+source-to-sequence mappings, and protected breath or laughter evidence. A
+following silence segment may be trimmed only when it exceeds the configured
+preserved pause; the resolver never selects arbitrary silence without evidence.
 
 The candidate word is expanded to frame boundaries only through adjacent safe
 silence. Start boundaries are floored and end boundaries are ceiled using exact
-rational arithmetic. If either boundary would cross a target, occurrence,
-adjacent speech, protected segment, or frame-safe interval, the decision is
-`SKIPPED`.
+rational arithmetic, then clamped against neighboring speech VAD boundaries as
+well as transcript words. If either boundary would cross a target, occurrence,
+speech, protected segment, or frame-safe interval, the decision is `SKIPPED`.
 
 | Status | Meaning |
 | --- | --- |

--- a/docs/architecture/filler-detection-safe-cuts.md
+++ b/docs/architecture/filler-detection-safe-cuts.md
@@ -1,0 +1,63 @@
+# Deterministic Filler Detection and Safe Cuts
+
+Issue #42 adds two editor-independent runtime components for the speech editing
+loop. `FillerDetector` identifies semantic candidates; `SafeCutResolver` decides
+whether a candidate can become a physical timeline range. Neither component
+mutates a project or calls an editor adapter.
+
+## Coordinate contract
+
+`FillerOccurrence.sourceRange` and `sequenceRange` describe the same-duration
+window in source-media and sequence coordinates. Detector word timestamps are
+source-relative. The detector maps each candidate into sequence coordinates using
+the occurrence offset and rejects unequal-duration or otherwise inconsistent
+mappings.
+
+`SafeCutRequest.targetRange` is in sequence coordinates. The candidate's
+`sequenceRange` must remain fully inside both this target and the occurrence's
+sequence range. The resulting `TimeRange` includes exact rational
+`startTime` and `durationTime` values for the sequence frame grid.
+
+## Candidate policy
+
+The detector uses an analyzer's `word.filler` metadata or an exact normalized
+vocabulary match. Punctuation at the end of a word is ignored for vocabulary
+matching. Candidates below the configured confidence threshold are retained as
+evidence with `eligible: false`; this allows a later resolver to return a
+`SUGGESTED` decision without permitting automatic application.
+
+Candidate IDs are deterministic hashes of the preview ID, optional analysis
+revision, occurrence identity, word index, and source range. Repeating the same
+preview input produces the same ID; a different preview produces a different
+scope.
+
+## Safe-cut policy
+
+The resolver requires valid VAD evidence covering the candidate word. It rejects
+overlapping speech, malformed VAD ranges, ambiguous source-to-sequence mappings,
+and protected breath or laughter evidence. A following silence segment may be
+trimmed only when it exceeds the configured preserved pause; the resolver never
+selects arbitrary silence without evidence.
+
+The candidate word is expanded to frame boundaries only through adjacent safe
+silence. Start boundaries are floored and end boundaries are ceiled using exact
+rational arithmetic. If either boundary would cross a target, occurrence,
+adjacent speech, protected segment, or frame-safe interval, the decision is
+`SKIPPED`.
+
+| Status | Meaning |
+| --- | --- |
+| `AUTO_APPLY` | Evidence and confidence authorize a safe operation. |
+| `SUGGESTED` | The range is safe, but confidence requires review. |
+| `SKIPPED` | Evidence or boundaries are insufficient; no operation is returned. |
+
+Every decision carries `evidence` and structured `reasonCodes`. Successful
+decisions return an editor-independent `ripple-delete` operation for a caller to
+preview and apply through its own transaction and capability policy.
+
+## Fixture boundary
+
+`FixtureSpeechAnalyzer` preserves and range-filters words, VAD, silence, and
+protected segments so deterministic tests can exercise the same contract. Fixture
+results are test evidence only and do not imply Final Cut capability or live
+timeline state.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "build:package": "tsc -p tsconfig.package.json && tsc-alias -p tsconfig.package.json",
-    "test": "tsx --test tests/integration/*.test.ts tests/evaluation/*.test.ts tests/filler-removal/*.test.ts tests/golden/*.test.ts",
+    "test": "tsx --test tests/integration/*.test.ts tests/evaluation/*.test.ts tests/filler-removal/*.test.ts tests/speech/*.test.ts tests/golden/*.test.ts",
     "test:filler-removal": "tsx --test tests/filler-removal/*.test.ts",
     "benchmark:filler-removal": "tsx scripts/run-filler-removal-benchmark.ts",
     "test:golden": "tsx --test tests/golden/*.test.ts",

--- a/packages/runtime/src/domain/media.ts
+++ b/packages/runtime/src/domain/media.ts
@@ -12,6 +12,15 @@ export interface SpeechWord {
   filler?: boolean;
 }
 
+export type SpeechSegmentKind = "speech" | "silence" | "breath" | "laughter" | "noise";
+
+export interface SpeechSegment {
+  start: number;
+  end: number;
+  kind: SpeechSegmentKind;
+  confidence?: number;
+}
+
 export type MediaAnalysisCapability = "metadata" | "speech" | "audio" | "visual";
 
 export interface SemanticTag {
@@ -126,6 +135,9 @@ export interface RoughCutPlan {
 
 export interface SpeechAnalysis {
   words: SpeechWord[];
+  vadSegments?: SpeechSegment[];
+  silenceSegments?: SpeechSegment[];
+  protectedSegments?: SpeechSegment[];
 }
 
 export interface AudioAnalysis {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -7,3 +7,4 @@ export * from "./editing/duration-policy.js";
 export * from "./capabilities.js";
 export * from "./timeline/snapshot-digest.js";
 export * from "./speech/filler-removal.js";
+export * from "./speech/filler-detector.js";

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -8,3 +8,4 @@ export * from "./capabilities.js";
 export * from "./timeline/snapshot-digest.js";
 export * from "./speech/filler-removal.js";
 export * from "./speech/filler-detector.js";
+export * from "./speech/safe-cut-resolver.js";

--- a/packages/runtime/src/speech/filler-detector.ts
+++ b/packages/runtime/src/speech/filler-detector.ts
@@ -78,7 +78,7 @@ export class FillerDetector {
       throw new Error("AMBIGUOUS_MAPPING: source and sequence occurrence durations differ");
     }
 
-    return words.flatMap((word, index) => {
+    return words.flatMap((word) => {
       const analyzerMarkedFiller = word.filler === true;
       const vocabularyMatch = this.vocabulary.has(normalizeWord(word.text));
       if (!analyzerMarkedFiller && !vocabularyMatch) return [];
@@ -98,7 +98,7 @@ export class FillerDetector {
       if (!eligible) reasonCodes.push("BELOW_CONFIDENCE_THRESHOLD");
       const sourceRange = { start: word.start, end: word.end };
       const candidate: FillerCandidate = {
-        id: stableCandidateId(input, index, sourceRange),
+        id: stableCandidateId(input, sourceRange),
         word: { ...word },
         wordEvidence: { ...word },
         confidence: word.confidence,
@@ -171,7 +171,6 @@ function normalizeWord(text: string): string {
 
 function stableCandidateId(
   input: FillerDetectionInput,
-  wordIndex: number,
   sourceRange: TimeRange,
 ): string {
   const identity = JSON.stringify({
@@ -179,7 +178,6 @@ function stableCandidateId(
     revisionId: input.revisionId ?? "",
     occurrenceId: input.occurrence.occurrenceId,
     mediaId: input.occurrence.mediaId ?? "",
-    wordIndex,
     sourceRange,
   });
   return `filler-candidate-${createHash("sha256").update(identity).digest("hex").slice(0, 24)}`;

--- a/packages/runtime/src/speech/filler-detector.ts
+++ b/packages/runtime/src/speech/filler-detector.ts
@@ -4,6 +4,7 @@ import type { TimeRange } from "../domain/primitives.js";
 
 export const DEFAULT_FILLER_VOCABULARY = ["er", "erm", "hmm", "uh", "um"] as const;
 export const DEFAULT_FILLER_CONFIDENCE_THRESHOLD = 0.92;
+const TRAILING_PUNCTUATION = ".,!?;:";
 
 export type FillerReasonCode =
   | "ANALYZER_MARKED_FILLER"
@@ -166,7 +167,12 @@ function containsRange(container: TimeRange, candidate: TimeRange): boolean {
 }
 
 function normalizeWord(text: string): string {
-  return text.trim().toLocaleLowerCase().replace(/[.,!?;:]+$/u, "");
+  const normalized = text.trim().toLocaleLowerCase();
+  let end = normalized.length;
+  while (end > 0 && TRAILING_PUNCTUATION.includes(normalized.charAt(end - 1))) {
+    end -= 1;
+  }
+  return normalized.slice(0, end);
 }
 
 function stableCandidateId(

--- a/packages/runtime/src/speech/filler-detector.ts
+++ b/packages/runtime/src/speech/filler-detector.ts
@@ -1,0 +1,186 @@
+import { createHash } from "node:crypto";
+import type { SpeechAnalysis, SpeechWord } from "../domain/media.js";
+import type { TimeRange } from "../domain/primitives.js";
+
+export const DEFAULT_FILLER_VOCABULARY = ["er", "erm", "hmm", "uh", "um"] as const;
+export const DEFAULT_FILLER_CONFIDENCE_THRESHOLD = 0.92;
+
+export type FillerReasonCode =
+  | "ANALYZER_MARKED_FILLER"
+  | "VOCABULARY_MATCH"
+  | "BELOW_CONFIDENCE_THRESHOLD";
+
+export interface FillerOccurrence {
+  occurrenceId: string;
+  mediaId?: string;
+  sourceRange: TimeRange;
+  sequenceRange: TimeRange;
+}
+
+export interface FillerDetectionInput {
+  previewId: string;
+  analysis: SpeechAnalysis;
+  targetRange: TimeRange;
+  occurrence: FillerOccurrence;
+  revisionId?: string;
+}
+
+export interface FillerDetectorOptions {
+  vocabulary?: readonly string[];
+  confidenceThreshold?: number;
+}
+
+export interface FillerCandidateEvidence {
+  word: SpeechWord;
+  analyzerMarkedFiller: boolean;
+  vocabularyMatch: boolean;
+  withinTarget: boolean;
+}
+
+export interface FillerCandidate {
+  id: string;
+  word: SpeechWord;
+  wordEvidence: SpeechWord;
+  confidence: number;
+  confidenceThreshold: number;
+  eligible: boolean;
+  occurrenceId: string;
+  mediaId?: string;
+  sourceRange: TimeRange;
+  sequenceRange: TimeRange;
+  reasonCodes: FillerReasonCode[];
+  evidence: FillerCandidateEvidence;
+}
+
+/** Turn analyzer speech evidence into deterministic, preview-scoped candidates. */
+export class FillerDetector {
+  private readonly vocabulary: ReadonlySet<string>;
+  private readonly confidenceThreshold: number;
+
+  public constructor(options: FillerDetectorOptions = {}) {
+    this.vocabulary = new Set((options.vocabulary ?? DEFAULT_FILLER_VOCABULARY).map(normalizeWord));
+    this.confidenceThreshold = options.confidenceThreshold ?? DEFAULT_FILLER_CONFIDENCE_THRESHOLD;
+    if (!Number.isFinite(this.confidenceThreshold)
+      || this.confidenceThreshold < 0
+      || this.confidenceThreshold > 1) {
+      throw new Error("INVALID_OPERATION: filler confidence threshold must be between 0 and 1");
+    }
+  }
+
+  public detect(input: FillerDetectionInput): FillerCandidate[] {
+    validateInput(input);
+    const words = orderAndValidateWords(input.analysis.words);
+    const source = input.occurrence.sourceRange;
+    const sequence = input.occurrence.sequenceRange;
+    const sourceDuration = source.end - source.start;
+    const sequenceDuration = sequence.end - sequence.start;
+    if (Math.abs(sourceDuration - sequenceDuration) > 0.000001) {
+      throw new Error("AMBIGUOUS_MAPPING: source and sequence occurrence durations differ");
+    }
+
+    return words.flatMap((word, index) => {
+      const analyzerMarkedFiller = word.filler === true;
+      const vocabularyMatch = this.vocabulary.has(normalizeWord(word.text));
+      if (!analyzerMarkedFiller && !vocabularyMatch) return [];
+      if (word.start < source.start || word.end > source.end) return [];
+
+      const sequenceRange = {
+        start: sequence.start + (word.start - source.start),
+        end: sequence.start + (word.end - source.start),
+      };
+      const withinTarget = containsRange(input.targetRange, sequenceRange);
+      if (!withinTarget) return [];
+
+      const eligible = word.confidence >= this.confidenceThreshold;
+      const reasonCodes: FillerReasonCode[] = [];
+      if (analyzerMarkedFiller) reasonCodes.push("ANALYZER_MARKED_FILLER");
+      if (vocabularyMatch) reasonCodes.push("VOCABULARY_MATCH");
+      if (!eligible) reasonCodes.push("BELOW_CONFIDENCE_THRESHOLD");
+      const sourceRange = { start: word.start, end: word.end };
+      const candidate: FillerCandidate = {
+        id: stableCandidateId(input, index, sourceRange),
+        word: { ...word },
+        wordEvidence: { ...word },
+        confidence: word.confidence,
+        confidenceThreshold: this.confidenceThreshold,
+        eligible,
+        occurrenceId: input.occurrence.occurrenceId,
+        ...(input.occurrence.mediaId ? { mediaId: input.occurrence.mediaId } : {}),
+        sourceRange,
+        sequenceRange,
+        reasonCodes,
+        evidence: {
+          word: { ...word },
+          analyzerMarkedFiller,
+          vocabularyMatch,
+          withinTarget,
+        },
+      };
+      return [candidate];
+    });
+  }
+}
+
+function validateInput(input: FillerDetectionInput): void {
+  if (!input.previewId.trim()) throw new Error("INVALID_OPERATION: filler preview ID is required");
+  validateRange(input.targetRange, "target range");
+  validateRange(input.occurrence.sourceRange, "source occurrence range");
+  validateRange(input.occurrence.sequenceRange, "sequence occurrence range");
+  if (!input.occurrence.occurrenceId.trim()) {
+    throw new Error("INVALID_OPERATION: filler occurrence ID is required");
+  }
+}
+
+function orderAndValidateWords(words: SpeechWord[]): SpeechWord[] {
+  const ordered = words
+    .map((word) => ({ ...word }))
+    .sort((left, right) => left.start - right.start || left.end - right.end || left.text.localeCompare(right.text));
+  for (let index = 0; index < ordered.length; index += 1) {
+    const word = ordered[index]!;
+    if (!word.text.trim()
+      || !Number.isFinite(word.start)
+      || !Number.isFinite(word.end)
+      || word.start < 0
+      || word.end <= word.start
+      || !Number.isFinite(word.confidence)
+      || word.confidence < 0
+      || word.confidence > 1) {
+      throw new Error("ANALYSIS_INVALID: speech word boundaries or confidence");
+    }
+    const previous = ordered[index - 1];
+    if (previous && previous.end > word.start) {
+      throw new Error("ANALYSIS_INVALID: speech word boundaries overlap");
+    }
+  }
+  return ordered;
+}
+
+function validateRange(range: TimeRange, label: string): void {
+  if (!Number.isFinite(range.start) || !Number.isFinite(range.end) || range.end <= range.start) {
+    throw new Error(`INVALID_OPERATION: filler ${label} must be positive`);
+  }
+}
+
+function containsRange(container: TimeRange, candidate: TimeRange): boolean {
+  return candidate.start >= container.start && candidate.end <= container.end;
+}
+
+function normalizeWord(text: string): string {
+  return text.trim().toLocaleLowerCase().replace(/[.,!?;:]+$/u, "");
+}
+
+function stableCandidateId(
+  input: FillerDetectionInput,
+  wordIndex: number,
+  sourceRange: TimeRange,
+): string {
+  const identity = JSON.stringify({
+    previewId: input.previewId,
+    revisionId: input.revisionId ?? "",
+    occurrenceId: input.occurrence.occurrenceId,
+    mediaId: input.occurrence.mediaId ?? "",
+    wordIndex,
+    sourceRange,
+  });
+  return `filler-candidate-${createHash("sha256").update(identity).digest("hex").slice(0, 24)}`;
+}

--- a/packages/runtime/src/speech/safe-cut-resolver.ts
+++ b/packages/runtime/src/speech/safe-cut-resolver.ts
@@ -177,15 +177,21 @@ export class SafeCutResolver {
     const minimumSourceStart = previousWord
       ? Math.max(previousWord.end, request.occurrence.sourceRange.start)
       : request.occurrence.sourceRange.start;
+    const precedingSpeechEnd = evidence.speechSegments
+      .filter((segment) => segment.end <= word.start)
+      .reduce((latest, segment) => Math.max(latest, segment.end), minimumSourceStart);
+    const followingSpeechStart = evidence.speechSegments
+      .filter((segment) => segment.start >= sourceEnd)
+      .reduce((earliest, segment) => Math.min(earliest, segment.start), nextStart);
     const sequenceStart = mapSourceToSequence(sourceStart, request.occurrence);
     const sequenceEnd = mapSourceToSequence(sourceEnd, request.occurrence);
     const minimumSequenceStart = Math.max(
-      mapSourceToSequence(minimumSourceStart, request.occurrence),
+      mapSourceToSequence(Math.max(minimumSourceStart, precedingSpeechEnd), request.occurrence),
       request.targetRange.start,
       request.occurrence.sequenceRange.start,
     );
     const maximumSequenceEnd = Math.min(
-      mapSourceToSequence(nextStart, request.occurrence),
+      mapSourceToSequence(Math.min(nextStart, followingSpeechStart), request.occurrence),
       request.targetRange.end,
       request.occurrence.sequenceRange.end,
     );

--- a/packages/runtime/src/speech/safe-cut-resolver.ts
+++ b/packages/runtime/src/speech/safe-cut-resolver.ts
@@ -129,7 +129,7 @@ export class SafeCutResolver {
       return { ...base, status: "SKIPPED", reasonCodes: ["INVALID_VAD_EVIDENCE"] };
     }
     evidence.speechSegments = vadSegments.filter((segment) => segment.kind === "speech");
-    if (hasOverlappingSpeech(vadSegments) || hasOverlappingWords(words)) {
+    if (hasOverlappingSpeech(vadSegments)) {
       return { ...base, status: "SKIPPED", reasonCodes: ["OVERLAPPING_SPEECH"] };
     }
     if (hasOverlappingSegments(vadSegments)) {

--- a/packages/runtime/src/speech/safe-cut-resolver.ts
+++ b/packages/runtime/src/speech/safe-cut-resolver.ts
@@ -130,14 +130,16 @@ export class SafeCutResolver {
     if (hasOverlappingSpeech(vadSegments) || hasOverlappingWords(words)) {
       return { ...base, status: "SKIPPED", reasonCodes: ["OVERLAPPING_SPEECH"] };
     }
+    if (hasOverlappingSegments(vadSegments)) {
+      return { ...base, status: "SKIPPED", reasonCodes: ["INVALID_VAD_EVIDENCE"] };
+    }
     if (!coversRange(evidence.speechSegments, request.candidate.sourceRange)) {
       return { ...base, status: "SKIPPED", reasonCodes: ["MISSING_VAD_EVIDENCE"] };
     }
 
-    const silenceSegments = validateSegments([
-      ...(request.analysis.silenceSegments ?? []),
-      ...vadSegments.filter((segment) => segment.kind === "silence"),
-    ]);
+    const silenceSegments = validateSegments(
+      request.analysis.silenceSegments ?? vadSegments.filter((segment) => segment.kind === "silence"),
+    );
     if (!silenceSegments) {
       return { ...base, status: "SKIPPED", reasonCodes: ["INVALID_VAD_EVIDENCE"] };
     }
@@ -197,6 +199,16 @@ export class SafeCutResolver {
       return { ...base, status: "SKIPPED", reasonCodes: ["NO_FRAME_ALIGNED_RANGE"] };
     }
 
+    const alignedSourceRange = {
+      start: request.occurrence.sourceRange.start
+        + (safeStart - request.occurrence.sequenceRange.start),
+      end: request.occurrence.sourceRange.start
+        + (safeEnd - request.occurrence.sequenceRange.start),
+    };
+    if (overlapsAny(protectedSegments, alignedSourceRange)) {
+      return { ...base, status: "SKIPPED", reasonCodes: ["PROTECTED_SEGMENT_OVERLAP"] };
+    }
+
     const range = rangeFromRationals(alignedStart, subtractRationals(alignedEnd, alignedStart));
     evidence.safeRange = structuredClone(range);
     initialReasons.push("SAFE_BOUNDARY_RESOLVED");
@@ -242,7 +254,8 @@ function createEvidence(request: SafeCutRequest): SafeCutEvidence {
 function validateSegments(segments: SpeechSegment[] | undefined): SpeechSegment[] | undefined {
   if (!segments) return undefined;
   const ordered = segments.map((segment) => ({ ...segment })).sort((left, right) => left.start - right.start || left.end - right.end);
-  for (const segment of ordered) {
+  for (let index = 0; index < ordered.length; index += 1) {
+    const segment = ordered[index]!;
     if (!Number.isFinite(segment.start)
       || !Number.isFinite(segment.end)
       || segment.start < 0
@@ -266,6 +279,10 @@ function hasOverlappingWords(words: SpeechWord[]): boolean {
 function hasOverlappingSpeech(segments: SpeechSegment[]): boolean {
   const speech = segments.filter((segment) => segment.kind === "speech");
   return speech.some((segment, index) => index > 0 && speech[index - 1]!.end > segment.start);
+}
+
+function hasOverlappingSegments(segments: SpeechSegment[]): boolean {
+  return segments.some((segment, index) => index > 0 && segments[index - 1]!.end > segment.start);
 }
 
 function coversRange(segments: SpeechSegment[], range: TimeRange): boolean {

--- a/packages/runtime/src/speech/safe-cut-resolver.ts
+++ b/packages/runtime/src/speech/safe-cut-resolver.ts
@@ -162,6 +162,9 @@ export class SafeCutResolver {
       }
     }
     evidence.pauseAfterCutMs = Math.max(0, (nextStart - sourceEnd) * 1000);
+    if (overlapsAny(protectedSegments, { start: word.start, end: sourceEnd })) {
+      return { ...base, status: "SKIPPED", reasonCodes: ["PROTECTED_SEGMENT_OVERLAP"] };
+    }
 
     const sourceStart = word.start;
     const minimumSourceStart = previousWord
@@ -169,38 +172,30 @@ export class SafeCutResolver {
       : request.occurrence.sourceRange.start;
     const sequenceStart = mapSourceToSequence(sourceStart, request.occurrence);
     const sequenceEnd = mapSourceToSequence(sourceEnd, request.occurrence);
-    const boundedStart = Math.max(sequenceStart, request.targetRange.start, request.occurrence.sequenceRange.start);
-    const boundedEnd = Math.min(sequenceEnd, request.targetRange.end, request.occurrence.sequenceRange.end);
-    const alignedStart = floorMultiple(decimalToRational(boundedStart), frame);
-    const alignedEnd = ceilMultiple(decimalToRational(boundedEnd), frame);
+    const minimumSequenceStart = Math.max(
+      mapSourceToSequence(minimumSourceStart, request.occurrence),
+      request.targetRange.start,
+      request.occurrence.sequenceRange.start,
+    );
+    const maximumSequenceEnd = Math.min(
+      mapSourceToSequence(nextStart, request.occurrence),
+      request.targetRange.end,
+      request.occurrence.sequenceRange.end,
+    );
+    const alignedStart = floorMultiple(decimalToRational(sequenceStart), frame);
+    const alignedEnd = ceilMultiple(decimalToRational(sequenceEnd), frame);
     const safeStart = rationalToNumber(alignedStart);
     const safeEnd = rationalToNumber(alignedEnd);
     if (!Number.isFinite(safeStart)
       || !Number.isFinite(safeEnd)
-      || safeStart < boundedStart - 0.000000001
-      || safeEnd > boundedEnd + 0.000000001
       || safeEnd <= safeStart
-      || safeStart < mapSourceToSequence(minimumSourceStart, request.occurrence)
-      || safeStart < request.targetRange.start
-      || safeEnd > request.targetRange.end
-      || safeStart < request.occurrence.sequenceRange.start
-      || safeEnd > request.occurrence.sequenceRange.end
-      || safeEnd > mapSourceToSequence(nextStart, request.occurrence) + 0.000000001
-      || overlapsAny(protectedSegments, {
-        start: sourceStart,
-        end: sourceEnd,
-      })) {
+      || safeStart < minimumSequenceStart - 0.000000001
+      || safeEnd > maximumSequenceEnd + 0.000000001) {
       return { ...base, status: "SKIPPED", reasonCodes: ["NO_FRAME_ALIGNED_RANGE"] };
     }
 
     const range = rangeFromRationals(alignedStart, subtractRationals(alignedEnd, alignedStart));
     evidence.safeRange = structuredClone(range);
-    if (overlapsAny(protectedSegments, {
-      start: sourceStart,
-      end: sourceEnd,
-    })) {
-      return { ...base, status: "SKIPPED", reasonCodes: ["PROTECTED_SEGMENT_OVERLAP"] };
-    }
     initialReasons.push("SAFE_BOUNDARY_RESOLVED");
     if (pauseReason) initialReasons.push("PAUSE_PRESERVED");
     if (!request.candidate.eligible || request.candidate.confidence < request.candidate.confidenceThreshold) {

--- a/packages/runtime/src/speech/safe-cut-resolver.ts
+++ b/packages/runtime/src/speech/safe-cut-resolver.ts
@@ -119,9 +119,12 @@ export class SafeCutResolver {
     if (previousWord) evidence.previousWord = { ...previousWord };
     if (nextWord) evidence.nextWord = { ...nextWord };
 
+    if (!request.analysis.vadSegments) {
+      return { ...base, status: "SKIPPED", reasonCodes: ["MISSING_VAD_EVIDENCE"] };
+    }
     const vadSegments = validateSegments(request.analysis.vadSegments);
     if (!vadSegments) {
-      return { ...base, status: "SKIPPED", reasonCodes: ["MISSING_VAD_EVIDENCE"] };
+      return { ...base, status: "SKIPPED", reasonCodes: ["INVALID_VAD_EVIDENCE"] };
     }
     evidence.speechSegments = vadSegments.filter((segment) => segment.kind === "speech");
     if (hasOverlappingSpeech(vadSegments) || hasOverlappingWords(words)) {
@@ -240,7 +243,11 @@ function validateSegments(segments: SpeechSegment[] | undefined): SpeechSegment[
   if (!segments) return undefined;
   const ordered = segments.map((segment) => ({ ...segment })).sort((left, right) => left.start - right.start || left.end - right.end);
   for (const segment of ordered) {
-    if (!Number.isFinite(segment.start) || !Number.isFinite(segment.end) || segment.start < 0 || segment.end <= segment.start) {
+    if (!Number.isFinite(segment.start)
+      || !Number.isFinite(segment.end)
+      || segment.start < 0
+      || segment.end <= segment.start
+      || !["speech", "silence", "breath", "laughter", "noise"].includes(segment.kind)) {
       return undefined;
     }
   }

--- a/packages/runtime/src/speech/safe-cut-resolver.ts
+++ b/packages/runtime/src/speech/safe-cut-resolver.ts
@@ -14,6 +14,8 @@ export type SafeCutReasonCode =
   | "LOW_CONFIDENCE"
   | "MISSING_VAD_EVIDENCE"
   | "INVALID_VAD_EVIDENCE"
+  | "INVALID_SILENCE_EVIDENCE"
+  | "INVALID_PROTECTED_EVIDENCE"
   | "AMBIGUOUS_MAPPING"
   | "OVERLAPPING_SPEECH"
   | "PROTECTED_SEGMENT_OVERLAP"
@@ -141,12 +143,12 @@ export class SafeCutResolver {
       request.analysis.silenceSegments ?? vadSegments.filter((segment) => segment.kind === "silence"),
     );
     if (!silenceSegments) {
-      return { ...base, status: "SKIPPED", reasonCodes: ["INVALID_VAD_EVIDENCE"] };
+      return { ...base, status: "SKIPPED", reasonCodes: ["INVALID_SILENCE_EVIDENCE"] };
     }
     evidence.silenceSegments = silenceSegments;
     const protectedSegments = validateSegments(request.analysis.protectedSegments ?? []);
     if (!protectedSegments) {
-      return { ...base, status: "SKIPPED", reasonCodes: ["INVALID_VAD_EVIDENCE"] };
+      return { ...base, status: "SKIPPED", reasonCodes: ["INVALID_PROTECTED_EVIDENCE"] };
     }
     evidence.protectedSegments = protectedSegments;
     if (overlapsAny(protectedSegments, request.candidate.sourceRange)) {

--- a/packages/runtime/src/speech/safe-cut-resolver.ts
+++ b/packages/runtime/src/speech/safe-cut-resolver.ts
@@ -1,0 +1,390 @@
+import type { SpeechAnalysis, SpeechSegment, SpeechWord } from "../domain/media.js";
+import type { EditOperation } from "../domain/editing.js";
+import type { RationalTime, TimeRange } from "../domain/primitives.js";
+import type { FillerCandidate, FillerOccurrence } from "./filler-detector.js";
+
+export const DEFAULT_SAFE_CUT_PRESERVE_PAUSE_MS = 700;
+export const DEFAULT_SAFE_CUT_TARGET_PAUSE_MS = 500;
+
+export type SafeCutStatus = "AUTO_APPLY" | "SUGGESTED" | "SKIPPED";
+
+export type SafeCutReasonCode =
+  | "SAFE_BOUNDARY_RESOLVED"
+  | "PAUSE_PRESERVED"
+  | "LOW_CONFIDENCE"
+  | "MISSING_VAD_EVIDENCE"
+  | "INVALID_VAD_EVIDENCE"
+  | "AMBIGUOUS_MAPPING"
+  | "OVERLAPPING_SPEECH"
+  | "PROTECTED_SEGMENT_OVERLAP"
+  | "OUTSIDE_TARGET_BOUND"
+  | "OUTSIDE_OCCURRENCE_BOUND"
+  | "NO_FRAME_ALIGNED_RANGE";
+
+export interface SafeCutResolverOptions {
+  preservePauseMs?: number;
+  targetPauseMs?: number;
+}
+
+export interface SafeCutRequest {
+  candidate: FillerCandidate;
+  analysis: SpeechAnalysis;
+  targetRange: TimeRange;
+  occurrence: FillerOccurrence;
+  timelineId: string;
+  sequenceFrameDuration: RationalTime;
+}
+
+export interface SafeCutEvidence {
+  word: SpeechWord;
+  previousWord?: SpeechWord;
+  nextWord?: SpeechWord;
+  speechSegments: SpeechSegment[];
+  silenceSegments: SpeechSegment[];
+  protectedSegments: SpeechSegment[];
+  occurrenceRange: TimeRange;
+  targetRange: TimeRange;
+  frameDuration: RationalTime;
+  pauseBeforeCutMs: number;
+  pauseAfterCutMs: number;
+  safeRange?: TimeRange;
+}
+
+export interface SafeCutDecision {
+  status: SafeCutStatus;
+  candidateId: string;
+  occurrenceId: string;
+  reasonCodes: SafeCutReasonCode[];
+  evidence: SafeCutEvidence;
+  range?: TimeRange;
+  operation?: Extract<EditOperation, { type: "ripple-delete" }>;
+}
+
+/** Resolve filler words to safe frame-aligned operations without mutating an editor. */
+export class SafeCutResolver {
+  private readonly preservePauseMs: number;
+  private readonly targetPauseMs: number;
+
+  public constructor(options: SafeCutResolverOptions = {}) {
+    this.preservePauseMs = options.preservePauseMs ?? DEFAULT_SAFE_CUT_PRESERVE_PAUSE_MS;
+    this.targetPauseMs = options.targetPauseMs ?? DEFAULT_SAFE_CUT_TARGET_PAUSE_MS;
+    if (!Number.isFinite(this.preservePauseMs)
+      || this.preservePauseMs < 0
+      || !Number.isFinite(this.targetPauseMs)
+      || this.targetPauseMs < 0
+      || this.targetPauseMs > this.preservePauseMs) {
+      throw new Error("INVALID_OPERATION: safe cut pause settings are invalid");
+    }
+  }
+
+  public resolve(request: SafeCutRequest): SafeCutDecision {
+    const evidence = createEvidence(request);
+    const base = {
+      candidateId: request.candidate.id,
+      occurrenceId: request.occurrence.occurrenceId,
+      evidence,
+    };
+    const initialReasons: SafeCutReasonCode[] = [];
+
+    if (request.candidate.occurrenceId !== request.occurrence.occurrenceId) {
+      return { ...base, status: "SKIPPED", reasonCodes: ["AMBIGUOUS_MAPPING"] };
+    }
+    if (!isContained(request.candidate.sequenceRange, request.targetRange)) {
+      return { ...base, status: "SKIPPED", reasonCodes: ["OUTSIDE_TARGET_BOUND"] };
+    }
+    if (!isContained(request.candidate.sequenceRange, request.occurrence.sequenceRange)) {
+      return { ...base, status: "SKIPPED", reasonCodes: ["OUTSIDE_OCCURRENCE_BOUND"] };
+    }
+    if (!isSequenceMappingConsistent(request.candidate, request.occurrence)) {
+      return { ...base, status: "SKIPPED", reasonCodes: ["AMBIGUOUS_MAPPING"] };
+    }
+
+    const frame = parseRational(request.sequenceFrameDuration);
+    if (!frame || frame.numerator <= 0n) {
+      return { ...base, status: "SKIPPED", reasonCodes: ["NO_FRAME_ALIGNED_RANGE"] };
+    }
+    const words = orderWords(request.analysis.words);
+    if (!words) {
+      return { ...base, status: "SKIPPED", reasonCodes: ["OVERLAPPING_SPEECH"] };
+    }
+    const wordMatches = words.filter((word) => sameWord(word, request.candidate.word));
+    if (wordMatches.length !== 1) {
+      return { ...base, status: "SKIPPED", reasonCodes: ["AMBIGUOUS_MAPPING"] };
+    }
+    const wordIndex = words.indexOf(wordMatches[0]!);
+    const word = wordMatches[0]!;
+    const previousWord = words[wordIndex - 1];
+    const nextWord = words[wordIndex + 1];
+    evidence.word = { ...word };
+    if (previousWord) evidence.previousWord = { ...previousWord };
+    if (nextWord) evidence.nextWord = { ...nextWord };
+
+    const vadSegments = validateSegments(request.analysis.vadSegments);
+    if (!vadSegments) {
+      return { ...base, status: "SKIPPED", reasonCodes: ["MISSING_VAD_EVIDENCE"] };
+    }
+    evidence.speechSegments = vadSegments.filter((segment) => segment.kind === "speech");
+    if (hasOverlappingSpeech(vadSegments) || hasOverlappingWords(words)) {
+      return { ...base, status: "SKIPPED", reasonCodes: ["OVERLAPPING_SPEECH"] };
+    }
+    if (!coversRange(evidence.speechSegments, request.candidate.sourceRange)) {
+      return { ...base, status: "SKIPPED", reasonCodes: ["MISSING_VAD_EVIDENCE"] };
+    }
+
+    const silenceSegments = validateSegments([
+      ...(request.analysis.silenceSegments ?? []),
+      ...vadSegments.filter((segment) => segment.kind === "silence"),
+    ]);
+    if (!silenceSegments) {
+      return { ...base, status: "SKIPPED", reasonCodes: ["INVALID_VAD_EVIDENCE"] };
+    }
+    evidence.silenceSegments = silenceSegments;
+    const protectedSegments = validateSegments(request.analysis.protectedSegments ?? []);
+    if (!protectedSegments) {
+      return { ...base, status: "SKIPPED", reasonCodes: ["INVALID_VAD_EVIDENCE"] };
+    }
+    evidence.protectedSegments = protectedSegments;
+    if (overlapsAny(protectedSegments, request.candidate.sourceRange)) {
+      return { ...base, status: "SKIPPED", reasonCodes: ["PROTECTED_SEGMENT_OVERLAP"] };
+    }
+
+    const nextStart = nextWord?.start ?? request.occurrence.sourceRange.end;
+    const followingPauseMs = Math.max(0, (nextStart - word.end) * 1000);
+    evidence.pauseBeforeCutMs = Math.max(0, (word.start - (previousWord?.end ?? word.start)) * 1000);
+    let sourceEnd = word.end;
+    let pauseReason = false;
+    if (followingPauseMs > this.preservePauseMs) {
+      const silenceEnd = silenceEndFor(silenceSegments, word.end, nextStart);
+      const desiredEnd = word.end + (followingPauseMs - this.targetPauseMs) / 1000;
+      if (silenceEnd !== undefined && silenceEnd >= desiredEnd) {
+        sourceEnd = Math.min(desiredEnd, nextStart);
+        pauseReason = true;
+      }
+    }
+    evidence.pauseAfterCutMs = Math.max(0, (nextStart - sourceEnd) * 1000);
+
+    const sourceStart = word.start;
+    const minimumSourceStart = previousWord
+      ? Math.max(previousWord.end, request.occurrence.sourceRange.start)
+      : request.occurrence.sourceRange.start;
+    const sequenceStart = mapSourceToSequence(sourceStart, request.occurrence);
+    const sequenceEnd = mapSourceToSequence(sourceEnd, request.occurrence);
+    const boundedStart = Math.max(sequenceStart, request.targetRange.start, request.occurrence.sequenceRange.start);
+    const boundedEnd = Math.min(sequenceEnd, request.targetRange.end, request.occurrence.sequenceRange.end);
+    const alignedStart = floorMultiple(decimalToRational(boundedStart), frame);
+    const alignedEnd = ceilMultiple(decimalToRational(boundedEnd), frame);
+    const safeStart = rationalToNumber(alignedStart);
+    const safeEnd = rationalToNumber(alignedEnd);
+    if (!Number.isFinite(safeStart)
+      || !Number.isFinite(safeEnd)
+      || safeStart < boundedStart - 0.000000001
+      || safeEnd > boundedEnd + 0.000000001
+      || safeEnd <= safeStart
+      || safeStart < mapSourceToSequence(minimumSourceStart, request.occurrence)
+      || safeStart < request.targetRange.start
+      || safeEnd > request.targetRange.end
+      || safeStart < request.occurrence.sequenceRange.start
+      || safeEnd > request.occurrence.sequenceRange.end
+      || safeEnd > mapSourceToSequence(nextStart, request.occurrence) + 0.000000001
+      || overlapsAny(protectedSegments, {
+        start: sourceStart,
+        end: sourceEnd,
+      })) {
+      return { ...base, status: "SKIPPED", reasonCodes: ["NO_FRAME_ALIGNED_RANGE"] };
+    }
+
+    const range = rangeFromRationals(alignedStart, subtractRationals(alignedEnd, alignedStart));
+    evidence.safeRange = structuredClone(range);
+    if (overlapsAny(protectedSegments, {
+      start: sourceStart,
+      end: sourceEnd,
+    })) {
+      return { ...base, status: "SKIPPED", reasonCodes: ["PROTECTED_SEGMENT_OVERLAP"] };
+    }
+    initialReasons.push("SAFE_BOUNDARY_RESOLVED");
+    if (pauseReason) initialReasons.push("PAUSE_PRESERVED");
+    if (!request.candidate.eligible || request.candidate.confidence < request.candidate.confidenceThreshold) {
+      initialReasons.push("LOW_CONFIDENCE");
+    }
+    const status: SafeCutStatus = initialReasons.includes("LOW_CONFIDENCE") ? "SUGGESTED" : "AUTO_APPLY";
+    return {
+      ...base,
+      status,
+      reasonCodes: initialReasons,
+      range,
+      operation: {
+        type: "ripple-delete",
+        timelineId: request.timelineId,
+        range: structuredClone(range),
+        reason: `remove filler candidate ${request.candidate.id}`,
+      },
+    };
+  }
+}
+
+interface RationalParts {
+  numerator: bigint;
+  denominator: bigint;
+}
+
+function createEvidence(request: SafeCutRequest): SafeCutEvidence {
+  return {
+    word: { ...request.candidate.word },
+    speechSegments: [],
+    silenceSegments: [],
+    protectedSegments: [],
+    occurrenceRange: structuredClone(request.occurrence.sequenceRange),
+    targetRange: structuredClone(request.targetRange),
+    frameDuration: structuredClone(request.sequenceFrameDuration),
+    pauseBeforeCutMs: 0,
+    pauseAfterCutMs: 0,
+  };
+}
+
+function validateSegments(segments: SpeechSegment[] | undefined): SpeechSegment[] | undefined {
+  if (!segments) return undefined;
+  const ordered = segments.map((segment) => ({ ...segment })).sort((left, right) => left.start - right.start || left.end - right.end);
+  for (const segment of ordered) {
+    if (!Number.isFinite(segment.start) || !Number.isFinite(segment.end) || segment.start < 0 || segment.end <= segment.start) {
+      return undefined;
+    }
+  }
+  return ordered;
+}
+
+function orderWords(words: SpeechWord[]): SpeechWord[] | undefined {
+  const ordered = words.map((word) => ({ ...word })).sort((left, right) => left.start - right.start || left.end - right.end);
+  return hasOverlappingWords(ordered) ? undefined : ordered;
+}
+
+function hasOverlappingWords(words: SpeechWord[]): boolean {
+  return words.some((word, index) => index > 0 && words[index - 1]!.end > word.start);
+}
+
+function hasOverlappingSpeech(segments: SpeechSegment[]): boolean {
+  const speech = segments.filter((segment) => segment.kind === "speech");
+  return speech.some((segment, index) => index > 0 && speech[index - 1]!.end > segment.start);
+}
+
+function coversRange(segments: SpeechSegment[], range: TimeRange): boolean {
+  return segments.some((segment) => segment.start <= range.start && segment.end >= range.end);
+}
+
+function overlapsAny(segments: SpeechSegment[], range: TimeRange): boolean {
+  return segments.some((segment) => segment.start < range.end && segment.end > range.start);
+}
+
+function silenceEndFor(segments: SpeechSegment[], start: number, end: number): number | undefined {
+  return segments
+    .filter((segment) => segment.kind === "silence" && segment.start <= start && segment.end >= end)
+    .map((segment) => segment.end)
+    .sort((left, right) => right - left)[0];
+}
+
+function sameWord(left: SpeechWord, right: SpeechWord): boolean {
+  return left.text === right.text && left.start === right.start && left.end === right.end;
+}
+
+function isContained(candidate: TimeRange, container: TimeRange): boolean {
+  return candidate.start >= container.start && candidate.end <= container.end;
+}
+
+function isSequenceMappingConsistent(candidate: FillerCandidate, occurrence: FillerOccurrence): boolean {
+  const expectedStart = mapSourceToSequence(candidate.sourceRange.start, occurrence);
+  const expectedEnd = mapSourceToSequence(candidate.sourceRange.end, occurrence);
+  return Math.abs(expectedStart - candidate.sequenceRange.start) <= 0.000001
+    && Math.abs(expectedEnd - candidate.sequenceRange.end) <= 0.000001;
+}
+
+function mapSourceToSequence(sourceTime: number, occurrence: FillerOccurrence): number {
+  return occurrence.sequenceRange.start + (sourceTime - occurrence.sourceRange.start);
+}
+
+function parseRational(time: RationalTime): RationalParts | undefined {
+  if (!/^-?\d+$/.test(time.value) || !/^\d+$/.test(time.timescale)) return undefined;
+  const denominator = BigInt(time.timescale);
+  if (denominator <= 0n) return undefined;
+  return normalizeRational({ numerator: BigInt(time.value), denominator });
+}
+
+function decimalToRational(value: number): RationalParts {
+  const text = value.toString();
+  if (/[eE]/u.test(text)) {
+    const [coefficient, exponentText] = text.split(/[eE]/u);
+    const exponent = Number(exponentText);
+    const coefficientParts = decimalToRational(Number(coefficient));
+    if (exponent >= 0) return normalizeRational({ numerator: coefficientParts.numerator * 10n ** BigInt(exponent), denominator: coefficientParts.denominator });
+    return normalizeRational({ numerator: coefficientParts.numerator, denominator: coefficientParts.denominator * 10n ** BigInt(-exponent) });
+  }
+  const [whole, fraction = ""] = text.split(".");
+  const sign = whole.startsWith("-") ? -1n : 1n;
+  const unsignedWhole = whole.replace(/^-/, "");
+  return normalizeRational({
+    numerator: sign * BigInt(`${unsignedWhole}${fraction}` || "0"),
+    denominator: 10n ** BigInt(fraction.length),
+  });
+}
+
+function normalizeRational(value: RationalParts): RationalParts {
+  const divisor = greatestCommonDivisor(value.numerator < 0n ? -value.numerator : value.numerator, value.denominator);
+  return { numerator: value.numerator / divisor, denominator: value.denominator / divisor };
+}
+
+function floorMultiple(value: RationalParts, multiple: RationalParts): RationalParts {
+  const quotient = floorDivide(value.numerator * multiple.denominator, value.denominator * multiple.numerator);
+  return normalizeRational({ numerator: quotient * multiple.numerator, denominator: multiple.denominator });
+}
+
+function ceilMultiple(value: RationalParts, multiple: RationalParts): RationalParts {
+  const numerator = value.numerator * multiple.denominator;
+  const denominator = value.denominator * multiple.numerator;
+  const quotient = ceilDivide(numerator, denominator);
+  return normalizeRational({ numerator: quotient * multiple.numerator, denominator: multiple.denominator });
+}
+
+function floorDivide(numerator: bigint, denominator: bigint): bigint {
+  if (numerator >= 0n) return numerator / denominator;
+  return -((-numerator + denominator - 1n) / denominator);
+}
+
+function ceilDivide(numerator: bigint, denominator: bigint): bigint {
+  if (numerator >= 0n) return (numerator + denominator - 1n) / denominator;
+  return -((-numerator) / denominator);
+}
+
+function subtractRationals(left: RationalParts, right: RationalParts): RationalParts {
+  return normalizeRational({
+    numerator: left.numerator * right.denominator - right.numerator * left.denominator,
+    denominator: left.denominator * right.denominator,
+  });
+}
+
+function rangeFromRationals(start: RationalParts, duration: RationalParts): TimeRange {
+  const end = normalizeRational({
+    numerator: start.numerator * duration.denominator + duration.numerator * start.denominator,
+    denominator: start.denominator * duration.denominator,
+  });
+  return {
+    start: rationalToNumber(start),
+    end: rationalToNumber(end),
+    startTime: rationalToTime(start),
+    durationTime: rationalToTime(duration),
+  };
+}
+
+function rationalToNumber(value: RationalParts): number {
+  return Number(value.numerator) / Number(value.denominator);
+}
+
+function rationalToTime(value: RationalParts): RationalTime {
+  return { value: String(value.numerator), timescale: String(value.denominator) };
+}
+
+function greatestCommonDivisor(left: bigint, right: bigint): bigint {
+  while (right !== 0n) {
+    const remainder = left % right;
+    left = right;
+    right = remainder;
+  }
+  return left || 1n;
+}

--- a/packages/testkit/src/fixture-analyzers.ts
+++ b/packages/testkit/src/fixture-analyzers.ts
@@ -8,6 +8,7 @@ import type {
   VisualAnalyzer,
   SpeechAnalysis,
   SpeechAnalyzer,
+  SpeechSegment,
   SpeechWord,
   TimeRange,
 } from "@framekit/runtime";
@@ -20,6 +21,9 @@ export class FixtureSpeechAnalyzer implements SpeechAnalyzer {
     if (!speech) throw new Error(`ANALYSIS_FAILED: no speech fixture for ${input.media.mediaId}`);
     return {
       words: filterRange(speech.words, range),
+      ...(speech.vadSegments ? { vadSegments: filterSegments(speech.vadSegments, range) } : {}),
+      ...(speech.silenceSegments ? { silenceSegments: filterSegments(speech.silenceSegments, range) } : {}),
+      ...(speech.protectedSegments ? { protectedSegments: filterSegments(speech.protectedSegments, range) } : {}),
     };
   }
 }
@@ -68,4 +72,11 @@ function filterRange(words: SpeechWord[], range?: TimeRange): SpeechWord[] {
   return words
     .filter((word) => word.end > range.start && word.start < range.end)
     .map((word) => ({ ...word }));
+}
+
+function filterSegments(segments: SpeechSegment[], range?: TimeRange): SpeechSegment[] {
+  if (!range) return segments.map((segment) => ({ ...segment }));
+  return segments
+    .filter((segment) => segment.end > range.start && segment.start < range.end)
+    .map((segment) => ({ ...segment }));
 }

--- a/tests/integration/filler-removal-ci.test.ts
+++ b/tests/integration/filler-removal-ci.test.ts
@@ -11,6 +11,7 @@ test("filler-removal benchmark is wired into local and CI validation", async () 
   const documentation = await readFile(resolve("docs/tests/filler-removal-benchmark.md"), "utf8");
 
   assert.match(packageJson.scripts?.test ?? "", /tests\/filler-removal\/\*\.test\.ts/);
+  assert.match(packageJson.scripts?.test ?? "", /tests\/speech\/\*\.test\.ts/);
   assert.equal(packageJson.scripts?.["test:filler-removal"], "tsx --test tests/filler-removal/*.test.ts");
   assert.equal(packageJson.scripts?.["benchmark:filler-removal"], "tsx scripts/run-filler-removal-benchmark.ts");
   assert.match(workflow, /pnpm run benchmark:filler-removal --output-dir artifacts\/filler-removal\/\$\{\{ github\.run_id \}\}/);

--- a/tests/speech/filler-components.test.ts
+++ b/tests/speech/filler-components.test.ts
@@ -92,6 +92,31 @@ test("candidate IDs are stable within a preview and change across previews", () 
   assert.notEqual(first[0]?.id, other[0]?.id);
 });
 
+test("candidate IDs stay stable when an analysis window adds unrelated words", () => {
+  const detector = new FillerDetector({ vocabulary: ["um", "uh"], confidenceThreshold: 0.9 });
+  const occurrence = {
+    occurrenceId: "occurrence-window",
+    sourceRange: { start: 5, end: 8 },
+    sequenceRange: { start: 10, end: 13 },
+  };
+  const original = detector.detect({
+    previewId: "preview-window",
+    analysis,
+    targetRange: { start: 10, end: 13 },
+    occurrence,
+  })[0]!;
+  const expanded = detector.detect({
+    previewId: "preview-window",
+    analysis: {
+      words: [{ text: "intro", start: 4, end: 4.2, confidence: 0.99 }, ...analysis.words],
+    },
+    targetRange: { start: 10, end: 13 },
+    occurrence,
+  })[0]!;
+
+  assert.equal(expanded.id, original.id);
+});
+
 test("detector records vocabulary-only and low-confidence evidence", () => {
   const detector = new FillerDetector({ vocabulary: ["uh"], confidenceThreshold: 0.9 });
   const candidates = detector.detect({
@@ -275,6 +300,26 @@ test("resolver distinguishes malformed VAD evidence from missing VAD", () => {
 
   assert.equal(decision.status, "SKIPPED");
   assert.deepEqual(decision.reasonCodes, ["INVALID_VAD_EVIDENCE"]);
+});
+
+test("resolver identifies malformed silence and protected evidence", () => {
+  const malformedSilence = new SafeCutResolver().resolve(resolverRequest({
+    analysis: {
+      ...analysisWithVAD,
+      silenceSegments: [{ start: 5.7, end: 5.6, kind: "silence" }],
+    } as SpeechAnalysis,
+  }));
+  assert.equal(malformedSilence.status, "SKIPPED");
+  assert.deepEqual(malformedSilence.reasonCodes, ["INVALID_SILENCE_EVIDENCE"]);
+
+  const malformedProtected = new SafeCutResolver().resolve(resolverRequest({
+    analysis: {
+      ...analysisWithVAD,
+      protectedSegments: [{ start: 6.2, end: 6.1, kind: "breath" }],
+    } as SpeechAnalysis,
+  }));
+  assert.equal(malformedProtected.status, "SKIPPED");
+  assert.deepEqual(malformedProtected.reasonCodes, ["INVALID_PROTECTED_EVIDENCE"]);
 });
 
 test("resolver rejects VAD segments that overlap across speech and silence", () => {
@@ -463,4 +508,44 @@ test("resolver aligns non-integral word bounds inside surrounding silence", () =
     startTime: { value: "52", timescale: "5" },
     durationTime: { value: "7", timescale: "30" },
   });
+});
+
+test("resolver skips cuts that would clip untranscribed speech", () => {
+  const detector = new FillerDetector({ vocabulary: ["um"] });
+  const words = [
+    { text: "So", start: 5, end: 5.3, confidence: 0.99 },
+    { text: "um", start: 5.36, end: 5.6, confidence: 0.99, filler: true },
+    { text: "okay", start: 6, end: 6.3, confidence: 0.99 },
+  ];
+  const occurrence = {
+    occurrenceId: "occurrence-untranscribed",
+    sourceRange: { start: 5, end: 8 },
+    sequenceRange: { start: 10, end: 13 },
+  };
+  const candidate = detector.detect({
+    previewId: "preview-untranscribed",
+    analysis: { words },
+    targetRange: { start: 10, end: 13 },
+    occurrence,
+  })[0]!;
+  const decision = new SafeCutResolver().resolve({
+    candidate,
+    analysis: {
+      words,
+      vadSegments: [
+        { start: 5, end: 5.35, kind: "speech" },
+        { start: 5.35, end: 5.36, kind: "silence" },
+        { start: 5.36, end: 5.6, kind: "speech" },
+        { start: 5.6, end: 6, kind: "silence" },
+        { start: 6, end: 6.3, kind: "speech" },
+      ],
+    } as SpeechAnalysis,
+    targetRange: { start: 10, end: 13 },
+    occurrence,
+    timelineId: "timeline-untranscribed",
+    sequenceFrameDuration: { value: "1", timescale: "30" },
+  });
+
+  assert.equal(decision.status, "SKIPPED");
+  assert.deepEqual(decision.reasonCodes, ["NO_FRAME_ALIGNED_RANGE"]);
 });

--- a/tests/speech/filler-components.test.ts
+++ b/tests/speech/filler-components.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   FillerDetector,
+  SafeCutResolver,
   type SpeechAnalysis,
 } from "@framekit/runtime";
 
@@ -50,4 +51,51 @@ test("candidate IDs are stable within a preview and change across previews", () 
 
   assert.equal(first[0]?.id, repeat[0]?.id);
   assert.notEqual(first[0]?.id, other[0]?.id);
+});
+
+test("resolver auto-applies a bounded frame-aligned cut with pause preservation", () => {
+  const candidate = detect()[0]!;
+  const resolver = new SafeCutResolver({ preservePauseMs: 700, targetPauseMs: 500 });
+  const speech = {
+    words: [
+      { text: "So", start: 5, end: 5.3, confidence: 0.99 },
+      { text: "um", start: 5.4, end: 5.7, confidence: 0.98, filler: true },
+      { text: "okay", start: 6.6, end: 6.9, confidence: 0.99 },
+    ],
+    vadSegments: [
+      { start: 5, end: 5.3, kind: "speech" },
+      { start: 5.3, end: 5.4, kind: "silence" },
+      { start: 5.4, end: 5.7, kind: "speech" },
+      { start: 5.7, end: 6.6, kind: "silence" },
+      { start: 6.6, end: 6.9, kind: "speech" },
+    ],
+    silenceSegments: [{ start: 5.7, end: 6.6, kind: "silence" }],
+  } as SpeechAnalysis;
+
+  const decision = resolver.resolve({
+    candidate,
+    analysis: speech,
+    targetRange: { start: 10, end: 13 },
+    occurrence: {
+      occurrenceId: "occurrence-1",
+      sourceRange: { start: 5, end: 8 },
+      sequenceRange: { start: 10, end: 13 },
+    },
+    timelineId: "timeline-1",
+    sequenceFrameDuration: { value: "1", timescale: "30" },
+  });
+
+  assert.equal(decision.status, "AUTO_APPLY");
+  assert.deepEqual(decision.range, {
+    start: 10.4,
+    end: 10.9,
+    startTime: { value: "52", timescale: "5" },
+    durationTime: { value: "1", timescale: "2" },
+  });
+  assert.deepEqual(decision.operation, {
+    type: "ripple-delete",
+    timelineId: "timeline-1",
+    range: decision.range,
+    reason: "remove filler candidate filler-candidate",
+  });
 });

--- a/tests/speech/filler-components.test.ts
+++ b/tests/speech/filler-components.test.ts
@@ -88,14 +88,14 @@ test("resolver auto-applies a bounded frame-aligned cut with pause preservation"
   assert.equal(decision.status, "AUTO_APPLY");
   assert.deepEqual(decision.range, {
     start: 10.4,
-    end: 10.9,
+    end: 11.1,
     startTime: { value: "52", timescale: "5" },
-    durationTime: { value: "1", timescale: "2" },
+    durationTime: { value: "7", timescale: "10" },
   });
   assert.deepEqual(decision.operation, {
     type: "ripple-delete",
     timelineId: "timeline-1",
     range: decision.range,
-    reason: "remove filler candidate filler-candidate",
+    reason: `remove filler candidate ${candidate.id}`,
   });
 });

--- a/tests/speech/filler-components.test.ts
+++ b/tests/speech/filler-components.test.ts
@@ -139,6 +139,24 @@ test("detector records vocabulary-only and low-confidence evidence", () => {
   assert.deepEqual(candidates[0]?.reasonCodes, ["VOCABULARY_MATCH", "BELOW_CONFIDENCE_THRESHOLD"]);
 });
 
+test("detector normalizes repeated trailing punctuation", () => {
+  const candidates = new FillerDetector({ vocabulary: ["uh"] }).detect({
+    previewId: "preview-punctuation",
+    analysis: {
+      words: [{ text: "uh!!!", start: 5.4, end: 5.7, confidence: 0.99 }],
+    },
+    targetRange: { start: 10, end: 13 },
+    occurrence: {
+      occurrenceId: "occurrence-punctuation",
+      sourceRange: { start: 5, end: 8 },
+      sequenceRange: { start: 10, end: 13 },
+    },
+  });
+
+  assert.equal(candidates.length, 1);
+  assert.equal(candidates[0]?.evidence.vocabularyMatch, true);
+});
+
 test("fixture speech analysis preserves range-bound VAD and protected evidence", async () => {
   const input = {
     project: {} as AnalysisInput["project"],

--- a/tests/speech/filler-components.test.ts
+++ b/tests/speech/filler-components.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  FillerDetector,
+  type SpeechAnalysis,
+} from "@framekit/runtime";
+
+const analysis: SpeechAnalysis = {
+  words: [
+    { text: "So", start: 5, end: 5.3, confidence: 0.99 },
+    { text: "um", start: 5.4, end: 5.7, confidence: 0.98, filler: true },
+    { text: "like", start: 6, end: 6.2, confidence: 0.96 },
+    { text: "okay", start: 6.5, end: 6.9, confidence: 0.99 },
+  ],
+};
+
+function detect(previewId = "preview-1") {
+  return new FillerDetector({ vocabulary: ["um", "uh"], confidenceThreshold: 0.9 }).detect({
+    previewId,
+    analysis,
+    targetRange: { start: 10, end: 13 },
+    occurrence: {
+      occurrenceId: "occurrence-1",
+      mediaId: "media-1",
+      sourceRange: { start: 5, end: 8 },
+      sequenceRange: { start: 10, end: 13 },
+    },
+  });
+}
+
+test("detector creates deterministic candidates from metadata and vocabulary", () => {
+  const candidates = detect();
+
+  assert.equal(candidates.length, 1);
+  assert.equal(candidates[0]?.word.text, "um");
+  assert.equal(candidates[0]?.occurrenceId, "occurrence-1");
+  assert.equal(candidates[0]?.confidence, 0.98);
+  assert.equal(candidates[0]?.confidenceThreshold, 0.9);
+  assert.deepEqual(candidates[0]?.sourceRange, { start: 5.4, end: 5.7 });
+  assert.deepEqual(candidates[0]?.sequenceRange, { start: 10.4, end: 10.7 });
+  assert.ok(candidates[0]?.reasonCodes.includes("ANALYZER_MARKED_FILLER"));
+  assert.ok(candidates[0]?.reasonCodes.includes("VOCABULARY_MATCH"));
+  assert.equal(candidates[0]?.eligible, true);
+});
+
+test("candidate IDs are stable within a preview and change across previews", () => {
+  const first = detect("preview-1");
+  const repeat = detect("preview-1");
+  const other = detect("preview-2");
+
+  assert.equal(first[0]?.id, repeat[0]?.id);
+  assert.notEqual(first[0]?.id, other[0]?.id);
+});

--- a/tests/speech/filler-components.test.ts
+++ b/tests/speech/filler-components.test.ts
@@ -246,6 +246,95 @@ test("resolver distinguishes malformed VAD evidence from missing VAD", () => {
   assert.deepEqual(decision.reasonCodes, ["INVALID_VAD_EVIDENCE"]);
 });
 
+test("resolver rejects VAD segments that overlap across speech and silence", () => {
+  const decision = new SafeCutResolver().resolve(resolverRequest({
+    analysis: {
+      ...analysisWithVAD,
+      vadSegments: [
+        { start: 5, end: 5.3, kind: "speech" },
+        { start: 5.3, end: 5.4, kind: "silence" },
+        { start: 5.4, end: 6, kind: "speech" },
+        { start: 5.7, end: 6.6, kind: "silence" },
+        { start: 6.6, end: 6.9, kind: "speech" },
+      ],
+    } as SpeechAnalysis,
+  }));
+
+  assert.equal(decision.status, "SKIPPED");
+  assert.deepEqual(decision.reasonCodes, ["INVALID_VAD_EVIDENCE"]);
+});
+
+test("resolver protects segments touched by outward frame alignment", () => {
+  const decision = new SafeCutResolver().resolve(resolverRequest({
+    analysis: {
+      ...analysisWithVAD,
+      protectedSegments: [{ start: 6.11, end: 6.12, kind: "laughter" }],
+    } as SpeechAnalysis,
+    sequenceFrameDuration: { value: "1", timescale: "24" },
+  }));
+
+  assert.equal(decision.status, "SKIPPED");
+  assert.deepEqual(decision.reasonCodes, ["PROTECTED_SEGMENT_OVERLAP"]);
+});
+
+test("resolver keeps multiple resolved candidates deterministic and non-overlapping", () => {
+  const detector = new FillerDetector({ vocabulary: ["um", "uh"] });
+  const words = [
+    { text: "So", start: 0, end: 0.3, confidence: 0.99 },
+    { text: "um", start: 0.4, end: 0.7, confidence: 0.99, filler: true },
+    { text: "we", start: 0.8, end: 1.1, confidence: 0.99 },
+    { text: "uh", start: 1.2, end: 1.4, confidence: 0.99, filler: true },
+    { text: "go", start: 1.5, end: 1.8, confidence: 0.99 },
+  ];
+  const occurrence = {
+    occurrenceId: "occurrence-many",
+    sourceRange: { start: 0, end: 2 },
+    sequenceRange: { start: 20, end: 22 },
+  };
+  const analysisWithSegments = {
+    words,
+    vadSegments: [
+      { start: 0, end: 0.3, kind: "speech" },
+      { start: 0.3, end: 0.4, kind: "silence" },
+      { start: 0.4, end: 0.7, kind: "speech" },
+      { start: 0.7, end: 0.8, kind: "silence" },
+      { start: 0.8, end: 1.1, kind: "speech" },
+      { start: 1.1, end: 1.2, kind: "silence" },
+      { start: 1.2, end: 1.4, kind: "speech" },
+      { start: 1.4, end: 1.5, kind: "silence" },
+      { start: 1.5, end: 1.8, kind: "speech" },
+    ],
+  } as SpeechAnalysis;
+  const candidates = detector.detect({
+    previewId: "preview-many",
+    analysis: analysisWithSegments,
+    targetRange: { start: 20, end: 22 },
+    occurrence,
+  });
+  const resolver = new SafeCutResolver();
+  const resolve = () => candidates.map((candidate) => resolver.resolve({
+    candidate,
+    analysis: analysisWithSegments,
+    targetRange: { start: 20, end: 22 },
+    occurrence,
+    timelineId: "timeline-many",
+    sequenceFrameDuration: { value: "1", timescale: "30" },
+  }));
+  const decisions = resolve();
+
+  assert.deepEqual(decisions, resolve());
+  assert.equal(decisions.every((decision) => decision.status === "AUTO_APPLY"), true);
+  const ranges = decisions.map((decision) => decision.range!).sort((left, right) => left.start - right.start);
+  for (let index = 0; index < ranges.length; index += 1) {
+    const range = ranges[index]!;
+    assert.equal(range.start >= 20 && range.end <= 22, true);
+    assert.equal(range.end > range.start, true);
+    assert.equal(Math.abs(range.start * 30 - Math.round(range.start * 30)) < 0.000001, true);
+    assert.equal(Math.abs(range.end * 30 - Math.round(range.end * 30)) < 0.000001, true);
+    assert.equal(index === 0 || ranges[index - 1]!.end <= range.start, true);
+  }
+});
+
 test("resolver keeps every range inside target and occurrence bounds", () => {
   const outsideTarget = new SafeCutResolver().resolve(resolverRequest({
     targetRange: { start: 10.5, end: 13 },

--- a/tests/speech/filler-components.test.ts
+++ b/tests/speech/filler-components.test.ts
@@ -29,6 +29,43 @@ function detect(previewId = "preview-1") {
   });
 }
 
+function resolverRequest(overrides: Partial<Parameters<SafeCutResolver["resolve"]>[0]> = {}) {
+  const candidate = detect()[0]!;
+  const analysis = {
+    ...analysisWithVAD,
+    words: analysisWithVAD.words.map((word) => ({ ...word })),
+  } as SpeechAnalysis;
+  return {
+    candidate,
+    analysis,
+    targetRange: { start: 10, end: 13 },
+    occurrence: {
+      occurrenceId: "occurrence-1",
+      sourceRange: { start: 5, end: 8 },
+      sequenceRange: { start: 10, end: 13 },
+    },
+    timelineId: "timeline-1",
+    sequenceFrameDuration: { value: "1", timescale: "30" },
+    ...overrides,
+  };
+}
+
+const analysisWithVAD = {
+  words: [
+    { text: "So", start: 5, end: 5.3, confidence: 0.99 },
+    { text: "um", start: 5.4, end: 5.7, confidence: 0.98, filler: true },
+    { text: "okay", start: 6.6, end: 6.9, confidence: 0.99 },
+  ],
+  vadSegments: [
+    { start: 5, end: 5.3, kind: "speech" },
+    { start: 5.3, end: 5.4, kind: "silence" },
+    { start: 5.4, end: 5.7, kind: "speech" },
+    { start: 5.7, end: 6.6, kind: "silence" },
+    { start: 6.6, end: 6.9, kind: "speech" },
+  ],
+  silenceSegments: [{ start: 5.7, end: 6.6, kind: "silence" }],
+};
+
 test("detector creates deterministic candidates from metadata and vocabulary", () => {
   const candidates = detect();
 
@@ -98,4 +135,122 @@ test("resolver auto-applies a bounded frame-aligned cut with pause preservation"
     range: decision.range,
     reason: `remove filler candidate ${candidate.id}`,
   });
+});
+
+test("resolver suggests but never auto-applies a low-confidence candidate", () => {
+  const request = resolverRequest();
+  request.candidate = {
+    ...request.candidate,
+    confidence: 0.5,
+    confidenceThreshold: 0.9,
+    eligible: false,
+  };
+
+  const decision = new SafeCutResolver().resolve(request);
+
+  assert.equal(decision.status, "SUGGESTED");
+  assert.ok(decision.reasonCodes.includes("LOW_CONFIDENCE"));
+  assert.equal(decision.operation?.type, "ripple-delete");
+});
+
+test("resolver skips a candidate when VAD evidence is missing", () => {
+  const request = resolverRequest({ analysis: { words: analysisWithVAD.words } });
+
+  const decision = new SafeCutResolver().resolve(request);
+
+  assert.equal(decision.status, "SKIPPED");
+  assert.deepEqual(decision.reasonCodes, ["MISSING_VAD_EVIDENCE"]);
+  assert.equal(decision.operation, undefined);
+});
+
+test("resolver skips ambiguous source-to-sequence mappings", () => {
+  const request = resolverRequest({
+    candidate: {
+      ...detect()[0]!,
+      sequenceRange: { start: 10.5, end: 10.8 },
+    },
+  });
+
+  const decision = new SafeCutResolver().resolve(request);
+
+  assert.equal(decision.status, "SKIPPED");
+  assert.deepEqual(decision.reasonCodes, ["AMBIGUOUS_MAPPING"]);
+});
+
+test("resolver skips overlapping speech and protected segments", () => {
+  const overlapping = resolverRequest({
+    analysis: {
+      ...analysisWithVAD,
+      vadSegments: [
+        { start: 5, end: 5.5, kind: "speech" },
+        { start: 5.4, end: 6.6, kind: "speech" },
+      ],
+    } as SpeechAnalysis,
+  });
+  const overlapDecision = new SafeCutResolver().resolve(overlapping);
+  assert.equal(overlapDecision.status, "SKIPPED");
+  assert.deepEqual(overlapDecision.reasonCodes, ["OVERLAPPING_SPEECH"]);
+
+  const protectedRequest = resolverRequest({
+    analysis: {
+      ...analysisWithVAD,
+      protectedSegments: [{ start: 5.5, end: 5.8, kind: "breath" }],
+    } as SpeechAnalysis,
+  });
+  const protectedDecision = new SafeCutResolver().resolve(protectedRequest);
+  assert.equal(protectedDecision.status, "SKIPPED");
+  assert.deepEqual(protectedDecision.reasonCodes, ["PROTECTED_SEGMENT_OVERLAP"]);
+});
+
+test("resolver keeps every range inside target and occurrence bounds", () => {
+  const outsideTarget = new SafeCutResolver().resolve(resolverRequest({
+    targetRange: { start: 10.5, end: 13 },
+  }));
+  assert.equal(outsideTarget.status, "SKIPPED");
+  assert.deepEqual(outsideTarget.reasonCodes, ["OUTSIDE_TARGET_BOUND"]);
+
+  const outsideOccurrence = new SafeCutResolver().resolve(resolverRequest({
+    occurrence: {
+      occurrenceId: "occurrence-1",
+      sourceRange: { start: 5, end: 8 },
+      sequenceRange: { start: 10.5, end: 13.5 },
+    },
+  }));
+  assert.equal(outsideOccurrence.status, "SKIPPED");
+  assert.deepEqual(outsideOccurrence.reasonCodes, ["OUTSIDE_OCCURRENCE_BOUND"]);
+});
+
+test("resolver skips a range that cannot retain frame-safe boundaries", () => {
+  const detector = new FillerDetector({ vocabulary: ["um"] });
+  const request = {
+    candidate: detector.detect({
+      previewId: "preview-frame",
+      analysis: {
+        words: [{ text: "um", start: 5.405, end: 5.415, confidence: 0.99, filler: true }],
+      },
+      targetRange: { start: 10.405, end: 10.415 },
+      occurrence: {
+        occurrenceId: "occurrence-frame",
+        sourceRange: { start: 5.405, end: 8.405 },
+        sequenceRange: { start: 10.405, end: 13.405 },
+      },
+    })[0]!,
+    analysis: {
+      words: [{ text: "um", start: 5.405, end: 5.415, confidence: 0.99, filler: true }],
+      vadSegments: [{ start: 5.405, end: 5.415, kind: "speech" }],
+    } as SpeechAnalysis,
+    targetRange: { start: 10.405, end: 10.415 },
+    occurrence: {
+      occurrenceId: "occurrence-frame",
+      sourceRange: { start: 5.405, end: 8.405 },
+      sequenceRange: { start: 10.405, end: 13.405 },
+    },
+    timelineId: "timeline-frame",
+    sequenceFrameDuration: { value: "1", timescale: "30" },
+  };
+
+  const decision = new SafeCutResolver().resolve(request);
+
+  assert.equal(decision.status, "SKIPPED");
+  assert.deepEqual(decision.reasonCodes, ["NO_FRAME_ALIGNED_RANGE"]);
 });

--- a/tests/speech/filler-components.test.ts
+++ b/tests/speech/filler-components.test.ts
@@ -3,8 +3,10 @@ import test from "node:test";
 import {
   FillerDetector,
   SafeCutResolver,
+  type AnalysisInput,
   type SpeechAnalysis,
 } from "@framekit/runtime";
+import { FixtureSpeechAnalyzer } from "@framekit/testkit";
 
 const analysis: SpeechAnalysis = {
   words: [
@@ -110,6 +112,35 @@ test("detector records vocabulary-only and low-confidence evidence", () => {
   assert.equal(candidates[0]?.evidence.vocabularyMatch, true);
   assert.equal(candidates[0]?.eligible, false);
   assert.deepEqual(candidates[0]?.reasonCodes, ["VOCABULARY_MATCH", "BELOW_CONFIDENCE_THRESHOLD"]);
+});
+
+test("fixture speech analysis preserves range-bound VAD and protected evidence", async () => {
+  const input = {
+    project: {} as AnalysisInput["project"],
+    media: {
+      mediaId: "fixture-media",
+      source: "fixture.wav",
+      speech: {
+        words: [{ text: "um", start: 0.3, end: 0.5, confidence: 0.99, filler: true }],
+        vadSegments: [
+          { start: 0, end: 0.2, kind: "speech" },
+          { start: 0.2, end: 0.6, kind: "speech" },
+          { start: 0.6, end: 0.8, kind: "silence" },
+        ],
+        silenceSegments: [{ start: 0.6, end: 0.8, kind: "silence" }],
+        protectedSegments: [{ start: 0.6, end: 0.7, kind: "breath" }],
+      },
+    },
+  } as AnalysisInput;
+
+  const result = await new FixtureSpeechAnalyzer().analyze(input, { start: 0.25, end: 0.75 });
+
+  assert.deepEqual(result.vadSegments, [
+    { start: 0.2, end: 0.6, kind: "speech" },
+    { start: 0.6, end: 0.8, kind: "silence" },
+  ]);
+  assert.deepEqual(result.silenceSegments, [{ start: 0.6, end: 0.8, kind: "silence" }]);
+  assert.deepEqual(result.protectedSegments, [{ start: 0.6, end: 0.7, kind: "breath" }]);
 });
 
 test("resolver auto-applies a bounded frame-aligned cut with pause preservation", () => {

--- a/tests/speech/filler-components.test.ts
+++ b/tests/speech/filler-components.test.ts
@@ -90,6 +90,28 @@ test("candidate IDs are stable within a preview and change across previews", () 
   assert.notEqual(first[0]?.id, other[0]?.id);
 });
 
+test("detector records vocabulary-only and low-confidence evidence", () => {
+  const detector = new FillerDetector({ vocabulary: ["uh"], confidenceThreshold: 0.9 });
+  const candidates = detector.detect({
+    previewId: "preview-policy",
+    analysis: {
+      words: [{ text: "uh", start: 5.4, end: 5.7, confidence: 0.5 }],
+    },
+    targetRange: { start: 10, end: 13 },
+    occurrence: {
+      occurrenceId: "occurrence-policy",
+      sourceRange: { start: 5, end: 8 },
+      sequenceRange: { start: 10, end: 13 },
+    },
+  });
+
+  assert.equal(candidates.length, 1);
+  assert.equal(candidates[0]?.evidence.analyzerMarkedFiller, false);
+  assert.equal(candidates[0]?.evidence.vocabularyMatch, true);
+  assert.equal(candidates[0]?.eligible, false);
+  assert.deepEqual(candidates[0]?.reasonCodes, ["VOCABULARY_MATCH", "BELOW_CONFIDENCE_THRESHOLD"]);
+});
+
 test("resolver auto-applies a bounded frame-aligned cut with pause preservation", () => {
   const candidate = detect()[0]!;
   const resolver = new SafeCutResolver({ preservePauseMs: 700, targetPauseMs: 500 });
@@ -200,6 +222,28 @@ test("resolver skips overlapping speech and protected segments", () => {
   const protectedDecision = new SafeCutResolver().resolve(protectedRequest);
   assert.equal(protectedDecision.status, "SKIPPED");
   assert.deepEqual(protectedDecision.reasonCodes, ["PROTECTED_SEGMENT_OVERLAP"]);
+
+  const protectedPauseRequest = resolverRequest({
+    analysis: {
+      ...analysisWithVAD,
+      protectedSegments: [{ start: 5.95, end: 6.15, kind: "laughter" }],
+    } as SpeechAnalysis,
+  });
+  const protectedPauseDecision = new SafeCutResolver().resolve(protectedPauseRequest);
+  assert.equal(protectedPauseDecision.status, "SKIPPED");
+  assert.deepEqual(protectedPauseDecision.reasonCodes, ["PROTECTED_SEGMENT_OVERLAP"]);
+});
+
+test("resolver distinguishes malformed VAD evidence from missing VAD", () => {
+  const decision = new SafeCutResolver().resolve(resolverRequest({
+    analysis: {
+      ...analysisWithVAD,
+      vadSegments: [{ start: 5.4, end: 5.3, kind: "speech" }],
+    } as SpeechAnalysis,
+  }));
+
+  assert.equal(decision.status, "SKIPPED");
+  assert.deepEqual(decision.reasonCodes, ["INVALID_VAD_EVIDENCE"]);
 });
 
 test("resolver keeps every range inside target and occurrence bounds", () => {

--- a/tests/speech/filler-components.test.ts
+++ b/tests/speech/filler-components.test.ts
@@ -254,3 +254,49 @@ test("resolver skips a range that cannot retain frame-safe boundaries", () => {
   assert.equal(decision.status, "SKIPPED");
   assert.deepEqual(decision.reasonCodes, ["NO_FRAME_ALIGNED_RANGE"]);
 });
+
+test("resolver aligns non-integral word bounds inside surrounding silence", () => {
+  const detector = new FillerDetector({ vocabulary: ["um"] });
+  const words = [
+    { text: "So", start: 5, end: 5.3, confidence: 0.99 },
+    { text: "um", start: 5.405, end: 5.615, confidence: 0.99, filler: true },
+    { text: "okay", start: 6, end: 6.3, confidence: 0.99 },
+  ];
+  const occurrence = {
+    occurrenceId: "occurrence-non-integral",
+    sourceRange: { start: 5, end: 8 },
+    sequenceRange: { start: 10, end: 13 },
+  };
+  const candidate = detector.detect({
+    previewId: "preview-non-integral",
+    analysis: { words },
+    targetRange: { start: 10, end: 13 },
+    occurrence,
+  })[0]!;
+
+  const decision = new SafeCutResolver().resolve({
+    candidate,
+    analysis: {
+      words,
+      vadSegments: [
+        { start: 5, end: 5.3, kind: "speech" },
+        { start: 5.3, end: 5.405, kind: "silence" },
+        { start: 5.405, end: 5.615, kind: "speech" },
+        { start: 5.615, end: 6, kind: "silence" },
+        { start: 6, end: 6.3, kind: "speech" },
+      ],
+    } as SpeechAnalysis,
+    targetRange: { start: 10, end: 13 },
+    occurrence,
+    timelineId: "timeline-non-integral",
+    sequenceFrameDuration: { value: "1", timescale: "30" },
+  });
+
+  assert.equal(decision.status, "AUTO_APPLY");
+  assert.deepEqual(decision.range, {
+    start: 10.4,
+    end: 319 / 30,
+    startTime: { value: "52", timescale: "5" },
+    durationTime: { value: "7", timescale: "30" },
+  });
+});


### PR DESCRIPTION
## Summary

Implemented the editor-independent runtime components for issue #42:

- Added `FillerDetector` with analyzer metadata, configurable vocabulary, confidence evidence, deterministic preview-scoped IDs, and source-to-occurrence mapping.
- Added `SafeCutResolver` with VAD/silence/protected-segment checks, fail-closed decisions, exact rational frame alignment, pause preservation, and pure `ripple-delete` operations.
- Extended fixture speech analysis to preserve range-bound VAD and protected evidence.
- Added deterministic unit/property-style coverage and documented the contract.

Closes: #42

## Validation

```bash
pnpm install --frozen-lockfile
pnpm run build
pnpm run test
pnpm run check:boundaries
```

All passed: 396 tests, build, and boundary checks. Native/Xcode validation is not applicable; no native files changed.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Public package interfaces are documented.
- [x] Existing adapters and test fixtures remain compatible.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [x] Documentation reflects the changed runtime contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added deterministic detection of filler words in speech, with confidence scoring and clear evidence.
  - Added safe-cut resolution that preserves natural pauses, respects speech boundaries, and avoids protected content.
  - Added frame-aligned ripple-delete decisions with actionable statuses for accepted, suggested, or rejected cuts.
  - Added support for speech, silence, breath, laughter, and noise segment data.
  - Exposed filler detection and safe-cut capabilities through the runtime package.

- **Documentation**
  - Documented filler detection rules, safe-cut behavior, evidence, and decision statuses.

- **Tests**
  - Expanded automated coverage for speech analysis, detection, cut safety, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->