### PR TITLE
chore: enable Renovate automerge for safe updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,11 +7,17 @@
   "prHourlyLimit": 2,
   "packageRules": [
     {
-      "description": "Group non-major development dependency updates",
+      "description": "Automerge non-major npm development dependency updates",
       "matchManagers": ["npm"],
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "dev dependencies"
+      "groupName": "dev dependencies",
+      "automerge": true
+    },
+    {
+      "description": "Automerge lock file maintenance",
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "automerge": true
     },
     {
       "description": "Group GitHub Actions updates",


### PR DESCRIPTION
## Summary

Enable Renovate automerge for low-risk dependency maintenance while keeping higher-risk updates manual.

### Automerged
- npm `devDependencies` minor updates
- npm `devDependencies` patch updates
- lock file maintenance

### Still manual
- major dependency updates
- GitHub Actions updates
- any Renovate update not matched by the automerge rules

This keeps routine maintenance hands-off while preserving manual review for changes with a larger compatibility or supply-chain surface.