### PR TITLE
fix(ci): use packageManager pnpm version across workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,7 +56,7 @@ jobs:
   analyze-swift:
     name: Analyze (swift)
     runs-on: macos-15
-    timeout-minutes: 25
+    timeout-minutes: 40
 
     steps:
       - name: Check out repository
@@ -69,7 +69,7 @@ jobs:
           build-mode: manual
 
       - name: Build Swift sources for CodeQL extraction
-        timeout-minutes: 15
+        timeout-minutes: 25
         run: |
           xcodebuild \
             -project adapters/final-cut/swift-bridge/FinalCutWorkflowExtension/FramekitFinalCutWorkflow.xcodeproj \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 11.10.0
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -15,7 +15,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PNPM_VERSION: 11.10.0
   NODE_VERSION: 22.14.0
 
 jobs:
@@ -28,8 +27,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -55,8 +52,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

- remove the hard-coded `PNPM_VERSION` from TypeScript CI
- remove explicit `version` inputs from both CI jobs
- remove the hard-coded pnpm version from the npm release workflow
- let `pnpm/action-setup@v4` use `package.json#packageManager` as the single source of truth

## Why

The failed `Unit / integration tests` job in run `33450933685` / job `99680434332` was caused by pnpm being specified twice with different versions:

- `11.10.0` in `.github/workflows/typescript.yml`
- `pnpm@11.24.0` in `package.json`

`pnpm/action-setup@v4` rejects this with `Multiple versions of pnpm specified`.

The release workflow had the same stale `11.10.0` pin, so it would fail for the same reason when publishing the next release. This PR removes both duplicate pins so future Renovate pnpm updates only need to update `package.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated release workflows to recognize existing version tags and publish releases consistently.
  * Simplified package manager setup across continuous integration and release processes by using the default pnpm version.
  * Increased time limits for Swift code analysis and builds.
  * Updated validation checks to reflect the revised Swift analysis and build time limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->