### PR TITLE
chore: automerge pinned dev dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
       "description": "Automerge non-major npm development dependency updates",
       "matchManagers": ["npm"],
       "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["minor", "patch"],
+      "matchUpdateTypes": ["minor", "patch", "pin"],
       "groupName": "dev dependencies",
       "automerge": true
     },


### PR DESCRIPTION
## Summary

Allow Renovate to automatically merge pinned npm development dependency updates.

This extends the existing low-risk devDependency automerge rule from:

- minor
- patch

to:

- minor
- patch
- pin

Major updates, regular dependencies, and GitHub Actions updates remain manual.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated npm development dependency updates now include pinned-version updates alongside minor and patch updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->