### PR TITLE
feat: define the editor-independent Skill contract

### DIFF
--- a/docs/adr/0008-skill-contract.md
+++ b/docs/adr/0008-skill-contract.md
@@ -1,0 +1,58 @@
+# ADR 0008: Editor-independent Skill contract
+
+## Status
+
+Accepted for the v0.0.2 Skill runtime.
+
+## Context
+
+Framekit already has specialized filler-removal and dialogue-normalization
+workflows, but their manifests and handlers are coupled to the MCP server and
+to individual runtime services. A reusable Skill needs a public contract that
+can be inspected and planned without importing MCP or Final Cut code.
+
+## Decision
+
+`@framekit/runtime` owns the versioned Skill contract. A `SkillManifest` is
+metadata: a stable ID, semantic version, title, description, transport-neutral
+input schema, capability requirements, and optional verification defaults.
+
+The executable `SkillHandler` is kept separate from the manifest. It receives a
+read-only `SkillPlanningContext` containing a project snapshot, runtime
+capabilities, and base revision. It returns semantic `WorkflowOperation`s,
+affected ranges, and warnings. It never receives an editor adapter.
+
+The lifecycle is explicitly ordered:
+
+```text
+discover → resolve → plan → preview → execute → verify → accept | rollback
+```
+
+`SkillPlan` records the pinned Skill identity, base revision, normalized input,
+semantic operations, affected ranges, and warnings. `SkillExecution` records
+the plan reference, transaction IDs, verification result, and rollback result.
+Preview is a runtime session concern and must not mutate editor state; execution
+is a runtime transaction concern and may proceed only after requirement
+resolution and preview-token validation.
+
+## Scope boundaries
+
+- v0.0.2 defines the public contract, deterministic requirement resolution,
+  in-process registration, preview sessions, generic MCP mapping, and the
+  neutral conformance fixture.
+- v0.0.3 builds product Skills such as filler removal and dialogue
+  normalization on the generic contract.
+- v0.0.4 may add observability and workflow history after the safety contract is
+  stable.
+
+Dynamic package discovery, arbitrary third-party code loading, sandboxing, and
+persistent workflow history are deferred. No Skill contract type contains a
+Final Cut-specific command or adapter type.
+
+## Consequences
+
+The runtime can validate and inspect Skills without knowing their transport or
+editor implementation. Existing specialized workflows remain compatible while
+they are migrated behind the generic runtime. The contract intentionally uses
+semantic operations and capability names, so adapters remain responsible for
+mapping those semantics to editor-specific mechanisms.

--- a/docs/mcp/skills.md
+++ b/docs/mcp/skills.md
@@ -1,5 +1,18 @@
 # Generic MCP Skills
 
+Framekit's public Skill contract lives in `@framekit/runtime`. A manifest is
+metadata and an executable handler is separate from it; handlers receive a
+read-only planning context and return semantic operations. Skill implementations
+must not call Final Cut or another editor adapter directly.
+
+The lifecycle is:
+
+```text
+discover → resolve → plan → preview → execute → verify → accept | rollback
+```
+
+The v0.0.2 contract is documented in [ADR 0008](../adr/0008-skill-contract.md).
+
 Framekit Skills describe editing knowledge and use generic MCP tools. A Skill
 contains no Final Cut-specific commands; editor and analyzer capabilities are
 resolved by the runtime before mutation.

--- a/packages/runtime/src/domain/index.ts
+++ b/packages/runtime/src/domain/index.ts
@@ -9,3 +9,4 @@ export * from "./ports.js";
 export * from "./verification.js";
 export * from "./rough-cut.js";
 export * from "./duration.js";
+export * from "./skills.js";

