### PR TITLE
feat: add the generic Skill runtime

### DIFF
--- a/docs/architecture/skill-runtime.md
+++ b/docs/architecture/skill-runtime.md
@@ -1,0 +1,19 @@
+# Generic Skill runtime
+
+`SkillRuntime` and `SkillRegistry` live under `@framekit/runtime`. Registration
+is in-process and rejects duplicate ID/version pairs. Listing is sorted by
+stable ID and semantic version; lookup can pin an exact version or select the
+highest registered version.
+
+The runtime resolves a manifest against the active session before invoking a
+handler. It validates the manifest input schema, normalizes input, and gives
+the handler only a frozen read-only planning context containing a project
+snapshot, capabilities, and base revision. The handler returns semantic
+operations; it never receives an editor adapter.
+
+Preview creates a runtime-issued, short-lived token and delegates the semantic
+operations to the existing non-mutating composite preview boundary. Execution
+consumes the token before checking expiry or revision, rechecks current
+requirements, and delegates to the transaction manager. Verification failures
+are returned as a rolled-back Skill execution with transaction and rollback
+evidence. Unknown, expired, reused, or stale tokens fail closed.

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -10,6 +10,7 @@ export * from "./speech/filler-removal.js";
 export * from "./audio/dialogue-normalization.js";
 export * from "./domain/skills.js";
 export * from "./skills/requirements.js";
+export * from "./skills/index.js";
 export type { RuntimeOptions } from "./application/runtime-options.js";
 export * from "./speech/filler-detector.js";
 export * from "./speech/safe-cut-resolver.js";

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -38,6 +38,8 @@ import type {
   DurationPolicyPlan,
   DurationPolicyRequest,
 } from "./domain/index.js";
+import type { SkillDefinition, SkillExecution, SkillManifest, SkillPreview } from "./domain/skills.js";
+import type { SkillPreviewRequest } from "./skills/runtime.js";
 import { planRoughCutConstruction as buildRoughCutConstructionPlan } from "./domain/rough-cut.js";
 import type { FillerRemovalPreview, FillerRemovalRequest } from "./speech/filler-removal.js";
 import { DefaultVerificationEngine } from "./verification/verification.js";
@@ -51,6 +53,7 @@ import type { RuntimeOptions } from "./application/runtime-options.js";
 import { TransactionStore } from "./application/transaction-store.js";
 import { DurationPolicyService } from "./application/duration-policy-service.js";
 import { DialogueNormalizationService } from "./editing/dialogue-normalization-service.js";
