### PR TITLE
fix(ci): use packageManager pnpm version in assign workflow

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -41,8 +41,6 @@ jobs:
               with:
                   node-version: '22.14.0'
             - uses: pnpm/action-setup@v4
-              with:
-                  version: 11.10.0
             - name: Run github-label-setup
               run: pnpm dlx --yes @azu/github-label-setup --token ${{ secrets.GITHUB_TOKEN }} --labels .github/labels/labels.json
 


### PR DESCRIPTION
## Summary

- remove the hard-coded `pnpm` version from `pnpm/action-setup@v4` in the Assign workflow
- let `pnpm/action-setup` read the version from `package.json#packageManager`

## Why

The `sync-labels` job currently specifies `pnpm` twice:

- `11.10.0` in `.github/workflows/assign.yml`
- `pnpm@11.24.0` in `package.json`

`pnpm/action-setup@v4` rejects this with `Multiple versions of pnpm specified`, which caused the failed Actions job in run `33450417597` / job `99678832800`.

Using `package.json#packageManager` as the single source of truth also prevents future Renovate pnpm updates from breaking this workflow in the same way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the label synchronization workflow to use the default pnpm version configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->