--- a/packages/runtime/src/domain/skills.ts
+++ b/packages/runtime/src/domain/skills.ts
@@ -1,0 +1,145 @@
+import type { RuntimeCapabilities } from "./capabilities.js";
+import type { ContextRevision, TimeRange } from "./primitives.js";
+import type { ProjectSnapshot } from "./project.js";
+import type { WorkflowOperation } from "./editing.js";
+import type { VerificationPolicy, VerificationReport } from "./verification.js";
+
+/** Version of the editor-independent Skill contract. */
+export const SKILL_CONTRACT_VERSION = 1 as const;
+
+/** The ordered phases shared by every Skill implementation. */
+export const SKILL_LIFECYCLE = [
+  "discover",
+  "resolve",
+  "plan",
+  "preview",
+  "execute",
+  "verify",
+  "accept",
+  "rollback",
+] as const;
+
+export type SkillLifecyclePhase = (typeof SKILL_LIFECYCLE)[number];
+
+export type SkillSchema =
+  | { type: "string"; description?: string; enum?: string[]; minLength?: number }
+  | { type: "number"; description?: string; minimum?: number; maximum?: number }
+  | { type: "integer"; description?: string; minimum?: number; maximum?: number }
+  | { type: "boolean"; description?: string }
+  | { type: "array"; description?: string; items: SkillSchema; minItems?: number }
+  | { type: "object"; description?: string; properties: Record<string, SkillSchema>; required?: string[]; additionalProperties?: boolean };
+
+/** A transport-neutral input schema carried by a Skill manifest. */
+export interface SkillInputSchema {
+  type: "object";
+  properties: Record<string, SkillSchema>;
+  required?: string[];
+  additionalProperties?: boolean;
+}
+
+export type EditorSkillCapability =
+  | "projectRead"
+  | "timelineSnapshotRead"
+  | "timelineWrite"
+  | "timelineArtifactWrite"
+  | "readAfterWrite"
+  | "rollback"
+  | "assetDiscovery"
+  | "liveStateRead"
+  | "playheadWrite"
+  | "frameCapture"
+  | "artifactPublish"
+  | "projectCatalogRead"
+  | "projectSelection"
+  | "compositeTransactions"
+  | "videoExport"
+  | "mediaImport"
+  | "mediaPlacement"
+  | "titlePlacement"
+  | "clipMove"
+  | "clipReplace"
+  | "clipRemoval"
+  | "transitionPlacement"
+  | "audioAttachment"
+  | "audioMixing";
+
+export type AnalyzerSkillCapability =
+  | "speechTranscribe"
+  | "speechVad"
+  | "audioLoudness"
+  | "visualTrack"
+  | "metadataDescribe";
+
+/** Semantic operation names are deliberately independent of editor commands. */
+export type SkillOperation = WorkflowOperation["type"];
+
+export type SkillRequirement =
+  | { type: "allOf"; requirements: SkillRequirement[] }
+  | { type: "anyOf"; requirements: SkillRequirement[] }
+  | { type: "editor"; capability: EditorSkillCapability }
+  | { type: "analyzer"; capability: AnalyzerSkillCapability }
+  | { type: "operation"; operation: SkillOperation };
+
+export interface SkillManifest {
+  contractVersion: typeof SKILL_CONTRACT_VERSION;
+  id: string;
+  version: string;
+  title: string;
+  description: string;
+  inputSchema: SkillInputSchema;
+  requirements: SkillRequirement;
+  verification?: VerificationPolicy;
+}
+
+export interface SkillPlanningContext {
+  /** The snapshot is read-only input to a handler; it is not an adapter. */
+  project: ProjectSnapshot;
+  capabilities: RuntimeCapabilities;
+  baseRevision: ContextRevision;
+}
+
+export interface SkillPlan {
+  id: string;
+  skillId: string;
+  skillVersion: string;
+  baseRevision: ContextRevision;
+  normalizedInput: Record<string, unknown>;
+  operations: WorkflowOperation[];
+  affectedRanges: TimeRange[];
+  warnings: string[];
+}
+
+export interface SkillPreview {
+  previewToken: string;
+  plan: SkillPlan;
+  expectedDiff?: unknown;
+  expiresAt: string;
+}
+
+export type SkillExecutionStatus = "VERIFIED" | "ROLLED_BACK" | "FAILED" | "SKIPPED";
+
+export interface SkillRollbackResult {
+  attempted: boolean;
+  succeeded: boolean;
+  transactionIds: string[];
+  reason?: string;
+}
+
+export interface SkillExecution {
+  status: SkillExecutionStatus;
+  plan: Pick<SkillPlan, "id" | "skillId" | "skillVersion" | "baseRevision">;
+  transactionIds: string[];
+  verification?: VerificationReport;
+  rollback: SkillRollbackResult;
+}
+
+export interface SkillHandler<Input extends Record<string, unknown> = Record<string, unknown>> {
+  normalize(input: unknown): Promise<Input> | Input;
+  plan(context: SkillPlanningContext, input: Input): Promise<Omit<SkillPlan, "id" | "skillId" | "skillVersion" | "baseRevision" | "normalizedInput">> | Omit<SkillPlan, "id" | "skillId" | "skillVersion" | "baseRevision" | "normalizedInput">;
+}
+
+/** Metadata and executable behavior are separate so manifests remain inspectable. */
+export interface SkillDefinition<Input extends Record<string, unknown> = Record<string, unknown>> {
+  manifest: SkillManifest;
+  handler: SkillHandler<Input>;
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -8,6 +8,7 @@ export * from "./capabilities.js";
 export * from "./timeline/snapshot-digest.js";
 export * from "./speech/filler-removal.js";
 export * from "./audio/dialogue-normalization.js";
+export * from "./domain/skills.js";
 export type { RuntimeOptions } from "./application/runtime-options.js";
 export * from "./speech/filler-detector.js";
 export * from "./speech/safe-cut-resolver.js";

--- a/tests/integration/skill-contract.test.ts
+++ b/tests/integration/skill-contract.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  SKILL_CONTRACT_VERSION,
+  SKILL_LIFECYCLE,
+  type SkillDefinition,
+} from "@framekit/runtime";
+
+test("the public Skill contract exposes the editor-independent lifecycle", () => {
+  const markerSkill: SkillDefinition = {
+    manifest: {
+      contractVersion: SKILL_CONTRACT_VERSION,
+      id: "fixture.add-marker",
+      version: "0.0.1",
+      title: "Add marker",
+      description: "Add one semantic marker to a timeline.",
+      inputSchema: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+      requirements: { type: "operation", operation: "add-marker" },
+    },
+    handler: {
+      normalize: (input) => (input && typeof input === "object" ? input as Record<string, unknown> : {}),
+      plan: () => ({ operations: [], affectedRanges: [], warnings: [] }),
+    },
+  };
+
+  assert.equal(markerSkill.manifest.contractVersion, 1);
+  assert.deepEqual(SKILL_LIFECYCLE, [
+    "discover", "resolve", "plan", "preview", "execute", "verify", "accept", "rollback",
+  ]);
+  assert.equal(markerSkill.manifest.requirements.type, "operation");
+});


### PR DESCRIPTION
## Summary

Closes #33.

- adds the public editor-independent Skill manifest, requirement, plan, preview, handler, and execution contracts
- defines the discover-to-rollback lifecycle and keeps handlers separate from manifest metadata
- documents the architecture and v0.0.2/v0.0.3/v0.0.4 scope boundaries

## Validation

- `PATH=/Users/shotomorisaki/.nix-profile/bin:$PATH pnpm run build`
- `PATH=/Users/shotomorisaki/.nix-profile/bin:$PATH pnpm exec tsx --test tests/integration/skill-contract.test.ts`
- `PATH=/Users/shotomorisaki/.nix-profile/bin:$PATH pnpm run check:boundaries`
- full deterministic test suite: 441 passed; package smoke tests pass when run directly under Nix Node 22

The repository pre-commit wrapper still reproduces the existing Corepack/Node 23 `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING` only for its nested `npm pack` invocation; no package or hook changes are included.