+import { SkillRuntime } from "./skills/runtime.js";
 import type {
   DialogueNormalizationPreview,
   DialogueNormalizationRequest,
@@ -66,6 +69,7 @@ export class AgentVideoRuntime {
   private readonly fillerRemoval: FillerRemovalService;
   private readonly durationPolicy: DurationPolicyService;
   private readonly dialogueNormalization: DialogueNormalizationService;
+  private readonly skills: SkillRuntime;
 
   public constructor(
     adapter: EditorPort,
@@ -82,6 +86,7 @@ export class AgentVideoRuntime {
     this.fillerRemoval = new FillerRemovalService(adapter, this.projects, verificationEngine, options, transactions);
     this.dialogueNormalization = new DialogueNormalizationService(adapter, this.projects, this.media, this.edits);
     this.durationPolicy = new DurationPolicyService();
+    this.skills = new SkillRuntime(this.projects, this.edits, options);
   }
 
   public async inspectProject(): Promise<ProjectSnapshot> {
@@ -202,6 +207,26 @@ export class AgentVideoRuntime {
 
   public async executeDialogueNormalization(previewToken: string): Promise<EditTransaction> {
     return this.dialogueNormalization.execute(previewToken);
+  }
+
+  public registerSkill(definition: SkillDefinition): void {
+    this.skills.register(definition);
+  }
+
+  public listSkills(): SkillManifest[] {
+    return this.skills.list();
+  }
+
+  public inspectSkill(skillId: string, version?: string): SkillManifest {
+    return this.skills.inspect(skillId, version);
+  }
+
+  public previewSkill(request: SkillPreviewRequest): Promise<SkillPreview> {
+    return this.skills.preview(request);
+  }
+
+  public executeSkill(previewToken: string): Promise<SkillExecution> {
+    return this.skills.execute(previewToken);
   }
 
   public async changesSince(revision: ContextRevision): Promise<TimelineDiff> {

--- a/packages/runtime/src/skills/index.ts
+++ b/packages/runtime/src/skills/index.ts
@@ -1,0 +1,3 @@
+export * from "./registry.js";
+export * from "./requirements.js";
+export * from "./runtime.js";

--- a/packages/runtime/src/skills/registry.ts
+++ b/packages/runtime/src/skills/registry.ts
@@ -1,0 +1,69 @@
+import type { SkillDefinition, SkillManifest } from "../domain/skills.js";
+
+export class SkillRegistry {
+  private readonly definitions = new Map<string, Map<string, SkillDefinition>>();
+
+  public register(definition: SkillDefinition): void {
+    validateManifest(definition.manifest);
+    const versions = this.definitions.get(definition.manifest.id) ?? new Map<string, SkillDefinition>();
+    if (versions.has(definition.manifest.version)) {
+      throw new Error(`SKILL_DUPLICATE: ${definition.manifest.id}@${definition.manifest.version} is already registered`);
+    }
+    versions.set(definition.manifest.version, definition);
+    this.definitions.set(definition.manifest.id, versions);
+  }
+
+  public list(): SkillManifest[] {
+    return [...this.definitions.values()]
+      .flatMap((versions) => [...versions.values()])
+      .sort((left, right) => left.manifest.id.localeCompare(right.manifest.id)
+        || compareVersions(left.manifest.version, right.manifest.version))
+      .map((definition) => structuredClone(definition.manifest));
+  }
+
+  public inspect(skillId: string, version?: string): SkillManifest {
+    return structuredClone(this.lookup(skillId, version).manifest);
+  }
+
+  public lookup(skillId: string, version?: string): SkillDefinition {
+    const versions = this.definitions.get(skillId);
+    if (!versions) throw new Error(`SKILL_NOT_FOUND: ${skillId}`);
+    if (version !== undefined) {
+      const definition = versions.get(version);
+      if (!definition) throw new Error(`SKILL_VERSION_NOT_FOUND: ${skillId}@${version}`);
+      return definition;
+    }
+    const definition = [...versions.values()].sort((left, right) => compareVersions(right.manifest.version, left.manifest.version))[0];
+    if (!definition) throw new Error(`SKILL_NOT_FOUND: ${skillId}`);
+    return definition;
+  }
+}
+
+export function validateManifest(manifest: SkillManifest): void {
+  if (manifest.contractVersion !== 1) throw new Error("SKILL_MANIFEST_INVALID: unsupported contract version");
+  if (!/^[a-z0-9]+(?:[._-][a-z0-9]+)*$/i.test(manifest.id)) throw new Error("SKILL_MANIFEST_INVALID: id must be stable and non-empty");
+  if (!isSemanticVersion(manifest.version)) throw new Error(`SKILL_MANIFEST_INVALID: version ${manifest.version} is not semantic`);
+  if (!manifest.title.trim() || !manifest.description.trim()) throw new Error("SKILL_MANIFEST_INVALID: title and description are required");
+  if (manifest.inputSchema.type !== "object") throw new Error("SKILL_MANIFEST_INVALID: inputSchema must be an object schema");
+}
+
+function isSemanticVersion(version: string): boolean {
+  return /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.test(version);
+}
+
+function compareVersions(left: string, right: string): number {
+  const a = parseVersion(left);
+  const b = parseVersion(right);
+  for (let index = 0; index < 3; index += 1) {
+    if (a.numbers[index] !== b.numbers[index]) return a.numbers[index]! - b.numbers[index]!;
+  }
+  if (!a.prerelease && !b.prerelease) return 0;
+  if (!a.prerelease) return 1;
+  if (!b.prerelease) return -1;
+  return a.prerelease.localeCompare(b.prerelease);
+}
+
+function parseVersion(version: string): { numbers: number[]; prerelease?: string } {
+  const [core, prerelease] = version.split("-");
+  return { numbers: core!.split(".").map(Number), ...(prerelease ? { prerelease } : {}) };
+}

--- a/packages/runtime/src/skills/runtime.ts
+++ b/packages/runtime/src/skills/runtime.ts
@@ -1,0 +1,219 @@
+import { randomUUID } from "node:crypto";
+import type { ProjectService } from "../application/project-service.js";
+import type { RuntimeOptions } from "../application/runtime-options.js";
+import type { ContextRevision } from "../domain/primitives.js";
+import type {
+  SkillDefinition,
+  SkillExecution,
+  SkillInputSchema,
+  SkillManifest,
+  SkillPlan,
+  SkillPreview,
+} from "../domain/skills.js";
+import type { EditService } from "../editing/edit-service.js";
+import { sameRevision } from "../context/revision.js";
+import {
+  assertSkillRequirements,
+  type SkillAvailability,
+} from "./requirements.js";
+import { SkillRegistry } from "./registry.js";
+
+export interface SkillPreviewRequest {
+  skillId: string;
+  version?: string;
+  baseRevision: ContextRevision;
+  input: unknown;
+}
+
+interface SkillPreviewSession {
+  preview: SkillPreview;
+  editPreviewToken: string;
+}
+
+export class SkillRuntime {
+  public readonly registry = new SkillRegistry();
+  private readonly previews = new Map<string, SkillPreviewSession>();
+
+  public constructor(
+    private readonly project: ProjectService,
+    private readonly edits: EditService,
+    private readonly options: RuntimeOptions = {},
+  ) {}
+
+  public register(definition: SkillDefinition): void {
+    this.registry.register(definition);
+  }
+
+  public list(): SkillManifest[] {
+    return this.registry.list();
+  }
+
+  public inspect(skillId: string, version?: string): SkillManifest {
+    return this.registry.inspect(skillId, version);
+  }
+
+  public async preview(request: SkillPreviewRequest): Promise<SkillPreview> {
+    const definition = this.registry.lookup(request.skillId, request.version);
+    const before = await this.project.inspectProject();
+    if (!sameRevision(request.baseRevision, before.revision)) {
+      throw new Error("STALE_CONTEXT: Skill preview base revision does not match current editor state");
+    }
+    const inspected = await this.project.inspectEditor();
+    const availability = assertSkillRequirements(definition.manifest, {
+      capabilities: inspected.capabilities,
+      editor: inspected.identity,
+      revision: before.revision,
+    });
+    this.assertInputSchema(definition.manifest.inputSchema, request.input);
+    const normalizedInput = await normalizeInput(definition, request.input);
+    const handlerContext = Object.freeze({
+      project: structuredClone(before),
+      capabilities: structuredClone(inspected.capabilities),
+      baseRevision: structuredClone(before.revision),
+    });
+    const planned = await definition.handler.plan(handlerContext, normalizedInput);
+    const plan: SkillPlan = {
+      id: `plan-${randomUUID()}`,
+      skillId: definition.manifest.id,
+      skillVersion: definition.manifest.version,
+      baseRevision: structuredClone(before.revision),
+      normalizedInput: structuredClone(normalizedInput),
+      operations: structuredClone(planned.operations),
+      affectedRanges: structuredClone(planned.affectedRanges),
+      warnings: [...planned.warnings],
+    };
+    if (plan.operations.length === 0) throw new Error("SKILL_PLAN_INVALID: at least one semantic operation is required");
+    const editPreview = await this.edits.previewEdit({
+      baseRevision: before.revision,
+      operations: plan.operations,
+      verification: definition.manifest.verification,
+    });
+    const previewToken = `skill-preview-${randomUUID()}`;
+    const preview: SkillPreview = {
+      previewToken,
+      plan,
+      expectedDiff: editPreview.expectedDiff,
+      expiresAt: editPreview.expiresAt,
+    };
+    this.prunePreviews();
+    this.previews.set(previewToken, { preview, editPreviewToken: editPreview.previewToken });
+    return structuredClone(preview);
+  }
+
+  public async execute(previewToken: string): Promise<SkillExecution> {
+    const session = this.previews.get(previewToken);
+    if (!session) throw new Error(`SKILL_PREVIEW_TOKEN_INVALID: unknown or already used preview ${previewToken}`);
+    this.previews.delete(previewToken);
+    if (this.now() > Date.parse(session.preview.expiresAt)) {
+      throw new Error("SKILL_PREVIEW_TOKEN_EXPIRED: Skill preview has expired");
+    }
+    const definition = this.registry.lookup(session.preview.plan.skillId, session.preview.plan.skillVersion);
+    const before = await this.project.inspectProject();
+    if (!sameRevision(session.preview.plan.baseRevision, before.revision)) {
+      throw new Error("STALE_CONTEXT: Skill preview base revision does not match current editor state");
+    }
+    const inspected = await this.project.inspectEditor();
+    assertSkillRequirements(definition.manifest, {
+      capabilities: inspected.capabilities,
+      editor: inspected.identity,
+      revision: before.revision,
+    });
+    const transaction = await this.edits.executeEdit(session.editPreviewToken);
+    const rolledBack = transaction.status === "ROLLED_BACK";
+    return {
+      status: rolledBack ? "ROLLED_BACK" : transaction.status === "VERIFIED" ? "VERIFIED" : "FAILED",
+      plan: {
+        id: session.preview.plan.id,
+        skillId: session.preview.plan.skillId,
+        skillVersion: session.preview.plan.skillVersion,
+        baseRevision: structuredClone(session.preview.plan.baseRevision),
+      },
+      transactionIds: [transaction.id],
+      ...(transaction.verification ? { verification: structuredClone(transaction.verification) } : {}),
+      rollback: {
+        attempted: rolledBack,
+        succeeded: rolledBack,
+        transactionIds: rolledBack ? [transaction.id] : [],
+      },
+    };
+  }
+
+  private assertInputSchema(schema: SkillInputSchema, input: unknown): asserts input is Record<string, unknown> {
+    if (!isRecord(input)) throw new Error("SKILL_INPUT_INVALID: input must be an object");
+    for (const required of schema.required ?? []) {
+      if (!(required in input)) throw new Error(`SKILL_INPUT_INVALID: missing required input ${required}`);
+    }
+    if (schema.additionalProperties === false) {
+      for (const key of Object.keys(input)) {
+        if (!(key in schema.properties)) throw new Error(`SKILL_INPUT_INVALID: unknown input ${key}`);
+      }
+    }
+    for (const [key, property] of Object.entries(schema.properties)) {
+      if (key in input) validateSchemaValue(property, input[key], key);
+    }
+  }
+
+  private prunePreviews(): void {
+    const now = this.now();
+    for (const [token, session] of this.previews) {
+      if (now > Date.parse(session.preview.expiresAt)) this.previews.delete(token);
+    }
+    const limit = Number.isInteger(this.options.maxActivePreviews) && this.options.maxActivePreviews! > 0
+      ? this.options.maxActivePreviews!
+      : 128;
+    while (this.previews.size >= limit) {
+      const oldest = this.previews.keys().next().value;
+      if (oldest === undefined) break;
+      this.previews.delete(oldest);
+    }
+  }
+
+  private now(): number {
+    return this.options.now?.() ?? Date.now();
+  }
+}
+
+async function normalizeInput(definition: SkillDefinition, input: Record<string, unknown>): Promise<Record<string, unknown>> {
+  try {
+    const normalized = await definition.handler.normalize(input);
+    if (!isRecord(normalized)) throw new Error("normalized input must be an object");
+    return normalized;
+  } catch (error) {
+    throw new Error(`SKILL_INPUT_INVALID: ${String(error)}`);
+  }
+}
+
+function validateSchemaValue(schema: SkillInputSchema["properties"][string], value: unknown, path: string): void {
+  if (schema.type === "object") {
+    if (!isRecord(value)) throw new Error(`SKILL_INPUT_INVALID: ${path} must be an object`);
+    return;
+  }
+  if (schema.type === "array") {
+    if (!Array.isArray(value)) throw new Error(`SKILL_INPUT_INVALID: ${path} must be an array`);
+    if (schema.minItems !== undefined && value.length < schema.minItems) throw new Error(`SKILL_INPUT_INVALID: ${path} has too few items`);
+    value.forEach((item, index) => validateSchemaValue(schema.items, item, `${path}[${index}]`));
+    return;
+  }
+  const valid = schema.type === "string"
+    ? typeof value === "string"
+    : schema.type === "boolean"
+      ? typeof value === "boolean"
+      : typeof value === "number" && Number.isFinite(value) && (schema.type !== "integer" || Number.isInteger(value));
+  if (!valid) throw new Error(`SKILL_INPUT_INVALID: ${path} has type ${schema.type}`);
+  if (schema.type === "string" && schema.minLength !== undefined && (value as string).length < schema.minLength) {
+    throw new Error(`SKILL_INPUT_INVALID: ${path} is too short`);
+  }
+  if ((schema.type === "number" || schema.type === "integer") && schema.minimum !== undefined && (value as number) < schema.minimum) {
+    throw new Error(`SKILL_INPUT_INVALID: ${path} is below minimum`);
+  }
+  if ((schema.type === "number" || schema.type === "integer") && schema.maximum !== undefined && (value as number) > schema.maximum) {
+    throw new Error(`SKILL_INPUT_INVALID: ${path} is above maximum`);
+  }
+  if (schema.type === "string" && schema.enum && !schema.enum.includes(value as string)) {
+    throw new Error(`SKILL_INPUT_INVALID: ${path} is not an allowed value`);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/tests/integration/skill-runtime.test.ts
+++ b/tests/integration/skill-runtime.test.ts
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  AgentVideoRuntime,
+  type SkillDefinition,
+  type VerificationEngine,
+} from "@framekit/runtime";
+import { InMemoryEditorAdapter } from "@framekit/testkit";
+
+function createSkillRuntime(options: ConstructorParameters<typeof AgentVideoRuntime>[1] = {}) {
+  const adapter = new InMemoryEditorAdapter({
+    projectId: "skill-runtime-project",
+    projectName: "Skill Runtime",
+    timelineId: "skill-runtime-timeline",
+    timelineName: "Main Edit",
+    clips: [],
+  });
+  return { adapter, runtime: new AgentVideoRuntime(adapter, options) };
+}
+
+function markerSkill(planCalls: { value: number } = { value: 0 }): SkillDefinition {
+  return {
+    manifest: {
+      contractVersion: 1,
+      id: "fixture.add-marker",
+      version: "1.0.0",
+      title: "Add marker",
+      description: "Add a deterministic marker.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          name: { type: "string", minLength: 1 },
+          start: { type: "number", minimum: 0 },
+        },
+        required: ["name", "start"],
+        additionalProperties: false,
+      },
+      requirements: {
+        type: "allOf",
+        requirements: [
+          { type: "editor", capability: "timelineSnapshotRead" },
+          { type: "editor", capability: "timelineWrite" },
+          { type: "editor", capability: "rollback" },
+          { type: "operation", operation: "add-marker" },
+        ],
+      },
+    },
+    handler: {
+      normalize: (input) => input as Record<string, unknown>,
+      plan: (context, input) => {
+        planCalls.value += 1;
+        assert.equal("adapter" in context, false);
+        return {
+          operations: [{
+            type: "add-marker" as const,
+            timelineId: context.project.timeline.id,
+            marker: {
+              id: `marker-${String(input.start)}`,
+              start: input.start as number,
+              duration: 0,
+              name: input.name as string,
+            },
+            baseRevision: context.baseRevision,
+          }],
+          affectedRanges: [{ start: input.start as number, end: input.start as number }],
+          warnings: [],
+        };
+      },
+    },
+  };
+}
+
+test("registry rejects duplicates and resolves deterministic version ordering", () => {
+  const { runtime } = createSkillRuntime();
+  const v1 = markerSkill();
+  const v2 = { ...v1, manifest: { ...v1.manifest } };
+  v2.manifest.version = "2.0.0";
+  runtime.registerSkill(v2);
+  runtime.registerSkill(v1);
+
+  assert.deepEqual(runtime.listSkills().map((skill) => `${skill.id}@${skill.version}`), [
+    "fixture.add-marker@1.0.0",
+    "fixture.add-marker@2.0.0",
+  ]);
+  assert.equal(runtime.inspectSkill("fixture.add-marker").version, "2.0.0");
+  assert.throws(() => runtime.registerSkill(v1), /SKILL_DUPLICATE/);
+  assert.throws(() => runtime.inspectSkill("missing"), /SKILL_NOT_FOUND/);
+  assert.throws(() => runtime.inspectSkill("fixture.add-marker", "9.0.0"), /SKILL_VERSION_NOT_FOUND/);
+});
+
+test("preview is isolated and execute uses the transaction boundary", async () => {
+  const { runtime } = createSkillRuntime();
+  runtime.registerSkill(markerSkill());
+  const before = await runtime.inspectProject();
+  const preview = await runtime.previewSkill({
+    skillId: "fixture.add-marker",
+    baseRevision: before.revision,
+    input: { name: "Review", start: 2 },
+  });
+
+  assert.match(preview.previewToken, /^skill-preview-/);
+  assert.equal(preview.plan.skillVersion, "1.0.0");
+  assert.equal(preview.plan.operations[0]?.type, "add-marker");
+  assert.deepEqual(await runtime.inspectProject(), before);
+
+  const execution = await runtime.executeSkill(preview.previewToken);
+  assert.equal(execution.status, "VERIFIED");
+  assert.equal(execution.rollback.attempted, false);
+  assert.equal(execution.transactionIds.length, 1);
+  const after = await runtime.inspectProject();
+  assert.equal(after.timeline.markers[0]?.name, "Review");
+});
+
+test("input validation and requirement resolution happen before the handler", async () => {
+  const { runtime } = createSkillRuntime();
+  const calls = { value: 0 };
+  runtime.registerSkill(markerSkill(calls));
+  const before = await runtime.inspectProject();
+
+  await assert.rejects(runtime.previewSkill({
+    skillId: "fixture.add-marker",
+    baseRevision: before.revision,
+    input: { name: "", start: 0 },
+  }), /SKILL_INPUT_INVALID/);
+  assert.equal(calls.value, 0);
+
+  const unavailable = markerSkill(calls);
+  unavailable.manifest.id = "fixture.unavailable";
+  unavailable.manifest.requirements = { type: "analyzer", capability: "speechTranscribe" };
+  runtime.registerSkill(unavailable);
+  await assert.rejects(runtime.previewSkill({
+    skillId: unavailable.manifest.id,
+    baseRevision: before.revision,
+    input: { name: "Review", start: 0 },
+  }), /SKILL_REQUIREMENTS_UNMET/);
+  assert.equal(calls.value, 0);
+});
+
+test("expired, reused, unknown, and stale preview tokens are rejected", async () => {
+  let now = 1_000;
+  const { runtime } = createSkillRuntime({ now: () => now, previewTtlMs: 10 });
+  runtime.registerSkill(markerSkill());
+  const before = await runtime.inspectProject();
+  const expired = await runtime.previewSkill({ skillId: "fixture.add-marker", baseRevision: before.revision, input: { name: "Expired", start: 0 } });
+  now = 1_011;
+  await assert.rejects(runtime.executeSkill(expired.previewToken), /SKILL_PREVIEW_TOKEN_EXPIRED/);
+  await assert.rejects(runtime.executeSkill(expired.previewToken), /SKILL_PREVIEW_TOKEN_INVALID/);
+  await assert.rejects(runtime.executeSkill("skill-preview-unknown"), /SKILL_PREVIEW_TOKEN_INVALID/);
+
+  now = 2_000;
+  const stale = await runtime.previewSkill({ skillId: "fixture.add-marker", baseRevision: before.revision, input: { name: "Stale", start: 1 } });
+  await runtime.edit({ type: "add-marker", timelineId: before.timeline.id, marker: { id: "external", start: 0, duration: 0, name: "External" } });
+  await assert.rejects(runtime.executeSkill(stale.previewToken), /STALE_CONTEXT/);
+});
+
+test("verification failure reports a complete rollback result", async () => {
+  const verificationEngine: VerificationEngine = {
+    verify: async () => ({
+      passed: false,
+      checks: [{ name: "fixture", passed: false, status: "failed", detail: "forced failure" }],
+    }),
+  };
+  const { runtime } = createSkillRuntime({ verificationEngine });
+  runtime.registerSkill(markerSkill());
+  const before = await runtime.inspectProject();
+  const preview = await runtime.previewSkill({ skillId: "fixture.add-marker", baseRevision: before.revision, input: { name: "Rollback", start: 3 } });
+
+  const execution = await runtime.executeSkill(preview.previewToken);
+  assert.equal(execution.status, "ROLLED_BACK");
+  assert.equal(execution.rollback.attempted, true);
+  assert.equal(execution.rollback.succeeded, true);
+  assert.deepEqual((await runtime.inspectProject()).timeline.markers, before.timeline.markers);
+});


### PR DESCRIPTION
## Summary

Closes #35.

- adds deterministic in-process Skill registration, listing, inspection, and version-pinned lookup
- validates manifest inputs and resolves requirements before invoking handlers
- adds read-only planning, short-lived single-use preview sessions, stale revision checks, and transaction-backed execution
- returns verification and complete rollback evidence for failed verification
- keeps handlers adapter-independent and documents the runtime boundary

Depends on #33/#34 and PRs #148/#149.

## Validation

- `PATH=/Users/shotomorisaki/.nix-profile/bin:$PATH pnpm run build`
- `PATH=/Users/shotomorisaki/.nix-profile/bin:$PATH pnpm exec tsx --test tests/integration/skill-runtime.test.ts`
- `git diff --check`
