### PR TITLE
Release for v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [v0.1.3](https://github.com/morshoto/framekit/compare/v0.1.2...v0.1.3) - 2026-09-08
+
+- chore(deps): pin dependencies by @renovate[bot] in https://github.com/morshoto/framekit/pull/122
+- chore: automerge pinned dev dependencies by @morshoto in https://github.com/morshoto/framekit/pull/123
+- chore(deps): update dependency @types/node to v24 by @renovate[bot] in https://github.com/morshoto/framekit/pull/126
+- chore(deps): update pnpm to v11.24.0 by @renovate[bot] in https://github.com/morshoto/framekit/pull/125
+- fix(ci): use packageManager pnpm version in assign workflow by @morshoto in https://github.com/morshoto/framekit/pull/127
+- fix: recover tagged npm releases by @morshoto in https://github.com/morshoto/framekit/pull/129
+- fix(ci): use packageManager pnpm version across workflows by @morshoto in https://github.com/morshoto/framekit/pull/128
+- perf: streamline Swift CodeQL extraction by @morshoto in https://github.com/morshoto/framekit/pull/131
+- chore(deps): pin dependencies by @renovate[bot] in https://github.com/morshoto/framekit/pull/121
+- chore(deps): update dev dependencies by @renovate[bot] in https://github.com/morshoto/framekit/pull/146
+- feat: define the editor-independent Skill contract by @morshoto in https://github.com/morshoto/framekit/pull/148
+- feat: resolve Skill requirements against runtime capabilities by @morshoto in https://github.com/morshoto/framekit/pull/149
+- feat: add the generic Skill runtime by @morshoto in https://github.com/morshoto/framekit/pull/150
+- feat: route generic Skill tools through the runtime by @morshoto in https://github.com/morshoto/framekit/pull/151
+- feat: add the v0.0.2 Skill conformance gate by @morshoto in https://github.com/morshoto/framekit/pull/152
+- feat: add the audio noise reduction Skill by @morshoto in https://github.com/morshoto/framekit/pull/153
+- feat: add the basic color correction Skill by @morshoto in https://github.com/morshoto/framekit/pull/154
+- chore(deps): lock file maintenance by @renovate[bot] in https://github.com/morshoto/framekit/pull/155
+- chore(deps): update pnpm to v11.25.0 by @renovate[bot] in https://github.com/morshoto/framekit/pull/147
+- chore(deps): update dependency typescript to v7 by @renovate[bot] in https://github.com/morshoto/framekit/pull/156
+- docs: add deep wiki navigation without deleting content by @morshoto in https://github.com/morshoto/framekit/pull/61
+- chore(deps): update github actions (major) by @renovate[bot] in https://github.com/morshoto/framekit/pull/157
+- feat: add repository agent workflow skills by @morshoto in https://github.com/morshoto/framekit/pull/158
+
 ## [v0.1.2](https://github.com/morshoto/framekit/compare/v0.1.1...v0.1.2) - 2026-08-30
 
 - chore: run Renovate daily at 7am by @morshoto in https://github.com/morshoto/framekit/pull/106

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@morshoto/framekit",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "packageManager": "pnpm@11.25.0",
   "private": false,
   "type": "module",

--- a/plugins/framekit/.codex-plugin/plugin.json
+++ b/plugins/framekit/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "framekit",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Connect Codex to Framekit's MCP tools for Final Cut Pro",
   "author": {
     "name": "Framekit Contributors",


### PR DESCRIPTION
This pull request is for the next release as v0.1.3 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.3 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.2" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* chore(deps): pin dependencies by @renovate[bot] in https://github.com/morshoto/framekit/pull/122
* chore: automerge pinned dev dependencies by @morshoto in https://github.com/morshoto/framekit/pull/123
* chore(deps): update dependency @types/node to v24 by @renovate[bot] in https://github.com/morshoto/framekit/pull/126
* chore(deps): update pnpm to v11.24.0 by @renovate[bot] in https://github.com/morshoto/framekit/pull/125
* fix(ci): use packageManager pnpm version in assign workflow by @morshoto in https://github.com/morshoto/framekit/pull/127
* fix: recover tagged npm releases by @morshoto in https://github.com/morshoto/framekit/pull/129
* fix(ci): use packageManager pnpm version across workflows by @morshoto in https://github.com/morshoto/framekit/pull/128
* perf: streamline Swift CodeQL extraction by @morshoto in https://github.com/morshoto/framekit/pull/131
* chore(deps): pin dependencies by @renovate[bot] in https://github.com/morshoto/framekit/pull/121
* chore(deps): update dev dependencies by @renovate[bot] in https://github.com/morshoto/framekit/pull/146
* feat: define the editor-independent Skill contract by @morshoto in https://github.com/morshoto/framekit/pull/148
* feat: resolve Skill requirements against runtime capabilities by @morshoto in https://github.com/morshoto/framekit/pull/149
* feat: add the generic Skill runtime by @morshoto in https://github.com/morshoto/framekit/pull/150
* feat: route generic Skill tools through the runtime by @morshoto in https://github.com/morshoto/framekit/pull/151
* feat: add the v0.0.2 Skill conformance gate by @morshoto in https://github.com/morshoto/framekit/pull/152
* feat: add the audio noise reduction Skill by @morshoto in https://github.com/morshoto/framekit/pull/153
* feat: add the basic color correction Skill by @morshoto in https://github.com/morshoto/framekit/pull/154
* chore(deps): lock file maintenance by @renovate[bot] in https://github.com/morshoto/framekit/pull/155
* chore(deps): update pnpm to v11.25.0 by @renovate[bot] in https://github.com/morshoto/framekit/pull/147
* chore(deps): update dependency typescript to v7 by @renovate[bot] in https://github.com/morshoto/framekit/pull/156
* docs: add deep wiki navigation without deleting content by @morshoto in https://github.com/morshoto/framekit/pull/61
* chore(deps): update github actions (major) by @renovate[bot] in https://github.com/morshoto/framekit/pull/157
* feat: add repository agent workflow skills by @morshoto in https://github.com/morshoto/framekit/pull/158


**Full Changelog**: https://github.com/morshoto/framekit/compare/v0.1.2...tagpr-from-v0.1.2