### PR TITLE
feat: add the v0.0.2 Skill conformance gate

### DIFF
--- a/adapters/final-cut/typescript/src/fcpxml.ts
+++ b/adapters/final-cut/typescript/src/fcpxml.ts
@@ -97,6 +97,8 @@ export class FcpxmlDocumentAdapter implements EditorPort {
         frameCapture: false,
         projectCatalogRead: true,
         projectSelection: true,
+        compositeTransactions: true,
+        semanticOperations: { "add-marker": true },
       },
       analyzers: emptyAnalyzerCapabilities(),
     }, { backend: "fcpxml-document" });
@@ -185,6 +187,58 @@ export class FcpxmlDocumentAdapter implements EditorPort {
       throw new Error("STALE_CONTEXT: FCPXML document changed before write");
     }
     this.history.set(expectedRevision.id, structuredClone(this.xml!));
+    this.applyOperation(operation);
+    this.sequence += 1;
+    await this.persist();
+    return this.revision();
+  }
+
+  public async previewTransaction(
+    operations: import("@framekit/runtime").WorkflowOperation[],
+    expectedRevision: ContextRevision,
+  ): Promise<ProjectSnapshot> {
+    await this.ensureLoaded();
+    if (!sameRevision(expectedRevision, this.revision())) {
+      throw new Error("STALE_CONTEXT: FCPXML document changed before preview");
+    }
+    const originalXml = structuredClone(this.xml!);
+    const originalSequence = this.sequence;
+    const originalSignature = this.fileSignature;
+    try {
+      for (const operation of operations) {
+        if (operation.type === "media.import" || operation.type.startsWith("timeline.")) {
+          throw new Error(`CAPABILITY_UNAVAILABLE: FCPXML preview does not support ${operation.type}`);
+        }
+        this.applyOperation(operation as EditOperation);
+      }
+      return this.readProject();
+    } finally {
+      this.xml = originalXml;
+      this.sequence = originalSequence;
+      this.fileSignature = originalSignature;
+    }
+  }
+
+  public async applyTransaction(
+    operations: import("@framekit/runtime").WorkflowOperation[],
+    expectedRevision: ContextRevision,
+  ): Promise<void> {
+    await this.ensureLoaded();
+    if (!sameRevision(expectedRevision, this.revision())) {
+      throw new Error("STALE_CONTEXT: FCPXML document changed before transaction");
+    }
+    this.history.set(expectedRevision.id, structuredClone(this.xml!));
+    for (const operation of operations) {
+      if (operation.type === "media.import" || operation.type.startsWith("timeline.")) {
+        throw new Error(`CAPABILITY_UNAVAILABLE: FCPXML transaction does not support ${operation.type}`);
+      }
+      this.applyOperation(operation as EditOperation);
+    }
+    this.sequence += 1;
+    await this.persist();
+  }
+
+  private applyOperation(operation: EditOperation): void {
     const project = this.projectNode();
     const sequenceNode = findElement(project, "sequence");
     const sequence = sequenceNode ?? {};
@@ -233,9 +287,6 @@ export class FcpxmlDocumentAdapter implements EditorPort {
       }
     }
     this.updateSequenceDuration(sequence, spine);
