### PR TITLE
fix: recover tagged npm releases

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -69,7 +69,7 @@ jobs:
           build-mode: manual
 
       - name: Build Swift sources for CodeQL extraction
-        timeout-minutes: 15
+        timeout-minutes: 20
         run: |
           xcodebuild \
             -project adapters/final-cut/swift-bridge/FinalCutWorkflowExtension/FramekitFinalCutWorkflow.xcodeproj \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,13 +23,19 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.TAGPR_TOKEN }}
+          persist-credentials: false
 
       - id: existing-tag
         name: Detect release tag on HEAD
         shell: bash
         run: |
           set -euo pipefail
-          tag="$(git tag --points-at HEAD --list 'v*' | head -n 1)"
+          mapfile -t tags < <(git tag --points-at HEAD --list 'v*')
+          if (( ${#tags[@]} > 1 )); then
+            echo "Multiple release tags point to HEAD" >&2
+            exit 1
+          fi
+          tag="${tags[0]-}"
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
 
       - id: run-tagpr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
   tagpr:
     runs-on: ubuntu-latest
     outputs:
-      tagpr-tag: ${{ steps.run-tagpr.outputs.tag }}
+      release-tag: ${{ steps.existing-tag.outputs.tag || steps.run-tagpr.outputs.tag }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -24,14 +24,23 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.TAGPR_TOKEN }}
 
+      - id: existing-tag
+        name: Detect release tag on HEAD
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="$(git tag --points-at HEAD --list 'v*' | head -n 1)"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
       - id: run-tagpr
         name: Run tagpr
+        if: steps.existing-tag.outputs.tag == ''
         uses: Songmu/tagpr@v1
         env:
           GITHUB_TOKEN: ${{ secrets.TAGPR_TOKEN }}
 
   publish-npm:
-    if: needs.tagpr.outputs.tagpr-tag != ''
+    if: needs.tagpr.outputs.release-tag != ''
     needs: tagpr
     runs-on: ubuntu-latest
     permissions:
@@ -46,7 +55,7 @@ jobs:
       - name: Validate release package
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
-          RELEASE_TAG: ${{ needs.tagpr.outputs.tagpr-tag }}
+          RELEASE_TAG: ${{ needs.tagpr.outputs.release-tag }}
         run: node scripts/validate-release-contract.mjs
 
       - name: Set up pnpm
@@ -72,7 +81,7 @@ jobs:
 
       - name: Verify npm publication
         env:
-          RELEASE_TAG: ${{ needs.tagpr.outputs.tagpr-tag }}
+          RELEASE_TAG: ${{ needs.tagpr.outputs.release-tag }}
         run: |
           set -eu
           expected_version="${RELEASE_TAG#v}"
@@ -83,5 +92,18 @@ jobs:
       - name: Publish GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ needs.tagpr.outputs.tagpr-tag }}
-        run: gh release edit "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" --draft=false
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          RELEASE_TAG: ${{ needs.tagpr.outputs.release-tag }}
+        run: |
+          set -euo pipefail
+          release_id="$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
+            --jq ".[] | select(.draft == true and (.name == \"${RELEASE_TAG}\" or .tag_name == \"${RELEASE_TAG}\")) | .id" \
+            | head -n 1)"
+          if [ -n "${release_id}" ]; then
+            gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/${release_id}" \
+              -f tag_name="${RELEASE_TAG}" \
+              -f name="${RELEASE_TAG}" \
+              -F draft=false
+          else
+            gh release edit "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" --draft=false
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 11.10.0
+          version: 11.24.0
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PNPM_VERSION: 11.10.0
+  PNPM_VERSION: 11.24.0
   NODE_VERSION: 22.14.0
 
 jobs:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,7 +10,7 @@ discovery, and the Phase 1 Final Cut runtime.
 Requirements:
 
 - Node.js 20 or newer;
-- pnpm 11.10.0;
+- pnpm 11.24.0;
 - Xcode 16.4 and the macOS 15.5 SDK for native Final Cut work.
 
 For the pinned Node and shell toolchain, enter the optional Nix shell first:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -32,7 +32,8 @@ repository. The workflow uses GitHub's OIDC identity and does not require an
 
 1. Merge the tagpr release pull request into `main`.
 2. The `tagpr` job creates the version tag and a draft GitHub release with
