### PR TITLE
feat: route generic Skill tools through the runtime

### DIFF
--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -414,31 +414,38 @@ const nativeEditToolInputSchema = z.object({
   duration: z.number().nonnegative().optional(),
 }).strict();
 
-const skillIds = ["filler-removal", "dialogue-normalization"] as const;
-const skillIdSchema = z.enum(skillIds);
-const skillManifests = [
-  {
-    id: "filler-removal",
-    version: 1,
-    description: "Remove high-confidence filler words through a guarded closed-loop transaction.",
-    previewTool: "skill.preview",
-    executeTool: "skill.execute",
-    requires: ["canonical timeline read", "speech analysis", "ripple-delete", "rollback"],
-  },
-  {
-    id: "dialogue-normalization",
-    version: 1,
-    description: "Normalize one complete dialogue clip occurrence with measured loudness and peak verification.",
-    previewTool: "skill.preview",
-    executeTool: "skill.execute",
-    requires: ["canonical timeline read", "dialogue audio analysis", "set-gain", "rollback"],
-  },
-] as const;
-
 function jsonResult(value: unknown) {
   return {
     content: [{ type: "text" as const, text: JSON.stringify(value) }],
   };
+}
+
+function skillErrorResult(error: unknown) {
+  const value = error && typeof error === "object" ? error as Record<string, unknown> : {};
+  const message = error instanceof Error ? error.message : String(error);
+  const code = error instanceof z.ZodError
+    ? "SKILL_INPUT_INVALID"
+    : typeof value.code === "string" ? value.code : message.split(":", 1)[0] || "SKILL_ERROR";
+  return {
+    isError: true,
+    content: [{
+      type: "text" as const,
+      text: JSON.stringify({
+        code,
+        message,
+        ...(value.availability ? { availability: value.availability } : {}),
+      }),
+    }],
+  };
+}
+
+function skillPreviewResult(preview: Awaited<ReturnType<AgentVideoRuntime["previewSkill"]>>) {
+  const details = preview.plan.details ?? {};
+  return jsonResult({
+    ...preview,
+    ...details,
+    plan: { ...preview.plan, ...details },
+  });
 }
 
 function normalizeConnectionStatus(value: unknown): unknown {
@@ -502,6 +509,7 @@ export interface McpServerOptions {
 }
 
 export function createMcpServer(runtime: AgentVideoRuntime, options: McpServerOptions = {}): McpServer {
+  runtime.registerBuiltinSkills();
   const server = new McpServer(
     { name: "framekit", version: "0.1.0" },
     { instructions: EDITOR_FIRST_MCP_INSTRUCTIONS },
@@ -513,39 +521,65 @@ export function createMcpServer(runtime: AgentVideoRuntime, options: McpServerOp
   }, async () => jsonResult(normalizeConnectionStatus(await connectionStatus(options))));
 
   server.registerTool("skill.list", {
-    description: "List versioned Framekit Skills available through the generic MCP surface.",
+    description: "List registered versioned Framekit Skills with current capability availability.",
     inputSchema: {},
-  }, async () => jsonResult(skillManifests));
+  }, async () => {
+    try {
+      return jsonResult((await runtime.listSkillAvailability()).map(({ manifest, availability }) => ({
+        ...manifest,
+        availability,
+      })));
+    } catch (error) {
+      return skillErrorResult(error);
+    }
+  });
 
   server.registerTool("skill.inspect", {
-    description: "Inspect one versioned Framekit Skill and its generic preview and execute tools.",
-    inputSchema: { skill: skillIdSchema },
-  }, async ({ skill }) => jsonResult(skillManifests.find((manifest) => manifest.id === skill)));
+    description: "Inspect one registered Framekit Skill version and its current capability availability.",
+    inputSchema: { skill: z.string().min(1), version: z.string().min(1).optional() },
+  }, async ({ skill, version }) => {
+    try {
+      const { manifest, availability } = await runtime.inspectSkillAvailability(skill, version);
+      return jsonResult({ ...manifest, availability });
+    } catch (error) {
+      return skillErrorResult(error);
+    }
+  });
 
   server.registerTool("skill.preview", {
-    description: "Preview a versioned Framekit Skill through its generic MCP contract without mutating the editor.",
+    description: "Validate and preview a registered Skill without mutating the editor.",
     inputSchema: {
-      skill: skillIdSchema,
+      skill: z.string().min(1),
+      version: z.string().min(1).optional(),
       arguments: z.record(z.unknown()),
     },
-  }, async ({ skill, arguments: skillArguments }) => {
-    if (skill === "filler-removal") {
-      return jsonResult(await runtime.previewFillerRemoval(z.object(fillerRemovalInputSchema).parse(skillArguments)));
+  }, async ({ skill, version, arguments: skillArguments }) => {
+    try {
+      const baseRevision = revisionValueSchema.parse(skillArguments.baseRevision);
+      const { baseRevision: _baseRevision, ...input } = skillArguments;
+      return skillPreviewResult(await runtime.previewSkill({
+        skillId: skill,
+        ...(version ? { version } : {}),
+        baseRevision,
+        input,
+      }));
+    } catch (error) {
+      return skillErrorResult(error);
     }
-    return jsonResult(await runtime.previewDialogueNormalization(
-      z.object(dialogueNormalizationInputSchema).parse(skillArguments),
-    ));
   });
 
   server.registerTool("skill.execute", {
-    description: "Execute one generic Framekit Skill preview token and return its verified or rolled-back transaction.",
+    description: "Execute only a runtime-issued Skill preview token and return verification/rollback evidence.",
     inputSchema: {
-      skill: skillIdSchema,
       previewToken: z.string().min(1),
     },
-  }, async ({ skill, previewToken }) => jsonResult(skill === "filler-removal"
-    ? await runtime.executeFillerRemoval(previewToken)
-    : await runtime.executeDialogueNormalization(previewToken)));
+  }, async ({ previewToken }) => {
+    try {
+      return jsonResult(await runtime.executeSkill(previewToken));
+    } catch (error) {
+      return skillErrorResult(error);
+    }
+  });
 
   server.registerTool("project.inspect", {
     description: "Read the current canonical project snapshot before editing.route selects a capability-checked path.",

--- a/docs/mcp/skills.md
+++ b/docs/mcp/skills.md
@@ -20,21 +20,26 @@ resolved by the runtime before mutation.
 ## Discovery
 
 Call `skill.list` to enumerate versioned Skills and `skill.inspect` with a Skill
-ID to read its requirements, preview tool, and execute tool. The v0.0.3 Skills
-are:
+ID to read its requirements, preview tool, and execute tool. The repository-owned
+Skills currently exposed by the generic surface are:
 
 | Skill | Version | Workflow |
 | --- | --- | --- |
-| `filler-removal` | 1 | speech analysis, safe deletion, re-analysis, verification, rollback |
-| `dialogue-normalization` | 1 | dialogue measurement, bounded gain, re-measurement, verification, rollback |
+| `filler-removal` | 1.0.0 | speech analysis, safe deletion, re-analysis, verification, rollback |
+| `dialogue-normalization` | 1.0.0 | dialogue measurement, bounded gain, re-measurement, verification, rollback |
 
 ## Execution contract
 
-Use `skill.preview` with `skill` and an `arguments` object. Preview is
-non-mutating and returns the plan, evidence, authorized operations, expected
-diff, warnings, and a short-lived token when mutation is safe. Use
-`skill.execute` with the same Skill ID and token. Execution accepts only the
-runtime-issued token and returns a verified or rolled-back transaction.
+Use `skill.preview` with `skill`, an optional semantic `version`, and an
+`arguments` object containing the inspected `baseRevision`. Preview is
+non-mutating and returns the version-pinned plan, normalized input, semantic
+operations, expected diff, warnings, and a short-lived runtime token. Use
+`skill.execute` with only that token; the token pins the Skill ID and version,
+so raw operations and editable plans cannot be submitted.
+
+`skill.list` and `skill.inspect` include the current capability-resolution
+result. Unsupported requirements are reported with exact missing leaves and
+stable reason codes; they do not fall back to a fixture or another editor.
 
 `filler-removal` skips low-confidence, ambiguous, overlapping, or protected
 speech rather than choosing a cut in natural-language code. It re-analyzes

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -282,6 +282,9 @@ preview tokens. An unrecognized or ambiguous destructive request returns
 ## Generic Skills
 
 The versioned Skill surface is `skill.list`, `skill.inspect`, `skill.preview`,
-and `skill.execute`. See [Generic MCP Skills](./skills.md) for the
-`filler-removal` and `dialogue-normalization` contracts. Skills use runtime
+and `skill.execute`. Discovery and inspection include current capability
+availability and structured missing requirements. Preview accepts a Skill ID,
+optional semantic version, and an argument object containing the inspected base
+revision; execute accepts only the runtime-issued preview token. See
+[Generic MCP Skills](./skills.md) for the full contract. Skills use runtime
 capabilities and never embed Final Cut-specific commands.

--- a/packages/runtime/src/application/media-analysis-service.ts
+++ b/packages/runtime/src/application/media-analysis-service.ts
@@ -31,11 +31,11 @@ export class MediaAnalysisService {
     private readonly options: RuntimeOptions,
   ) {}
 
-  public async analyzeSpeech(mediaId: string): Promise<SpeechAnalysis> {
+  public async analyzeSpeech(mediaId: string, range?: TimeRange): Promise<SpeechAnalysis> {
     if (!this.options.speechAnalyzer) throw new Error("CAPABILITY_UNAVAILABLE: speech analysis");
     const project = await this.project.inspectProject();
     const media = findMedia(project, mediaId);
-    return this.options.speechAnalyzer.analyze({ project, media });
+    return this.options.speechAnalyzer.analyze({ project, media }, range);
   }
 
   public async analyzeAudio(mediaId: string): Promise<AudioAnalysis> {

--- a/packages/runtime/src/domain/skills.ts
+++ b/packages/runtime/src/domain/skills.ts
@@ -2,6 +2,7 @@ import type { RuntimeCapabilities } from "./capabilities.js";
 import type { ContextRevision, TimeRange } from "./primitives.js";
 import type { ProjectSnapshot } from "./project.js";
 import type { WorkflowOperation } from "./editing.js";
+import type { TimelineDiff } from "./diff.js";
 import type { VerificationPolicy, VerificationReport } from "./verification.js";
 import type { AudioMeasurement, SpeechAnalysis } from "./media.js";
 
@@ -152,6 +153,7 @@ export interface SkillExecution {
   status: SkillExecutionStatus;
   plan: Pick<SkillPlan, "id" | "skillId" | "skillVersion" | "baseRevision">;
   transactionIds: string[];
+  diff?: TimelineDiff;
   verification?: VerificationReport;
   rollback: SkillRollbackResult;
 }

--- a/packages/runtime/src/domain/skills.ts
+++ b/packages/runtime/src/domain/skills.ts
@@ -3,6 +3,7 @@ import type { ContextRevision, TimeRange } from "./primitives.js";
 import type { ProjectSnapshot } from "./project.js";
 import type { WorkflowOperation } from "./editing.js";
 import type { VerificationPolicy, VerificationReport } from "./verification.js";
+import type { AudioMeasurement, SpeechAnalysis } from "./media.js";
 
 /** Version of the editor-independent Skill contract. */
 export const SKILL_CONTRACT_VERSION = 1 as const;
@@ -114,6 +115,8 @@ export interface SkillPlanningContext {
   project: ProjectSnapshot;
   capabilities: RuntimeCapabilities;
   baseRevision: ContextRevision;
+  analyzeSpeech?: (mediaId: string, range?: TimeRange) => Promise<SpeechAnalysis>;
+  measureAudio?: (mediaId: string, occurrenceId: string) => Promise<AudioMeasurement>;
 }
 
 export interface SkillPlan {
@@ -125,6 +128,8 @@ export interface SkillPlan {
   operations: WorkflowOperation[];
   affectedRanges: TimeRange[];
   warnings: string[];
+  verification?: VerificationPolicy;
+  details?: Record<string, unknown>;
 }
 
 export interface SkillPreview {

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -39,7 +39,7 @@ import type {
   DurationPolicyRequest,
 } from "./domain/index.js";
 import type { SkillDefinition, SkillExecution, SkillManifest, SkillPreview } from "./domain/skills.js";
-import type { SkillPreviewRequest } from "./skills/runtime.js";
+import type { SkillInspection, SkillPreviewRequest } from "./skills/runtime.js";
 import { planRoughCutConstruction as buildRoughCutConstructionPlan } from "./domain/rough-cut.js";
 import type { FillerRemovalPreview, FillerRemovalRequest } from "./speech/filler-removal.js";
 import { DefaultVerificationEngine } from "./verification/verification.js";
@@ -54,6 +54,7 @@ import { TransactionStore } from "./application/transaction-store.js";
 import { DurationPolicyService } from "./application/duration-policy-service.js";
 import { DialogueNormalizationService } from "./editing/dialogue-normalization-service.js";
 import { SkillRuntime } from "./skills/runtime.js";
+import { builtinSkills } from "./skills/builtin.js";
 import type {
   DialogueNormalizationPreview,
   DialogueNormalizationRequest,
@@ -86,7 +87,7 @@ export class AgentVideoRuntime {
     this.fillerRemoval = new FillerRemovalService(adapter, this.projects, verificationEngine, options, transactions);
     this.dialogueNormalization = new DialogueNormalizationService(adapter, this.projects, this.media, this.edits);
     this.durationPolicy = new DurationPolicyService();
-    this.skills = new SkillRuntime(this.projects, this.edits, options);
+    this.skills = new SkillRuntime(this.projects, this.media, this.edits, options);
   }
 
   public async inspectProject(): Promise<ProjectSnapshot> {
@@ -213,12 +214,29 @@ export class AgentVideoRuntime {
     this.skills.register(definition);
   }
 
+  /** Register the repository-owned Skills used by the generic MCP surface. */
+  public registerBuiltinSkills(): void {
+    for (const definition of builtinSkills()) {
+      if (!this.skills.registry.has(definition.manifest.id, definition.manifest.version)) {
+        this.skills.register(definition);
+      }
+    }
+  }
+
   public listSkills(): SkillManifest[] {
     return this.skills.list();
   }
 
   public inspectSkill(skillId: string, version?: string): SkillManifest {
     return this.skills.inspect(skillId, version);
+  }
+
+  public listSkillAvailability(): Promise<SkillInspection[]> {
+    return this.skills.listAvailability();
+  }
+
+  public inspectSkillAvailability(skillId: string, version?: string): Promise<SkillInspection> {
+    return this.skills.inspectAvailability(skillId, version);
   }
 
   public previewSkill(request: SkillPreviewRequest): Promise<SkillPreview> {

--- a/packages/runtime/src/skills/builtin.ts
+++ b/packages/runtime/src/skills/builtin.ts
@@ -1,0 +1,184 @@
+import type { SkillDefinition, SkillPlanningContext } from "../domain/skills.js";
+import type { TimeRange } from "../domain/primitives.js";
+import { planFillerRemoval } from "../speech/filler-removal.js";
+import { translateRationalRange } from "../timeline/rational-time.js";
+import { planDialogueGain, type DialogueNormalizationRequest } from "../audio/dialogue-normalization.js";
+import type { FillerRemovalTarget } from "../speech/filler-removal.js";
+
+export function builtinSkills(): SkillDefinition[] {
+  return [fillerRemovalSkill(), dialogueNormalizationSkill()];
+}
+
+function fillerRemovalSkill(): SkillDefinition {
+  return {
+    manifest: {
+      contractVersion: 1,
+      id: "filler-removal",
+      version: "1.0.0",
+      title: "Filler removal",
+      description: "Remove high-confidence filler words through a guarded closed-loop transaction.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          range: {
+            type: "object",
+            properties: {
+              start: { type: "number", minimum: 0 },
+              end: { type: "number", minimum: 0 },
+            },
+            required: ["start", "end"],
+            additionalProperties: false,
+          },
+          confidenceThreshold: { type: "number", minimum: 0, maximum: 1 },
+          preservePauseMs: { type: "number", minimum: 0 },
+          targetPauseMs: { type: "number", minimum: 0 },
+        },
+        required: ["range"],
+        additionalProperties: false,
+      },
+      requirements: {
+        type: "allOf",
+        requirements: [
+          { type: "editor", capability: "timelineSnapshotRead" },
+          { type: "editor", capability: "timelineWrite" },
+          { type: "editor", capability: "readAfterWrite" },
+          { type: "editor", capability: "rollback" },
+          { type: "analyzer", capability: "speechTranscribe" },
+          { type: "operation", operation: "ripple-delete" },
+        ],
+      },
+      verification: { requireExpectedChange: true, requireSpeechContinuity: true },
+    },
+    handler: {
+      normalize: (input) => input as Record<string, unknown>,
+      plan: async (context, input) => planFillerSkill(context, input),
+    },
+  };
+}
+
+async function planFillerSkill(context: SkillPlanningContext, input: Record<string, unknown>) {
+  const selectedRange = input.range as TimeRange;
+  const options = {
+    ...(input.confidenceThreshold !== undefined ? { confidenceThreshold: input.confidenceThreshold as number } : {}),
+    ...(input.preservePauseMs !== undefined ? { preservePauseMs: input.preservePauseMs as number } : {}),
+    ...(input.targetPauseMs !== undefined ? { targetPauseMs: input.targetPauseMs as number } : {}),
+  };
+  if (!context.analyzeSpeech) throw new Error("CAPABILITY_UNAVAILABLE: speech analysis");
+  const candidates: FillerRemovalTarget[] = [];
+  const selectedMediaIds = new Set<string>();
+  for (const clip of context.project.timeline.clips.filter((candidate) =>
+    Boolean(candidate.mediaId)
+      && candidate.start < selectedRange.end
+      && candidate.start + candidate.duration > selectedRange.start,
+  )) {
+    const mediaId = clip.mediaId!;
+    if (selectedMediaIds.has(mediaId)) {
+      throw new Error("CAPABILITY_UNAVAILABLE: filler removal cannot verify repeated timeline occurrences of the same media item");
+    }
+    selectedMediaIds.add(mediaId);
+    const localRange = {
+      start: Math.max(0, selectedRange.start - clip.start),
+      end: Math.min(clip.duration, selectedRange.end - clip.start),
+    };
+    if (localRange.end <= localRange.start) continue;
+    const speech = await context.analyzeSpeech(mediaId, localRange);
+    const mediaCandidates = planFillerRemoval(speech.words, localRange, options);
+    for (const candidate of mediaCandidates) {
+      candidates.push({
+        ...candidate,
+        clipId: clip.id,
+        mediaId,
+        sourceRange: structuredClone(candidate.range),
+        range: translateRationalRange(clip.startTime, clip.start, candidate.range),
+      });
+    }
+  }
+  if (candidates.length === 0) throw new Error("NO_FILLERS_FOUND: no high-confidence filler words in selected range");
+  candidates.sort((left, right) => right.range.start - left.range.start);
+  return {
+    operations: candidates.map((candidate) => ({
+      type: "ripple-delete" as const,
+      timelineId: context.project.timeline.id,
+      range: structuredClone(candidate.range),
+      reason: `remove high-confidence filler word: ${candidate.word.text}`,
+    })),
+    affectedRanges: candidates.map((candidate) => structuredClone(candidate.range)),
+    warnings: [],
+    details: { range: structuredClone(selectedRange), candidates: structuredClone(candidates) },
+  };
+}
+
+function dialogueNormalizationSkill(): SkillDefinition {
+  return {
+    manifest: {
+      contractVersion: 1,
+      id: "dialogue-normalization",
+      version: "1.0.0",
+      title: "Dialogue normalization",
+      description: "Normalize one complete dialogue clip occurrence with measured loudness and peak verification.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          mediaId: { type: "string", minLength: 1 },
+          occurrenceId: { type: "string", minLength: 1 },
+          targetLufs: { type: "number" },
+          toleranceDb: { type: "number", minimum: 0 },
+          maxTruePeakDb: { type: "number" },
+          minGainDb: { type: "number" },
+          maxGainDb: { type: "number" },
+          minDialogueDurationSeconds: { type: "number", minimum: 0 },
+        },
+        required: ["mediaId", "occurrenceId", "targetLufs", "toleranceDb", "maxTruePeakDb", "minGainDb", "maxGainDb", "minDialogueDurationSeconds"],
+        additionalProperties: false,
+      },
+      requirements: {
+        type: "allOf",
+        requirements: [
+          { type: "editor", capability: "timelineSnapshotRead" },
+          { type: "editor", capability: "timelineWrite" },
+          { type: "editor", capability: "readAfterWrite" },
+          { type: "editor", capability: "rollback" },
+          { type: "analyzer", capability: "audioLoudness" },
+          { type: "operation", operation: "set-gain" },
+        ],
+      },
+    },
+    handler: {
+      normalize: (input) => input as Record<string, unknown>,
+      plan: async (context, input) => planDialogueSkill(context, input),
+    },
+  };
+}
+
+async function planDialogueSkill(context: SkillPlanningContext, input: Record<string, unknown>) {
+  if (!context.measureAudio) throw new Error("CAPABILITY_UNAVAILABLE: audio analysis");
+  const request = input as unknown as DialogueNormalizationRequest;
+  const measurement = await context.measureAudio(request.mediaId, request.occurrenceId);
+  const plan = planDialogueGain(measurement, request);
+  const verification = plan.decision === "APPLY" ? {
+    requireExpectedChange: true,
+    maxTruePeakDb: request.maxTruePeakDb,
+    assertions: [{
+      type: "audio-loudness" as const,
+      mediaId: request.mediaId,
+      targetLufs: request.targetLufs,
+      toleranceDb: request.toleranceDb,
+    }],
+  } : undefined;
+  return {
+    operations: plan.decision === "APPLY" ? [{
+      type: "set-gain" as const,
+      clipId: request.occurrenceId,
+      gainDb: plan.clampedGainDb,
+      baseRevision: context.baseRevision,
+    }] : [],
+    affectedRanges: plan.decision === "APPLY" ? [{
+      start: context.project.timeline.clips.find((clip) => clip.id === request.occurrenceId)?.start ?? 0,
+      end: (context.project.timeline.clips.find((clip) => clip.id === request.occurrenceId)?.start ?? 0)
+        + (context.project.timeline.clips.find((clip) => clip.id === request.occurrenceId)?.duration ?? 0),
+    }] : [],
+    warnings: plan.decision === "SKIP" ? [...plan.reasonCodes] : [],
+    ...(verification ? { verification } : {}),
+    details: { measurement: structuredClone(measurement), ...structuredClone(plan) },
+  };
+}

--- a/packages/runtime/src/skills/registry.ts
+++ b/packages/runtime/src/skills/registry.ts
@@ -13,6 +13,10 @@ export class SkillRegistry {
     this.definitions.set(definition.manifest.id, versions);
   }
 
+  public has(skillId: string, version: string): boolean {
+    return this.definitions.get(skillId)?.has(version) ?? false;
+  }
+
   public list(): SkillManifest[] {
     return [...this.definitions.values()]
       .flatMap((versions) => [...versions.values()])

--- a/packages/runtime/src/skills/runtime.ts
+++ b/packages/runtime/src/skills/runtime.ts
@@ -175,6 +175,7 @@ export class SkillRuntime {
         baseRevision: structuredClone(session.preview.plan.baseRevision),
       },
       transactionIds: [transaction.id],
+      diff: structuredClone(transaction.diff),
       ...(transaction.verification ? { verification: structuredClone(transaction.verification) } : {}),
       rollback: {
         attempted: rolledBack,

--- a/packages/runtime/src/skills/runtime.ts
+++ b/packages/runtime/src/skills/runtime.ts
@@ -1,7 +1,9 @@
 import { randomUUID } from "node:crypto";
 import type { ProjectService } from "../application/project-service.js";
+import type { MediaAnalysisService } from "../application/media-analysis-service.js";
 import type { RuntimeOptions } from "../application/runtime-options.js";
 import type { ContextRevision } from "../domain/primitives.js";
+import type { ProjectSnapshot } from "../domain/project.js";
 import type {
   SkillDefinition,
   SkillExecution,
@@ -14,6 +16,7 @@ import type { EditService } from "../editing/edit-service.js";
 import { sameRevision } from "../context/revision.js";
 import {
   assertSkillRequirements,
+  resolveSkillRequirements,
   type SkillAvailability,
 } from "./requirements.js";
 import { SkillRegistry } from "./registry.js";
@@ -27,7 +30,17 @@ export interface SkillPreviewRequest {
 
 interface SkillPreviewSession {
   preview: SkillPreview;
-  editPreviewToken: string;
+  editPreviewToken?: string;
+}
+
+interface CurrentResolutionContext {
+  project: ProjectSnapshot;
+  inspected: Awaited<ReturnType<ProjectService["inspectEditor"]>>;
+}
+
+export interface SkillInspection {
+  manifest: SkillManifest;
+  availability: SkillAvailability;
 }
 
 export class SkillRuntime {
@@ -36,6 +49,7 @@ export class SkillRuntime {
 
   public constructor(
     private readonly project: ProjectService,
+    private readonly analysis: MediaAnalysisService,
     private readonly edits: EditService,
     private readonly options: RuntimeOptions = {},
   ) {}
@@ -52,6 +66,20 @@ export class SkillRuntime {
     return this.registry.inspect(skillId, version);
   }
 
+  public async listAvailability(): Promise<SkillInspection[]> {
+    const context = await this.currentResolutionContext();
+    return this.registry.list().map((manifest) => ({
+      manifest,
+      availability: resolveAvailability(manifest, context),
+    }));
+  }
+
+  public async inspectAvailability(skillId: string, version?: string): Promise<SkillInspection> {
+    const manifest = this.registry.inspect(skillId, version);
+    const context = await this.currentResolutionContext();
+    return { manifest, availability: resolveAvailability(manifest, context) };
+  }
+
   public async preview(request: SkillPreviewRequest): Promise<SkillPreview> {
     const definition = this.registry.lookup(request.skillId, request.version);
     const before = await this.project.inspectProject();
@@ -59,7 +87,7 @@ export class SkillRuntime {
       throw new Error("STALE_CONTEXT: Skill preview base revision does not match current editor state");
     }
     const inspected = await this.project.inspectEditor();
-    const availability = assertSkillRequirements(definition.manifest, {
+    assertSkillRequirements(definition.manifest, {
       capabilities: inspected.capabilities,
       editor: inspected.identity,
       revision: before.revision,
@@ -70,6 +98,8 @@ export class SkillRuntime {
       project: structuredClone(before),
       capabilities: structuredClone(inspected.capabilities),
       baseRevision: structuredClone(before.revision),
+      analyzeSpeech: (mediaId: string, range?: import("../domain/primitives.js").TimeRange) => this.analysis.analyzeSpeech(mediaId, range),
+      measureAudio: (mediaId: string, occurrenceId: string) => this.analysis.measureAudio(mediaId, occurrenceId),
     });
     const planned = await definition.handler.plan(handlerContext, normalizedInput);
     const plan: SkillPlan = {
@@ -81,22 +111,25 @@ export class SkillRuntime {
       operations: structuredClone(planned.operations),
       affectedRanges: structuredClone(planned.affectedRanges),
       warnings: [...planned.warnings],
+      ...(planned.verification ? { verification: structuredClone(planned.verification) } : {}),
+      ...(planned.details ? { details: structuredClone(planned.details) } : {}),
     };
-    if (plan.operations.length === 0) throw new Error("SKILL_PLAN_INVALID: at least one semantic operation is required");
-    const editPreview = await this.edits.previewEdit({
-      baseRevision: before.revision,
-      operations: plan.operations,
-      verification: definition.manifest.verification,
-    });
+    const editPreview = plan.operations.length > 0
+      ? await this.edits.previewEdit({
+        baseRevision: before.revision,
+        operations: plan.operations,
+        verification: plan.verification ?? definition.manifest.verification,
+      })
+      : undefined;
     const previewToken = `skill-preview-${randomUUID()}`;
     const preview: SkillPreview = {
       previewToken,
       plan,
-      expectedDiff: editPreview.expectedDiff,
-      expiresAt: editPreview.expiresAt,
+      ...(editPreview?.expectedDiff ? { expectedDiff: editPreview.expectedDiff } : {}),
+      expiresAt: editPreview?.expiresAt ?? new Date(this.now() + (this.options.previewTtlMs ?? 30_000)).toISOString(),
     };
     this.prunePreviews();
-    this.previews.set(previewToken, { preview, editPreviewToken: editPreview.previewToken });
+    this.previews.set(previewToken, { preview, ...(editPreview ? { editPreviewToken: editPreview.previewToken } : {}) });
     return structuredClone(preview);
   }
 
@@ -118,6 +151,19 @@ export class SkillRuntime {
       editor: inspected.identity,
       revision: before.revision,
     });
+    if (!session.editPreviewToken) {
+      return {
+        status: "SKIPPED",
+        plan: {
+          id: session.preview.plan.id,
+          skillId: session.preview.plan.skillId,
+          skillVersion: session.preview.plan.skillVersion,
+          baseRevision: structuredClone(session.preview.plan.baseRevision),
+        },
+        transactionIds: [],
+        rollback: { attempted: false, succeeded: true, transactionIds: [] },
+      };
+    }
     const transaction = await this.edits.executeEdit(session.editPreviewToken);
     const rolledBack = transaction.status === "ROLLED_BACK";
     return {
@@ -171,6 +217,17 @@ export class SkillRuntime {
   private now(): number {
     return this.options.now?.() ?? Date.now();
   }
+
+  private async currentResolutionContext() {
+    const [project, inspected] = await Promise.all([
+      this.project.inspectProject(),
+      this.project.inspectEditor(),
+    ]);
+    return {
+      project,
+      inspected,
+    };
+  }
 }
 
 async function normalizeInput(definition: SkillDefinition, input: Record<string, unknown>): Promise<Record<string, unknown>> {
@@ -216,4 +273,15 @@ function validateSchemaValue(schema: SkillInputSchema["properties"][string], val
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function resolveAvailability(
+  manifest: SkillManifest,
+  context: CurrentResolutionContext,
+): SkillAvailability {
+  return resolveSkillRequirements(manifest, {
+    capabilities: context.inspected.capabilities,
+    editor: context.inspected.identity,
+    revision: context.project.revision,
+  });
 }

--- a/tests/integration/skill-mcp-contract.test.ts
+++ b/tests/integration/skill-mcp-contract.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { AgentVideoRuntime, type SkillDefinition } from "@framekit/runtime";
+import { InMemoryEditorAdapter } from "@framekit/testkit";
+import { createMcpServer } from "../../apps/mcp-server/src/server.js";
+
+function textFrom(value: unknown): string {
+  const content = (value as { content?: Array<{ type?: string; text?: string }> }).content;
+  assert.equal(content?.[0]?.type, "text");
+  return content?.[0]?.text ?? "";
+}
+
+function markerSkill(): SkillDefinition {
+  return {
+    manifest: {
+      contractVersion: 1,
+      id: "fixture.mcp-marker",
+      version: "1.2.0",
+      title: "MCP marker",
+      description: "Add a marker through the generic MCP surface.",
+      inputSchema: {
+        type: "object",
+        properties: { name: { type: "string", minLength: 1 } },
+        required: ["name"],
+        additionalProperties: false,
+      },
+      requirements: { type: "operation", operation: "add-marker" },
+    },
+    handler: {
+      normalize: (input) => input as Record<string, unknown>,
+      plan: (context, input) => ({
+        operations: [{
+          type: "add-marker" as const,
+          timelineId: context.project.timeline.id,
+          marker: { id: "mcp-marker", start: 1, duration: 0, name: input.name as string },
+        }],
+        affectedRanges: [{ start: 1, end: 1 }],
+        warnings: [],
+      }),
+    },
+  };
+}
+
+function adapter(projectId: string): InMemoryEditorAdapter {
+  return new InMemoryEditorAdapter({
+    projectId,
+    projectName: "MCP Skill",
+    timelineId: `${projectId}-timeline`,
+    timelineName: "Main",
+    clips: [],
+  });
+}
+
+test("generic MCP Skill tools delegate discovery, inspection, preview, and token-only execution", async () => {
+  const runtime = new AgentVideoRuntime(adapter("mcp-skill-project"));
+  runtime.registerSkill(markerSkill());
+  const server = createMcpServer(runtime);
+  const client = new Client({ name: "skill-mcp-contract", version: "1.0.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  try {
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    const listed = JSON.parse(textFrom(await client.callTool({ name: "skill.list", arguments: {} }))) as Array<{ id: string; availability: { available: boolean } }>;
+    const listedMarker = listed.find((skill) => skill.id === "fixture.mcp-marker");
+    assert.equal(listedMarker?.availability.available, true);
+
+    const inspected = JSON.parse(textFrom(await client.callTool({
+      name: "skill.inspect",
+      arguments: { skill: "fixture.mcp-marker", version: "1.2.0" },
+    }))) as { version: string; availability: { available: boolean } };
+    assert.equal(inspected.version, "1.2.0");
+    assert.equal(inspected.availability.available, true);
+
+    const before = JSON.parse(textFrom(await client.callTool({ name: "project.inspect", arguments: {} }))) as {
+      revision: { id: string; sequence: number; timestamp: string };
+    };
+    const preview = JSON.parse(textFrom(await client.callTool({
+      name: "skill.preview",
+      arguments: {
+        skill: "fixture.mcp-marker",
+        version: "1.2.0",
+        arguments: { baseRevision: before.revision, name: "Review" },
+      },
+    }))) as { previewToken: string; plan: { skillVersion: string; operations: unknown[] } };
+    assert.equal(preview.plan.skillVersion, "1.2.0");
+    assert.equal(preview.plan.operations.length, 1);
+    assert.deepEqual(JSON.parse(textFrom(await client.callTool({ name: "project.inspect", arguments: {} }))), before);
+
+    const rawOperationAttempt = await client.callTool({
+      name: "skill.execute",
+      arguments: { previewToken: "not-issued", operations: [{ type: "add-marker" }] },
+    });
+    assert.equal(rawOperationAttempt.isError, true);
+    assert.equal(JSON.parse(textFrom(rawOperationAttempt)).code, "SKILL_PREVIEW_TOKEN_INVALID");
+
+    const execution = JSON.parse(textFrom(await client.callTool({
+      name: "skill.execute",
+      arguments: { previewToken: preview.previewToken },
+    }))) as { status: string };
+    assert.equal(execution.status, "VERIFIED");
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
+
+test("generic MCP maps unavailable Skill requirements to structured errors", async () => {
+  const runtime = new AgentVideoRuntime(adapter("mcp-unavailable-project"));
+  const unavailable = markerSkill();
+  unavailable.manifest.id = "fixture.mcp-unavailable";
+  unavailable.manifest.requirements = { type: "analyzer", capability: "speechTranscribe" };
+  runtime.registerSkill(unavailable);
+  const server = createMcpServer(runtime);
+  const client = new Client({ name: "skill-mcp-unavailable", version: "1.0.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  try {
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    const inspected = JSON.parse(textFrom(await client.callTool({ name: "skill.inspect", arguments: { skill: unavailable.manifest.id } }))) as {
+      availability: { available: boolean; reasonCodes: string[] };
+    };
+    assert.equal(inspected.availability.available, false);
+    assert.deepEqual(inspected.availability.reasonCodes, ["MISSING_ANALYZER_CAPABILITY"]);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});

--- a/tests/release-gate/release-gate.test.ts
+++ b/tests/release-gate/release-gate.test.ts
@@ -47,24 +47,26 @@ test("generic MCP Skill surface discovers both release workflows", async () => {
     assert.ok(tools.tools.some((tool) => tool.name === "skill.execute"));
     const listed = await client.callTool({ name: "skill.list", arguments: {} });
     const content = listed.content as Array<{ type: string; text?: string }>;
-    const payload = JSON.parse(content[0]?.text ?? "null") as Array<{ id: string; version: number }>;
-    assert.deepEqual(payload.map((skill) => skill.id), ["filler-removal", "dialogue-normalization"]);
-    assert.ok(payload.every((skill) => skill.version === 1));
+    const payload = JSON.parse(content[0]?.text ?? "null") as Array<{ id: string; version: string }>;
+    assert.deepEqual(payload.map((skill) => skill.id), ["dialogue-normalization", "filler-removal"]);
+    assert.ok(payload.every((skill) => skill.version === "1.0.0"));
 
     const inspected = await client.callTool({
       name: "skill.inspect",
       arguments: { skill: "dialogue-normalization" },
     });
     const inspectedContent = inspected.content as Array<{ type: string; text?: string }>;
-    const dialogueSkill = JSON.parse(inspectedContent[0]?.text ?? "null") as { previewTool: string; executeTool: string };
-    assert.deepEqual(dialogueSkill, {
-      id: "dialogue-normalization",
-      version: 1,
-      description: "Normalize one complete dialogue clip occurrence with measured loudness and peak verification.",
-      previewTool: "skill.preview",
-      executeTool: "skill.execute",
-      requires: ["canonical timeline read", "dialogue audio analysis", "set-gain", "rollback"],
-    });
+    const dialogueSkill = JSON.parse(inspectedContent[0]?.text ?? "null") as {
+      id: string;
+      version: string;
+      inputSchema: { type: string };
+      availability: { available: boolean; missingRequirements: unknown[] };
+    };
+    assert.equal(dialogueSkill.id, "dialogue-normalization");
+    assert.equal(dialogueSkill.version, "1.0.0");
+    assert.equal(dialogueSkill.inputSchema.type, "object");
+    assert.equal(dialogueSkill.availability.available, false);
+    assert.ok(dialogueSkill.availability.missingRequirements.length > 0);
   } finally {
     await client.close();
     await server.close();

--- a/tests/release-gate/runner.ts
+++ b/tests/release-gate/runner.ts
@@ -197,7 +197,7 @@ async function runWorkflow(workflow: ReleaseGateWorkflow): Promise<ReleaseGateWo
     await server.connect(serverTransport);
     await client.connect(clientTransport);
     const skills = parseJson(await client.callTool({ name: "skill.list", arguments: {} })) as Array<{ id: string }>;
-    assert.deepEqual(skills.map((skill) => skill.id), ["filler-removal", "dialogue-normalization"]);
+    assert.deepEqual(skills.map((skill) => skill.id), ["dialogue-normalization", "filler-removal"]);
     before = parseJson(await client.callTool({ name: "project.inspect", arguments: {} })) as ProjectSnapshot;
     previewed = true;
     const previewResult = await client.callTool({


### PR DESCRIPTION
## Summary

Closes #36.

- routes `skill.list`, `skill.inspect`, `skill.preview`, and `skill.execute` through the runtime registry/resolver/executor
- exposes current availability and structured missing requirements
- registers repository-owned filler-removal and dialogue-normalization Skills outside the MCP planning layer
- preserves non-mutating previews, version pinning, token-only execution, and structured errors
- adds MCP integration coverage for discovery, inspection, preview isolation, raw-operation rejection, and unavailable requirements

Depends on #33/#34/#35 and PRs #148/#149/#150.

## Validation

- `PATH=/Users/shotomorisaki/.nix-profile/bin:$PATH pnpm run build`
- `PATH=/Users/shotomorisaki/.nix-profile/bin:$PATH pnpm exec tsx --test tests/integration/skill-mcp-contract.test.ts tests/release-gate/mcp-skill.test.ts tests/release-gate/release-gate.test.ts tests/release-gate/runner.test.ts tests/integration/mcp.test.ts tests/integration/skill-runtime.test.ts`
- `PATH=/Users/shotomorisaki/.nix-profile/bin:$PATH pnpm run check:boundaries`
- `git diff --check`