-    this.sequence += 1;
-    await this.persist();
-    return this.revision();
   }
 
   public async restore(snapshot: ProjectSnapshot, expectedRevision: ContextRevision): Promise<void> {

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,9 @@ Repository-local GitHub agent playbooks are documented in
 - [Rough-cut duration policy](./rough-cut/duration-policy.md): explicit duration tradeoffs and safety defaults.
 - [Tests](./tests/README.md): reproducible checks and evidence, including the [golden workflow corpus](./tests/golden-corpus.md), [deterministic MCP evaluation](./tests/mcp-evaluation.md), and [v0.0.3 release gate](./tests/release-gate.md).
 - [Generic MCP Skills](./mcp/skills.md): versioned Skill discovery and execution.
+- [Skill authoring](./mcp/skill-authoring.md): public manifests, handlers, plans, and lifecycle boundaries.
+- [v0.0.2 Skill conformance](./tests/skill-conformance.md): deterministic gate and adapter evidence.
+- [v0.0.2 release checklist](./release-v0.0.2-checklist.md): scope and required repository gates.
 - [v0.0.3 release evidence](./release-notes-v0.0.3.md): verified behavior and explicit unsupported boundaries.
 - [Final Cut](./final-cut/README.md): native integration and operations.
 - [Native media insertion breakthrough](./final-cut/native-media-insertion-breakthrough.md):

--- a/docs/mcp/skill-authoring.md
+++ b/docs/mcp/skill-authoring.md
@@ -1,0 +1,61 @@
+# Skill authoring guide
+
+Skills are editor-independent editing knowledge. A Skill author provides a
+versioned `SkillManifest` and a separate `SkillHandler`; the handler receives a
+read-only planning context and returns semantic operations. It never imports an
+MCP SDK, Final Cut adapter, Accessibility command, or editor-specific API.
+
+## Manifest
+
+```ts
+const manifest: SkillManifest = {
+  contractVersion: 1,
+  id: "example.add-marker",
+  version: "1.0.0",
+  title: "Add marker",
+  description: "Add a review marker at a requested position.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      name: { type: "string", minLength: 1 },
+      start: { type: "number", minimum: 0 },
+    },
+    required: ["name", "start"],
+    additionalProperties: false,
+  },
+  requirements: {
+    type: "operation",
+    operation: "add-marker",
+  },
+};
+```
+
+The ID is stable across releases. The version is semantic and is pinned by
+preview tokens. Input schemas reject missing, unknown, or incorrectly typed
+values before planning. Requirements use `allOf` and `anyOf` trees over editor
+capabilities, analyzer capabilities, and explicit semantic operations.
+
+## Handler, plan, preview, and execution
+
+The handler normalizes validated input and receives a `SkillPlanningContext`
+containing only a project snapshot, runtime capabilities, base revision, and
+optional read-only analysis functions. It returns a `SkillPlan` payload with
+semantic operations, affected timeline ranges, warnings, and optional
+verification policy. It does not mutate state.
+
+The runtime then creates a non-mutating preview and a short-lived single-use
+token. Execution accepts only that token, checks the pinned base revision and
+current requirements, and sends the operations through the transaction manager.
+The runtime re-observes the result, applies verification, and returns a
+`SkillExecution` containing transaction IDs, verification evidence, and the
+rollback result. Verification failure must restore the complete pre-edit state;
+unknown, expired, reused, or stale tokens fail closed.
+
+## Scope
+
+The v0.0.2 contract includes in-process registration, capability resolution,
+preview sessions, generic MCP tools, and the neutral `add-marker` conformance
+fixture. v0.0.3 contains product workflows such as filler removal and dialogue
+normalization. v0.0.4 is reserved for observability and workflow history after
+the safety contract is stable. Dynamic third-party loading, sandboxing, and
+persistent sessions are not part of this API.

--- a/docs/release-v0.0.2-checklist.md
+++ b/docs/release-v0.0.2-checklist.md
@@ -1,0 +1,21 @@
+# v0.0.2 release checklist
+
+- [ ] Public Skill manifests, requirements, plans, previews, handlers, and
+      executions are exported from `@framekit/runtime`.
+- [ ] Requirement resolution is deterministic, structured, and fail-closed.
+- [ ] The generic runtime enforces input validation, revision checks, token
+      expiry/single-use behavior, transaction execution, verification, and
+      rollback.
+- [ ] `skill.list`, `skill.inspect`, `skill.preview`, and `skill.execute` are
+      documented and delegate to runtime APIs.
+- [ ] The neutral `fixture.add-marker` Skill passes in-memory/FCPXML parity and
+      metadata-only live failure tests.
+- [ ] `pnpm install --frozen-lockfile` passes.
+- [ ] `pnpm run build` passes.
+- [ ] `pnpm run test` passes.
+- [ ] `pnpm run check:boundaries` passes.
+
+Follow-up scope is explicit: v0.0.3 owns filler-removal and dialogue
+normalization workflows; v0.0.4 owns observability and workflow history. This
+release does not include dynamic third-party Skill loading, sandboxing, or
+native live mutation claims beyond the capabilities actually advertised.

--- a/docs/tests/skill-conformance.md
+++ b/docs/tests/skill-conformance.md
@@ -1,0 +1,26 @@
+# v0.0.2 Skill conformance gate
+
+The v0.0.2 gate validates the neutral `fixture.add-marker` Skill independently
+of product-specific workflows:
+
+1. register, list, and inspect the version-pinned manifest;
+2. resolve its requirements against the active capabilities;
+3. preview without changing the snapshot;
+4. execute with a runtime-issued token;
+5. verify the transaction and report rollback evidence;
+6. run the same definition against the in-memory and FCPXML adapters; and
+7. report the Skill unavailable for a metadata-only live backend.
+
+Run the deterministic gate with:
+
+```sh
+pnpm install --frozen-lockfile
+pnpm run build
+pnpm run test
+pnpm run check:boundaries
+```
+
+Native validation is not required for this fixture because it does not change
+the Swift bridge. The FCPXML result is artifact evidence, not proof that an
+open Final Cut project was changed. Live metadata-only output must remain
+unavailable and must not inherit fixture capabilities.

--- a/packages/runtime/src/skills/runtime.ts
+++ b/packages/runtime/src/skills/runtime.ts
@@ -34,7 +34,7 @@ interface SkillPreviewSession {
 }
 
 interface CurrentResolutionContext {
-  project: ProjectSnapshot;
+  project?: ProjectSnapshot;
   inspected: Awaited<ReturnType<ProjectService["inspectEditor"]>>;
 }
 
@@ -220,14 +220,7 @@ export class SkillRuntime {
   }
 
   private async currentResolutionContext() {
-    const [project, inspected] = await Promise.all([
-      this.project.inspectProject(),
-      this.project.inspectEditor(),
-    ]);
-    return {
-      project,
-      inspected,
-    };
+    return { inspected: await this.project.inspectEditor() };
   }
 }
 