-   generated notes.
+   generated notes. If the merge already placed the release tag on `HEAD`,
+   the workflow reuses that tag instead of trying to create it again.
 3. The `publish-npm` job installs npm 11.5.1, publishes the matching package,
    and verifies the version on the public registry.
 4. Only after npm verification succeeds, the workflow publishes the GitHub
@@ -40,6 +41,13 @@ repository. The workflow uses GitHub's OIDC identity and does not require an
 
 If npm publishing fails, the GitHub release remains a draft so the failure can
 be repaired without presenting an incomplete release as public.
+
+If a retry finds a draft release whose tag is shown as `untagged-*`, the
+workflow associates that draft with the release tag before publishing it.
+
+The npm Trusted Publisher relationship is configured in npm account settings;
+repository permissions alone cannot create or repair that relationship. The
+workflow can only use the OIDC identity after the relationship exists.
 
 ## Local validation
 

--- a/tests/integration/codeql-workflow.test.ts
+++ b/tests/integration/codeql-workflow.test.ts
@@ -63,10 +63,10 @@ test("CodeQL preserves JavaScript analysis and adds a bounded Swift job", async 
   assert.match(workflow, /timeout-minutes: 25/);
   assert.match(workflow, /languages: swift/);
   assert.match(workflow, /build-mode: manual/);
-  assert.match(workflow, /timeout-minutes: 15/);
+  assert.match(workflow, /timeout-minutes: 20/);
   assert.match(
     workflow,
-    /\n      - name: Build Swift sources for CodeQL extraction\n        timeout-minutes: 15\n        run: \|/,
+    /\n      - name: Build Swift sources for CodeQL extraction\n        timeout-minutes: 20\n        run: \|/,
   );
 });
 