@@ -283,6 +276,6 @@ function resolveAvailability(
   return resolveSkillRequirements(manifest, {
     capabilities: context.inspected.capabilities,
     editor: context.inspected.identity,
-    revision: context.project.revision,
+    revision: context.project?.revision,
   });
 }

--- a/packages/testkit/src/index.ts
+++ b/packages/testkit/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./in-memory-editor.js";
 export * from "./fixture-analyzers.js";
+export * from "./skill-fixtures.js";

--- a/packages/testkit/src/skill-fixtures.ts
+++ b/packages/testkit/src/skill-fixtures.ts
@@ -1,0 +1,66 @@
+import type { SkillDefinition } from "@framekit/runtime";
+
+/** Neutral Skill used to conformance-test runtime and adapter boundaries. */
+export function createAddMarkerSkill(): SkillDefinition {
+  return {
+    manifest: {
+      contractVersion: 1,
+      id: "fixture.add-marker",
+      version: "0.0.2",
+      title: "Add marker",
+      description: "Add one deterministic review marker to the active timeline.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          name: { type: "string", minLength: 1 },
+          start: { type: "number", minimum: 0 },
+        },
+        required: ["name", "start"],
+        additionalProperties: false,
+      },
+      requirements: {
+        type: "anyOf",
+        requirements: [
+          {
+            type: "allOf",
+            requirements: [
+              { type: "editor", capability: "timelineSnapshotRead" },
+              { type: "editor", capability: "timelineWrite" },
+              { type: "editor", capability: "readAfterWrite" },
+              { type: "editor", capability: "rollback" },
+              { type: "operation", operation: "add-marker" },
+            ],
+          },
+          {
+            type: "allOf",
+            requirements: [
+              { type: "editor", capability: "timelineSnapshotRead" },
+              { type: "editor", capability: "timelineArtifactWrite" },
+              { type: "editor", capability: "readAfterWrite" },
+              { type: "editor", capability: "rollback" },
+              { type: "operation", operation: "add-marker" },
+            ],
+          },
+        ],
+      },
+      verification: { requireExpectedChange: true },
+    },
+    handler: {
+      normalize: (input) => input as Record<string, unknown>,
+      plan: (context, input) => ({
+        operations: [{
+          type: "add-marker" as const,
+          timelineId: context.project.timeline.id,
+          marker: {
+            id: `fixture-marker-${String(input.start)}`,
+            start: input.start as number,
+            duration: 0,
+            name: input.name as string,
+          },
+        }],
+        affectedRanges: [{ start: input.start as number, end: input.start as number }],
+        warnings: [],
+      }),
+    },
+  };
+}

--- a/tests/integration/skill-conformance.test.ts
+++ b/tests/integration/skill-conformance.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { AgentVideoRuntime, type RuntimeCapabilities } from "@framekit/runtime";
+import { FcpxmlDocumentAdapter, FinalCutLiveAdapter } from "@framekit/final-cut";
+import { createAddMarkerSkill, InMemoryEditorAdapter } from "@framekit/testkit";
+
+async function runFixture(runtime: AgentVideoRuntime) {
+  runtime.registerSkill(createAddMarkerSkill());
+  const before = await runtime.inspectProject();
+  const listed = runtime.listSkills();
+  assert.deepEqual(listed.map((skill) => skill.id), ["fixture.add-marker"]);
+  assert.equal(runtime.inspectSkill("fixture.add-marker", "0.0.2").version, "0.0.2");
+  const preview = await runtime.previewSkill({
+    skillId: "fixture.add-marker",
+    version: "0.0.2",
+    baseRevision: before.revision,
+    input: { name: "Conformance", start: 1 },
+  });
+  assert.deepEqual(await runtime.inspectProject(), before);
+  const execution = await runtime.executeSkill(preview.previewToken);
+  assert.equal(execution.status, "VERIFIED");
+  assert.equal(execution.rollback.attempted, false);
+  const after = await runtime.inspectProject();
+  assert.equal(after.timeline.markers[0]?.name, "Conformance");
+  return {
+    operationType: preview.plan.operations[0]?.type,
+    status: execution.status,
+    markerName: after.timeline.markers[0]?.name,
+  };
+}
+
+test("neutral add-marker Skill passes the complete in-memory conformance lifecycle", async () => {
+  const adapter = new InMemoryEditorAdapter({
+    projectId: "conformance-memory",
+    projectName: "Conformance",
+    timelineId: "conformance-memory-timeline",
+    timelineName: "Main",
+    clips: [],
+  });
+  assert.deepEqual(await runFixture(new AgentVideoRuntime(adapter)), {
+    operationType: "add-marker",
+    status: "VERIFIED",
+    markerName: "Conformance",
+  });
+});
+
+test("the same add-marker Skill runs through the FCPXML adapter when artifact capabilities match", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "framekit-skill-conformance-"));
+  const path = join(directory, "fixture.fcpxml");
+  await writeFile(path, `<?xml version="1.0"?><fcpxml version="1.11"><resources/><library><event><project uid="conformance-project" name="Conformance"><sequence uid="conformance-sequence" name="Main" duration="0s"><spine/></sequence></project></event></library></fcpxml>`);
+  const adapter = new FcpxmlDocumentAdapter(path);
+  const capabilities = await adapter.getCapabilities();
+  assert.equal(capabilities.editor.timelineArtifactWrite, true);
+  assert.equal(capabilities.editor.semanticOperations?.["add-marker"], true);
+  assert.deepEqual(await runFixture(new AgentVideoRuntime(adapter)), {
+    operationType: "add-marker",
+    status: "VERIFIED",
+    markerName: "Conformance",
+  });
+});
+
+test("metadata-only live mode reports the fixture Skill as unavailable", async () => {
+  const metadataOnly: RuntimeCapabilities = {
+    editor: {
+      projectRead: false,
+      timelineSnapshotRead: false,
+      timelineWrite: false,
+      timelineArtifactWrite: false,
+      readAfterWrite: false,
+      incrementalChanges: false,
+      rollback: false,
+      assetDiscovery: false,
+      liveStateRead: true,
+      playheadWrite: false,
+      frameCapture: false,
+      canonicalTimelineMode: "metadata-only",
+      projectCatalogRead: false,
+      projectSelection: false,
+      semanticOperations: {},
+    },
+    analyzers: {
+      speechTranscribe: false,
+      speechVad: false,
+      audioLoudness: false,
+      visualTrack: false,
+    },
+  };
+  const adapter = new FinalCutLiveAdapter({
+    request: async (request) => ({
+      version: 1,
+      id: request.id,
+      ok: true,
+      result: {
+        identity: { name: "Final Cut Pro", version: "test", backend: "workflow-extension-ipc" },
+        capabilities: metadataOnly,
+      },
+    }),
+  });
+  const runtime = new AgentVideoRuntime(adapter);
+  runtime.registerSkill(createAddMarkerSkill());
+  const inspection = await runtime.inspectSkillAvailability("fixture.add-marker");
+  assert.equal(inspection.availability.available, false);
+  assert.equal(inspection.availability.context.backend, "workflow-extension-ipc");
+  assert.ok(inspection.availability.reasonCodes.length > 0);
+});


### PR DESCRIPTION
## Summary
- add deterministic in-memory and FCPXML Skill conformance fixtures
- document Skill authoring, evidence boundaries, and the v0.0.2 release gate
- keep metadata-only live Final Cut capability claims fail-closed

## Validation
- `PATH=/Users/shotomorisaki/.nix-profile/bin:$PATH pnpm run build`
- `PATH=/Users/shotomorisaki/.nix-profile/bin:$PATH pnpm run test` (460 passed)
- `PATH=/Users/shotomorisaki/.nix-profile/bin:$PATH pnpm run check:boundaries`
- `git diff --check`

Refs #37