@@ -83,7 +83,7 @@ test("Swift CodeQL extraction uses the checked-in shim only", async () => {
   assert.match(swiftJob, /-target FramekitFinalCutWorkflowCodeQL/);
   assert.match(swiftJob, /-sdk macosx/);
   assert.match(swiftJob, /timeout-minutes: 25/);
-  assert.match(swiftJob, /timeout-minutes: 15/);
+  assert.match(swiftJob, /timeout-minutes: 20/);
   assert.match(swiftJob, /SWIFT_ACTIVE_COMPILATION_CONDITIONS=FRAMEKIT_CODEQL/);
   assert.match(swiftJob, /SWIFT_USE_INTEGRATED_DRIVER=NO/);
   assert.match(swiftJob, /SWIFT_OBJC_INTERFACE_HEADER_NAME=/);

--- a/tests/integration/codex-plugin.test.ts
+++ b/tests/integration/codex-plugin.test.ts
@@ -130,12 +130,13 @@ test("tagpr releases publish the package consumed by the plugin", async () => {
   assert.match(workflow, /publish-npm:/);
   assert.match(workflow, /publish-npm:[\s\S]*?actions\/checkout@v4\s+with:\s+persist-credentials:\s+false/);
   assert.match(workflow, /needs:\s+tagpr/);
-  assert.match(workflow, /needs\.tagpr\.outputs\.tagpr-tag != ''/);
+  assert.match(workflow, /needs\.tagpr\.outputs\.release-tag != ''/);
+  assert.match(workflow, /git tag --points-at HEAD/);
   assert.match(workflow, /id-token:\s+write/);
   assert.match(workflow, /npm install --global npm@11\.5\.1/);
   assert.match(workflow, /npm publish --access public/);
   assert.doesNotMatch(workflow, /NODE_AUTH_TOKEN:\s+\$\{\{ secrets\.NPM_TOKEN \}\}/);
-  assert.match(workflow, /gh release edit [\s\S]*--draft=false/);
+  assert.match(workflow, /gh api --method PATCH [\s\S]*-F draft=false/);
   assert.ok(
     workflow.indexOf("Verify npm publication") < workflow.indexOf("Publish GitHub release"),
     "the GitHub release must be published only after npm verification",

--- a/tests/integration/codex-plugin.test.ts
+++ b/tests/integration/codex-plugin.test.ts
@@ -132,6 +132,7 @@ test("tagpr releases publish the package consumed by the plugin", async () => {
   assert.match(workflow, /needs:\s+tagpr/);
   assert.match(workflow, /needs\.tagpr\.outputs\.release-tag != ''/);
   assert.match(workflow, /git tag --points-at HEAD/);
+  assert.match(workflow, /tagpr:[\s\S]*?persist-credentials: false/);
   assert.match(workflow, /id-token:\s+write/);
   assert.match(workflow, /npm install --global npm@11\.5\.1/);
   assert.match(workflow, /npm publish --access public/);

--- a/tests/integration/release-workflow.test.ts
+++ b/tests/integration/release-workflow.test.ts
@@ -80,8 +80,20 @@ test("release workflow validates the package before publishing", async () => {
   assert.ok(validation < publication, "release validation must run before npm publish");
   assert.match(workflow, /GITHUB_REPOSITORY: \$\{\{ github\.repository \}\}/);
   assert.match(workflow, /release-tag: \$\{\{ steps\.existing-tag\.outputs\.tag \|\| steps\.run-tagpr\.outputs\.tag \}\}/);
-  assert.match(workflow, /git tag --points-at HEAD/);
+  const tagDetection = workflow.slice(
+    workflow.indexOf("name: Detect release tag on HEAD"),
+    workflow.indexOf("name: Run tagpr"),
+  );
+  assert.match(tagDetection, /git tag --points-at HEAD --list 'v\*'/);
+  assert.match(tagDetection, /mapfile -t tags/);
+  assert.match(tagDetection, /\$\{#tags\[@\]\} > 1/);
+  assert.match(tagDetection, /Multiple release tags point to HEAD/);
+  assert.doesNotMatch(tagDetection, /head -n 1/);
   assert.match(workflow, /if: steps\.existing-tag\.outputs\.tag == ''/);
+  assert.match(
+    workflow,
+    /tagpr:[\s\S]*?actions\/checkout@v4[\s\S]*?token: \$\{\{ secrets\.TAGPR_TOKEN \}\}[\s\S]*?persist-credentials: false/,
+  );
   assert.match(workflow, /RELEASE_TAG: \$\{\{ needs\.tagpr\.outputs\.release-tag \}\}/);
   assert.match(workflow, /releases\/\$\{release_id\}/);
 });

--- a/tests/integration/release-workflow.test.ts
+++ b/tests/integration/release-workflow.test.ts
@@ -79,7 +79,11 @@ test("release workflow validates the package before publishing", async () => {
   assert.notEqual(validation, -1);
   assert.ok(validation < publication, "release validation must run before npm publish");
   assert.match(workflow, /GITHUB_REPOSITORY: \$\{\{ github\.repository \}\}/);
-  assert.match(workflow, /RELEASE_TAG: \$\{\{ needs\.tagpr\.outputs\.tagpr-tag \}\}/);
+  assert.match(workflow, /release-tag: \$\{\{ steps\.existing-tag\.outputs\.tag \|\| steps\.run-tagpr\.outputs\.tag \}\}/);
+  assert.match(workflow, /git tag --points-at HEAD/);
+  assert.match(workflow, /if: steps\.existing-tag\.outputs\.tag == ''/);
+  assert.match(workflow, /RELEASE_TAG: \$\{\{ needs\.tagpr\.outputs\.release-tag \}\}/);
+  assert.match(workflow, /releases\/\$\{release_id\}/);
 });
 
 test("release documentation provides the exact npm trust command", async () => {


### PR DESCRIPTION
## Summary

- reuse a release tag already pointing at `main` HEAD instead of asking tagpr to recreate it
- restore an existing `untagged-*` draft release to the release tag before publishing
- document retry behavior and the external npm Trusted Publisher prerequisite

## Validation

- `pnpm run build`
- `pnpm run test` (442 passed under Node 22)
- `pnpm run check:boundaries`
- release workflow focused tests
- package distribution tests
- `git diff --check`

The npm Trusted Publisher relationship remains npm account configuration and is not changed by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Release Process**
  - Improved release handling when a version tag already exists, including reliable draft-release publication and retry support.
  - Release jobs now consistently share the resolved release tag.
  - Releases now fail safely when multiple tags are found for the same commit.

- **Documentation**
  - Updated setup instructions for pnpm 11.24.0.
  - Clarified tag reuse, release retries, and npm Trusted Publishing requirements.

- **Chores**
  - Updated automated workflows and validation to use pnpm 11.24.0 and the revised release process.
  - Increased the Swift CodeQL analysis timeout to 20 minutes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->