### PR TITLE
feat: add the audio noise reduction Skill

### DIFF
--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -43,7 +43,7 @@ const mediaIndexQuerySchema = z.object({
   mood: z.string().optional(),
   motion: z.enum(["static", "low", "medium", "high"]).optional(),
   range: rangeSchema.optional(),
-  capabilities: z.array(z.enum(["metadata", "speech", "audio", "visual"])).optional(),
+  capabilities: z.array(z.enum(["metadata", "speech", "audio", "noise", "visual"])).optional(),
 });
 const roughCutPlanSchema = mediaIndexQuerySchema.extend({
   maxShots: z.number().int().positive().optional(),
@@ -84,6 +84,13 @@ const trimClipSchema = z.object({
     baseRevision: revisionSchema,
 });
 const setGainSchema = z.object({ type: z.literal("set-gain"), clipId: z.string().min(1), gainDb: z.number().finite(), baseRevision: revisionSchema });
+const reduceNoiseSchema = z.object({
+  type: z.literal("reduce-noise"),
+  clipId: z.string().min(1),
+  range: rangeSchema,
+  reductionDb: z.number().finite().positive(),
+  baseRevision: revisionSchema,
+});
 const rippleDeleteSchema = z.object({ type: z.literal("ripple-delete"), timelineId: z.string().min(1), range: rangeSchema, reason: z.string().optional(), baseRevision: revisionSchema });
 const addMarkerSchema = z.object({ type: z.literal("add-marker"), timelineId: z.string().min(1), marker: markerSchema, baseRevision: revisionSchema });
 const roughCutImportSchema = z.object({
@@ -108,6 +115,7 @@ const editOperationSchema = z.discriminatedUnion("type", [
   renameClipSchema,
   trimClipSchema,
   setGainSchema,
+  reduceNoiseSchema,
   rippleDeleteSchema,
   addMarkerSchema,
 ]);
@@ -130,6 +138,12 @@ const verificationAssertionSchema = z.discriminatedUnion("type", [
     mediaId: z.string().min(1),
     targetLufs: z.number().finite(),
     toleranceDb: z.number().finite().nonnegative().optional(),
+  }),
+  z.object({
+    type: z.literal("audio-noise"),
+    mediaId: z.string().min(1),
+    maxNoiseFloorDb: z.number().finite(),
+    minConfidence: z.number().finite().min(0).max(1).optional(),
   }),
   z.object({
     type: z.literal("audio-source"),
@@ -172,12 +186,13 @@ const verificationPolicySchema = z.object({
   assertions: z.array(verificationAssertionSchema).optional(),
 }).strict();
 const editToolInputSchema = z.object({
-  type: z.enum(["rename-clip", "trim-clip", "set-gain", "ripple-delete", "add-marker"]),
+  type: z.enum(["rename-clip", "trim-clip", "set-gain", "reduce-noise", "ripple-delete", "add-marker"]),
   clipId: z.string().min(1).optional(),
   name: z.string().min(1).optional(),
   duration: z.number().positive().optional(),
   durationTime: rationalTimeSchema.optional(),
   gainDb: z.number().finite().optional(),
+  reductionDb: z.number().finite().positive().optional(),
   timelineId: z.string().min(1).optional(),
   range: rangeSchema.optional(),
   reason: z.string().optional(),
@@ -203,6 +218,7 @@ const workflowOperationSchema = z.discriminatedUnion("type", [
   renameClipSchema,
   trimClipSchema,
   setGainSchema,
+  reduceNoiseSchema,
   rippleDeleteSchema,
   addMarkerSchema,
   z.object({
@@ -340,6 +356,14 @@ const dialogueNormalizationInputSchema = {
   minGainDb: z.number().finite(),
   maxGainDb: z.number().finite(),
   minDialogueDurationSeconds: z.number().finite().nonnegative(),
+};
+const noiseReductionInputSchema = {
+  mediaId: z.string().trim().min(1),
+  occurrenceId: z.string().trim().min(1),
+  baseRevision: revisionValueSchema,
+  noiseThresholdDb: z.number().finite(),
+  maxReductionDb: z.number().finite().positive(),
+  minConfidence: z.number().finite().min(0).max(1),
 };
 const nativeEditSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("rename-selected-clip"), name: z.string().min(1) }),
@@ -1144,6 +1168,28 @@ export function createMcpServer(runtime: AgentVideoRuntime, options: McpServerOp
     description: "Analyze loudness, true peak, and silence for one media item.",
     inputSchema: { mediaId: z.string().min(1) },
   }, async ({ mediaId }) => jsonResult(await runtime.analyzeAudio(mediaId)));
+
+  server.registerTool("audio.noise.analyze", {
+    description: "Analyze unwanted background noise for one media item when a noise analyzer is configured.",
+    inputSchema: { mediaId: z.string().min(1), range: rangeSchema.optional() },
+  }, async ({ mediaId, range }) => jsonResult(await runtime.analyzeNoise(mediaId, range)));
+
+  server.registerTool("audio.noise.reduce.preview", {
+    description: "Preview a bounded noise-reduction adjustment and its affected ranges without mutating the editor.",
+    inputSchema: noiseReductionInputSchema,
+  }, async (request) => {
+    const { baseRevision, ...input } = request;
+    return skillPreviewResult(await runtime.previewSkill({
+      skillId: "audio-noise-reduction",
+      baseRevision,
+      input,
+    }));
+  });
+
+  server.registerTool("audio.noise.reduce.execute", {
+    description: "Execute one previewed noise-reduction adjustment and return post-write measurement verification and rollback state.",
+    inputSchema: { previewToken: z.string().min(1) },
+  }, async ({ previewToken }) => jsonResult(await runtime.executeSkill(previewToken)));
 
   server.registerTool("edit.diff", {
     description: "Read the deterministic diff for a completed edit transaction.",

--- a/docs/mcp/skills.md
+++ b/docs/mcp/skills.md
@@ -27,6 +27,7 @@ Skills currently exposed by the generic surface are:
 | --- | --- | --- |
 | `filler-removal` | 1.0.0 | speech analysis, safe deletion, re-analysis, verification, rollback |
 | `dialogue-normalization` | 1.0.0 | dialogue measurement, bounded gain, re-measurement, verification, rollback |
+| `audio-noise-reduction` | 1.0.0 | noise analysis, affected-range preview, bounded reduction, re-analysis, verification, rollback |
 
 ## Execution contract
 
@@ -50,6 +51,13 @@ dialogue loudness and true peak before planning gain, returns `NO_OP` for clips
 inside tolerance, and returns `SKIP` for silence, missing dialogue, invalid
 measurements, clamp violations, or peak risk. Verification uses a new
 post-write measurement rather than the estimate.
+
+`audio-noise-reduction` requires an explicitly configured noise analyzer and an
+editor-native noise-reduction capability. It reports revision-bound noise
+measurements, affected ranges, and a bounded reduction adjustment. The runtime
+re-analyzes the edited range after execution and rolls back when the configured
+noise-floor threshold is not met. Missing analyzer or effect capability fails
+closed before mutation.
 
 Both workflows require canonical read, supported timeline write, read-after-write,
 analysis, and rollback capabilities. Missing capabilities fail closed before

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -82,6 +82,9 @@ this routing tool.
 | `media.index` | Query analyzed media by semantic properties, capabilities, and usable ranges | Fixture or configured analyzer providers; unconfigured capabilities are explicit |
 | `speech.analyze` | Speech and filler analysis | Fixture or configured local JSON provider |
 | `audio.analyze` | Loudness, peak, and silence analysis | Fixture or configured local JSON provider |
+| `audio.noise.analyze` | Noise-floor analysis and affected ranges | Requires a configured noise analyzer |
+| `audio.noise.reduce.preview` | Preview a bounded noise-reduction adjustment for one audio occurrence | Requires noise analysis, native noise-reduction capability, and canonical transaction guarantees |
+| `audio.noise.reduce.execute` | Execute the noise preview and return post-write measurement verification/rollback evidence | Use `edit.undo` with the returned transaction ID for a later reversal |
 | `visual.analyze` | Scenes, subjects, motion, and keyframes | Fixture or configured local JSON provider |
 | `media.understand` | Combined speech, audio, visual, and metadata understanding | Returns per-capability analyzed or unavailable statuses |
 | `rough-cut.plan` | Explainable read-only shot plan from semantic media ranges | Requires analyzed usable ranges; never mutates the timeline |

--- a/packages/runtime/src/application/media-analysis-service.ts
+++ b/packages/runtime/src/application/media-analysis-service.ts
@@ -13,6 +13,8 @@ import type {
   RoughCutPlanRequest,
   MediaUnderstanding,
   MediaSourceIdentity,
+  NoiseAnalysis,
+  NoiseMeasurement,
   SpeechAnalysis,
   VisualAnalysis,
 } from "../domain/media.js";
@@ -43,6 +45,13 @@ export class MediaAnalysisService {
     const project = await this.project.inspectProject();
     const media = findMedia(project, mediaId);
     return this.options.audioAnalyzer.analyze({ project, media });
+  }
+
+  public async analyzeNoise(mediaId: string, range?: TimeRange): Promise<NoiseAnalysis> {
+    if (!this.options.noiseAnalyzer) throw new Error("CAPABILITY_UNAVAILABLE: audio noise analysis");
+    const project = await this.project.inspectProject();
+    const media = findMedia(project, mediaId);
+    return this.options.noiseAnalyzer.analyze({ project, media }, range);
   }
 
   public async measureAudio(mediaId: string, occurrenceId: string): Promise<AudioMeasurement> {
@@ -84,6 +93,43 @@ export class MediaAnalysisService {
     };
   }
 
+  public async measureNoise(mediaId: string, occurrenceId: string): Promise<NoiseMeasurement> {
+    if (!this.options.noiseAnalyzer) throw new Error("CAPABILITY_UNAVAILABLE: audio noise analysis");
+    const project = await this.project.inspectProject();
+    const clip = project.timeline.clips.find((candidate) => candidate.id === occurrenceId);
+    if (!clip) throw new Error(`OCCURRENCE_NOT_FOUND: ${occurrenceId}`);
+    if (clip.mediaId !== mediaId) {
+      throw new Error(`TARGET_MISMATCH: occurrence ${occurrenceId} does not reference media ${mediaId}`);
+    }
+    const media = findMedia(project, mediaId);
+    const requestedRange = { start: 0, end: clip.duration };
+    const analysis = await this.options.noiseAnalyzer.analyze({ project, media }, requestedRange);
+    const measuredEnd = analysis.affectedRanges.reduce((end, range) => Math.max(end, range.end), 0);
+    const measuredRange = {
+      start: 0,
+      end: Math.max(analysis.affectedRanges.length > 0 ? measuredEnd : requestedRange.end, 0),
+    };
+    const valid = analysis.valid !== false
+      && Number.isFinite(analysis.noiseFloorDb)
+      && Number.isFinite(analysis.recommendedReductionDb)
+      && Number.isFinite(analysis.confidence)
+      && analysis.confidence >= 0
+      && analysis.confidence <= 1
+      && analysis.affectedRanges.every((range) => Number.isFinite(range.start)
+        && Number.isFinite(range.end) && range.start >= 0 && range.end > range.start);
+    return {
+      ...structuredClone(analysis),
+      mediaId,
+      occurrenceId,
+      requestedRange,
+      measuredRange,
+      revision: project.revision,
+      provider: this.options.noiseAnalyzer.descriptor ?? { id: "framekit.audio-noise", provider: "unknown" },
+      valid,
+      ...(analysis.invalidReason ? { invalidReason: analysis.invalidReason } : {}),
+    };
+  }
+
   public async analyzeVisual(mediaId: string, range?: TimeRange): Promise<VisualAnalysis> {
     if (!this.options.visualAnalyzer) throw new Error("CAPABILITY_UNAVAILABLE: visual analysis");
     const project = await this.project.inspectProject();
@@ -95,14 +141,16 @@ export class MediaAnalysisService {
     const project = await this.project.inspectProject();
     const media = findMedia(project, mediaId);
     const input = { project, media };
-    const [speechResult, audioResult, visualResult, metadataResult] = await Promise.all([
+    const [speechResult, audioResult, noiseResult, visualResult, metadataResult] = await Promise.all([
       settle(() => this.options.speechAnalyzer?.analyze(input)),
       settle(() => this.options.audioAnalyzer?.analyze(input)),
+      settle(() => this.options.noiseAnalyzer?.analyze(input)),
       settle(() => this.options.visualAnalyzer?.analyze(input)),
       settle(() => this.options.metadataAnalyzer?.analyze(input)),
     ]);
     const speech = fulfilledValue(speechResult);
     const audio = fulfilledValue(audioResult);
+    const noise = fulfilledValue(noiseResult);
     const visual = fulfilledValue(visualResult);
     const metadata = fulfilledValue(metadataResult);
     const sourceIdentity = sourceIdentityOf(media);
@@ -113,11 +161,13 @@ export class MediaAnalysisService {
       ...(metadata ? { metadata } : {}),
       ...(speech ? { speech } : {}),
       ...(audio ? { audio } : {}),
+      ...(noise ? { noise } : {}),
       ...(visual ? { visual } : {}),
       semantic: semanticFromAnalyses(speech, audio, visual, metadata),
       analysis: [
         analysisStatus("speech", this.options.speechAnalyzer, sourceIdentity, Boolean(speech), [], failureReason(speechResult)),
         analysisStatus("audio", this.options.audioAnalyzer, sourceIdentity, Boolean(audio), [], failureReason(audioResult)),
+        analysisStatus("noise", this.options.noiseAnalyzer, sourceIdentity, Boolean(noise), noise?.affectedRanges, failureReason(noiseResult)),
         analysisStatus("visual", this.options.visualAnalyzer, sourceIdentity, Boolean(visual), [], failureReason(visualResult)),
         analysisStatus("metadata", this.options.metadataAnalyzer, sourceIdentity, Boolean(metadata), metadata?.usableRanges, failureReason(metadataResult)),
       ],
@@ -159,6 +209,7 @@ export class MediaAnalysisService {
         analysis: media.analysis ?? [
           analysisStatus("speech", this.options.speechAnalyzer, sourceIdentityOf(media), false),
           analysisStatus("audio", this.options.audioAnalyzer, sourceIdentityOf(media), false),
+          analysisStatus("noise", this.options.noiseAnalyzer, sourceIdentityOf(media), false),
           analysisStatus("visual", this.options.visualAnalyzer, sourceIdentityOf(media), false),
           analysisStatus("metadata", this.options.metadataAnalyzer, sourceIdentityOf(media), false),
         ],
@@ -200,6 +251,10 @@ export class MediaAnalysisService {
         const analyses = await Promise.all(ranges.map((range) => this.options.audioAnalyzer!.analyze(input, range)));
         if (analyses[analyses.length - 1]) media.audio = analyses[analyses.length - 1];
       }
+      if (this.options.noiseAnalyzer) {
+        const analyses = await Promise.all(ranges.map((range) => this.options.noiseAnalyzer!.analyze(input, range)));
+        if (analyses[analyses.length - 1]) media.noise = analyses[analyses.length - 1];
+      }
       if (this.options.visualAnalyzer) {
         const analyses = await Promise.all(ranges.map((range) => this.options.visualAnalyzer!.analyze(input, range)));
         media.visual = {
@@ -209,7 +264,7 @@ export class MediaAnalysisService {
           motion: analyses[analyses.length - 1]?.motion,
         };
       }
-      if (this.options.speechAnalyzer || this.options.audioAnalyzer || this.options.visualAnalyzer) {
+      if (this.options.speechAnalyzer || this.options.audioAnalyzer || this.options.noiseAnalyzer || this.options.visualAnalyzer) {
         for (const candidate of next.media) {
           if (candidate.mediaId === mediaId) candidate.analysisRevision = next.revision.id;
         }

--- a/packages/runtime/src/application/project-service.ts
+++ b/packages/runtime/src/application/project-service.ts
@@ -112,6 +112,7 @@ export class ProjectService {
       ...capabilities.analyzers,
       speechTranscribe: capabilities.analyzers.speechTranscribe || Boolean(this.options.speechAnalyzer),
       audioLoudness: capabilities.analyzers.audioLoudness || Boolean(this.options.audioAnalyzer),
+      audioNoise: capabilities.analyzers.audioNoise || Boolean(this.options.noiseAnalyzer),
       visualTrack: capabilities.analyzers.visualTrack || Boolean(this.options.visualAnalyzer),
       metadataDescribe: capabilities.analyzers.metadataDescribe || Boolean(this.options.metadataAnalyzer),
     };

--- a/packages/runtime/src/application/runtime-options.ts
+++ b/packages/runtime/src/application/runtime-options.ts
@@ -1,5 +1,6 @@
 import type {
   AudioAnalyzer,
+  NoiseAnalyzer,
   MetadataAnalyzer,
   SpeechAnalyzer,
   VisualAnalyzer,
@@ -9,6 +10,7 @@ import type { VerificationEngine } from "../domain/verification.js";
 export interface RuntimeOptions {
   speechAnalyzer?: SpeechAnalyzer;
   audioAnalyzer?: AudioAnalyzer;
+  noiseAnalyzer?: NoiseAnalyzer;
   visualAnalyzer?: VisualAnalyzer;
   metadataAnalyzer?: MetadataAnalyzer;
   verificationEngine?: VerificationEngine;

--- a/packages/runtime/src/audio/noise-reduction.ts
+++ b/packages/runtime/src/audio/noise-reduction.ts
@@ -1,0 +1,101 @@
+import type { ContextRevision } from "../domain/primitives.js";
+import type { EditOperation } from "../domain/editing.js";
+import type { NoiseMeasurement } from "../domain/media.js";
+import type { TimelineDiff } from "../domain/diff.js";
+
+export type NoiseReductionDecision = "APPLY" | "NO_OP" | "SKIP";
+
+export type NoiseReductionReasonCode =
+  | "APPLY_NOISE_REDUCTION"
+  | "ALREADY_BELOW_THRESHOLD"
+  | "MEASUREMENT_INVALID"
+  | "NO_AFFECTED_RANGE"
+  | "CONFIDENCE_TOO_LOW"
+  | "REDUCTION_INVALID";
+
+export interface NoiseReductionPlanningOptions {
+  noiseThresholdDb: number;
+  maxReductionDb: number;
+  minConfidence: number;
+}
+
+export interface NoiseReductionRequest extends NoiseReductionPlanningOptions {
+  mediaId: string;
+  occurrenceId: string;
+  baseRevision: ContextRevision;
+}
+
+export interface NoiseReductionPlan extends NoiseReductionPlanningOptions {
+  decision: NoiseReductionDecision;
+  noiseFloorDb: number;
+  recommendedReductionDb: number;
+  reductionDb: number;
+  affectedRanges: NoiseMeasurement["affectedRanges"];
+  reasonCodes: NoiseReductionReasonCode[];
+}
+
+export interface NoiseReductionPreview {
+  measurement: NoiseMeasurement;
+  plan: NoiseReductionPlan;
+  operations: EditOperation[];
+  expectedDiff?: TimelineDiff;
+  previewToken?: string;
+  warnings: string[];
+  expiresAt?: string;
+}
+
+export function planNoiseReduction(
+  measurement: NoiseMeasurement,
+  options: NoiseReductionPlanningOptions,
+): NoiseReductionPlan {
+  validateOptions(options);
+  const recommendedReductionDb = finiteOrZero(measurement.recommendedReductionDb);
+  const reductionDb = Math.min(Math.max(recommendedReductionDb, 0), options.maxReductionDb);
+  const base = {
+    ...structuredClone(options),
+    noiseFloorDb: measurement.noiseFloorDb,
+    recommendedReductionDb,
+    reductionDb,
+    affectedRanges: clampRanges(measurement.affectedRanges, measurement.requestedRange),
+  };
+  if (measurement.valid !== true || !Number.isFinite(measurement.noiseFloorDb)) {
+    return { ...base, decision: "SKIP", reasonCodes: ["MEASUREMENT_INVALID"] };
+  }
+  if (measurement.noiseFloorDb <= options.noiseThresholdDb) {
+    return { ...base, decision: "NO_OP", reductionDb: 0, reasonCodes: ["ALREADY_BELOW_THRESHOLD"] };
+  }
+  if (measurement.confidence < options.minConfidence) {
+    return { ...base, decision: "SKIP", reasonCodes: ["CONFIDENCE_TOO_LOW"] };
+  }
+  if (base.affectedRanges.length === 0) {
+    return { ...base, decision: "SKIP", reasonCodes: ["NO_AFFECTED_RANGE"] };
+  }
+  if (!Number.isFinite(recommendedReductionDb) || recommendedReductionDb <= 0 || reductionDb <= 0) {
+    return { ...base, decision: "SKIP", reasonCodes: ["REDUCTION_INVALID"] };
+  }
+  return { ...base, decision: "APPLY", reasonCodes: ["APPLY_NOISE_REDUCTION"] };
+}
+
+function validateOptions(options: NoiseReductionPlanningOptions): void {
+  if (!Number.isFinite(options.noiseThresholdDb)
+    || !Number.isFinite(options.maxReductionDb) || options.maxReductionDb <= 0
+    || !Number.isFinite(options.minConfidence) || options.minConfidence < 0 || options.minConfidence > 1) {
+    throw new Error("INVALID_OPERATION: noise reduction policy is invalid");
+  }
+}
+
+function clampRanges(
+  ranges: NoiseMeasurement["affectedRanges"],
+  bounds: { start: number; end: number },
+): NoiseMeasurement["affectedRanges"] {
+  return ranges
+    .map((range) => ({
+      start: Math.max(bounds.start, range.start),
+      end: Math.min(bounds.end, range.end),
+    }))
+    .filter((range) => Number.isFinite(range.start) && Number.isFinite(range.end) && range.end > range.start);
+}
+
+function finiteOrZero(value: number): number {
+  return Number.isFinite(value) ? value : 0;
+}

--- a/packages/runtime/src/capabilities.ts
+++ b/packages/runtime/src/capabilities.ts
@@ -150,6 +150,7 @@ export function withCapabilityFamilies(
       speechTranscribe: analyzerDescriptor(capabilities.analyzers.speechTranscribe, options.analyzerBackend ?? backend, "speech transcription"),
       speechVad: analyzerDescriptor(capabilities.analyzers.speechVad, options.analyzerBackend ?? backend, "speech VAD"),
       audioLoudness: analyzerDescriptor(capabilities.analyzers.audioLoudness, options.analyzerBackend ?? backend, "audio loudness analysis"),
+      audioNoise: analyzerDescriptor(Boolean(capabilities.analyzers.audioNoise), options.analyzerBackend ?? backend, "audio noise analysis"),
       visualTrack: analyzerDescriptor(capabilities.analyzers.visualTrack, options.analyzerBackend ?? backend, "visual analysis"),
     },
   };

--- a/packages/runtime/src/domain/capabilities.ts
+++ b/packages/runtime/src/domain/capabilities.ts
@@ -41,6 +41,8 @@ export interface EditorCapabilities {
   transitionPlacement?: boolean;
   audioAttachment?: boolean;
   audioMixing?: boolean;
+  noiseReduction?: boolean;
+  colorCorrection?: boolean;
   /** Explicit semantic operation guarantees; timelineWrite alone is insufficient. */
   semanticOperations?: Partial<Record<string, boolean>>;
 }
@@ -49,6 +51,7 @@ export interface AnalyzerCapabilities {
   speechTranscribe: boolean;
   speechVad: boolean;
   audioLoudness: boolean;
+  audioNoise?: boolean;
   visualTrack: boolean;
   metadataDescribe?: boolean;
 }
@@ -114,6 +117,7 @@ export interface CapabilityFamilies {
     speechTranscribe: CapabilityDescriptor;
     speechVad: CapabilityDescriptor;
     audioLoudness: CapabilityDescriptor;
+    audioNoise?: CapabilityDescriptor;
     visualTrack: CapabilityDescriptor;
   };
 }

--- a/packages/runtime/src/domain/editing.ts
+++ b/packages/runtime/src/domain/editing.ts
@@ -50,6 +50,19 @@ export type EditOperation =
       baseRevision?: ContextRevision;
     }
   | {
+      type: "reduce-noise";
+      clipId: string;
+      range: TimeRange;
+      reductionDb: number;
+      baseRevision?: ContextRevision;
+    }
+  | {
+      type: "set-color-correction";
+      clipId: string;
+      correction: import("./project.js").ColorCorrection;
+      baseRevision?: ContextRevision;
+    }
+  | {
       type: "ripple-delete";
       timelineId: string;
       range: TimeRange;

--- a/packages/runtime/src/domain/media.ts
+++ b/packages/runtime/src/domain/media.ts
@@ -21,7 +21,7 @@ export interface SpeechSegment {
   confidence?: number;
 }
 
-export type MediaAnalysisCapability = "metadata" | "speech" | "audio" | "visual";
+export type MediaAnalysisCapability = "metadata" | "speech" | "audio" | "noise" | "visual";
 
 export interface SemanticTag {
   value: string;
@@ -151,6 +151,27 @@ export interface AudioAnalysis {
   invalidReason?: string;
 }
 
+/** Provider output for locating and reducing unwanted background noise. */
+export interface NoiseAnalysis {
+  noiseFloorDb: number;
+  peakNoiseDb?: number;
+  affectedRanges: TimeRange[];
+  recommendedReductionDb: number;
+  confidence: number;
+  valid?: boolean;
+  invalidReason?: string;
+}
+
+/** Revision-bound noise evidence for one complete timeline occurrence. */
+export interface NoiseMeasurement extends NoiseAnalysis {
+  mediaId: string;
+  occurrenceId: string;
+  requestedRange: TimeRange;
+  measuredRange: TimeRange;
+  revision: ContextRevision;
+  provider: AnalyzerDescriptor;
+}
+
 /** Revision-bound audio evidence for one complete timeline occurrence. */
 export interface AudioMeasurement {
   mediaId: string;
@@ -237,6 +258,7 @@ export interface MediaContext {
   semantic?: MediaSemanticDescription;
   speech?: SpeechAnalysis;
   audio?: AudioAnalysis;
+  noise?: NoiseAnalysis;
   visual?: VisualAnalysis;
   /** Revision of the source context used to produce attached analysis. */
   analysisRevision?: string;
@@ -249,6 +271,7 @@ export interface MediaUnderstanding {
   metadata?: MetadataAnalysis;
   speech?: SpeechAnalysis;
   audio?: AudioAnalysis;
+  noise?: NoiseAnalysis;
   visual?: VisualAnalysis;
   semantic: MediaSemanticDescription;
   analysis: MediaAnalysisStatus[];
@@ -267,6 +290,11 @@ export interface SpeechAnalyzer {
 
 export interface AudioAnalyzer {
   analyze(input: AnalysisInput, range?: TimeRange): Promise<AudioAnalysis>;
+  readonly descriptor?: AnalyzerDescriptor;
+}
+
+export interface NoiseAnalyzer {
+  analyze(input: AnalysisInput, range?: TimeRange): Promise<NoiseAnalysis>;
   readonly descriptor?: AnalyzerDescriptor;
 }
 

--- a/packages/runtime/src/domain/project.ts
+++ b/packages/runtime/src/domain/project.ts
@@ -2,6 +2,17 @@ import type { ContextRevision, RationalTime } from "./primitives.js";
 
 import type { MediaContext } from "./media.js";
 
+export type ColorCorrectionPreset = "neutral" | "warm" | "cool" | "high-contrast";
+
+export interface ColorCorrection {
+  exposure: number;
+  contrast: number;
+  saturation: number;
+  temperature: number;
+  tint: number;
+  preset?: ColorCorrectionPreset;
+}
+
 export interface Clip {
   /** Stable identity of this timeline occurrence, never the media resource id. */
   id: string;
@@ -11,6 +22,8 @@ export interface Clip {
   duration: number;
   track: number;
   gainDb?: number;
+  noiseReductionDb?: number;
+  colorCorrection?: ColorCorrection;
   fadeIn?: number;
   fadeOut?: number;
   enabled?: boolean;

--- a/packages/runtime/src/domain/skills.ts
+++ b/packages/runtime/src/domain/skills.ts
@@ -4,7 +4,7 @@ import type { ProjectSnapshot } from "./project.js";
 import type { WorkflowOperation } from "./editing.js";
 import type { TimelineDiff } from "./diff.js";
 import type { VerificationPolicy, VerificationReport } from "./verification.js";
-import type { AudioMeasurement, SpeechAnalysis } from "./media.js";
+import type { AudioMeasurement, NoiseMeasurement, SpeechAnalysis } from "./media.js";
 
 /** Version of the editor-independent Skill contract. */
 export const SKILL_CONTRACT_VERSION = 1 as const;
@@ -63,12 +63,15 @@ export type EditorSkillCapability =
   | "clipRemoval"
   | "transitionPlacement"
   | "audioAttachment"
-  | "audioMixing";
+  | "audioMixing"
+  | "noiseReduction"
+  | "colorCorrection";
 
 export type AnalyzerSkillCapability =
   | "speechTranscribe"
   | "speechVad"
   | "audioLoudness"
+  | "audioNoise"
   | "visualTrack"
   | "metadataDescribe";
 
@@ -77,6 +80,8 @@ export const SKILL_OPERATIONS = [
   "rename-clip",
   "trim-clip",
   "set-gain",
+  "reduce-noise",
+  "set-color-correction",
   "ripple-delete",
   "add-marker",
   "media.import",
@@ -118,6 +123,7 @@ export interface SkillPlanningContext {
   baseRevision: ContextRevision;
   analyzeSpeech?: (mediaId: string, range?: TimeRange) => Promise<SpeechAnalysis>;
   measureAudio?: (mediaId: string, occurrenceId: string) => Promise<AudioMeasurement>;
+  measureNoise?: (mediaId: string, occurrenceId: string) => Promise<NoiseMeasurement>;
 }
 
 export interface SkillPlan {

--- a/packages/runtime/src/domain/verification.ts
+++ b/packages/runtime/src/domain/verification.ts
@@ -1,5 +1,6 @@
 import type { EditTransaction } from "./editing.js";
 import type { EditTarget } from "./editing.js";
+import type { ColorCorrection } from "./project.js";
 
 export interface AudioAudibilityAssertion {
   type: "audio-audibility";
@@ -21,6 +22,13 @@ export interface AudioLoudnessAssertion {
   mediaId: string;
   targetLufs: number;
   toleranceDb?: number;
+}
+
+export interface AudioNoiseAssertion {
+  type: "audio-noise";
+  mediaId: string;
+  maxNoiseFloorDb: number;
+  minConfidence?: number;
 }
 
 export interface AudioSourceAssertion {
@@ -59,15 +67,23 @@ export interface StructureAssertion {
   operationType?: string;
 }
 
+export interface ColorCorrectionAssertion {
+  type: "color-correction";
+  clipId: string;
+  expected: ColorCorrection;
+}
+
 export type VerificationAssertion =
   | AudioAudibilityAssertion
   | AudioCoverageAssertion
   | AudioLoudnessAssertion
+  | AudioNoiseAssertion
   | AudioSourceAssertion
   | VisualContentAssertion
   | DurationAssertion
   | StreamAssertion
-  | StructureAssertion;
+  | StructureAssertion
+  | ColorCorrectionAssertion;
 
 export interface VerificationPolicy {
   requireExpectedChange?: boolean;

--- a/packages/runtime/src/editing/edit-service.ts
+++ b/packages/runtime/src/editing/edit-service.ts
@@ -385,6 +385,12 @@ export class EditService {
     if (operations.some((operation) => operation.type === "timeline.audio.mix") && !capabilities.audioMixing) {
       throw new Error("CAPABILITY_UNAVAILABLE: timeline audio mixing");
     }
+    if (operations.some((operation) => operation.type === "reduce-noise") && !capabilities.noiseReduction) {
+      throw new Error("CAPABILITY_UNAVAILABLE: noise reduction effect");
+    }
+    if (operations.some((operation) => operation.type === "set-color-correction") && !capabilities.colorCorrection) {
+      throw new Error("CAPABILITY_UNAVAILABLE: color correction");
+    }
   }
 
   private async defaultTarget(

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -9,7 +9,6 @@ export * from "./timeline/snapshot-digest.js";
 export * from "./speech/filler-removal.js";
 export * from "./audio/dialogue-normalization.js";
 export * from "./audio/noise-reduction.js";
-export * from "./color-correction.js";
 export * from "./domain/skills.js";
 export * from "./skills/requirements.js";
 export * from "./skills/index.js";

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -8,6 +8,8 @@ export * from "./capabilities.js";
 export * from "./timeline/snapshot-digest.js";
 export * from "./speech/filler-removal.js";
 export * from "./audio/dialogue-normalization.js";
+export * from "./audio/noise-reduction.js";
+export * from "./color-correction.js";
 export * from "./domain/skills.js";
 export * from "./skills/requirements.js";
 export * from "./skills/index.js";

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -3,6 +3,7 @@ import type {
   AgentContext,
   AssetSearchQuery,
   AudioAnalysis,
+  NoiseAnalysis,
   CompositeEditPreview,
   CompositeEditRequest,
   ContextDiff,
@@ -261,6 +262,10 @@ export class AgentVideoRuntime {
 
   public async analyzeAudio(mediaId: string): Promise<AudioAnalysis> {
     return this.media.analyzeAudio(mediaId);
+  }
+
+  public async analyzeNoise(mediaId: string, range?: TimeRange): Promise<NoiseAnalysis> {
+    return this.media.analyzeNoise(mediaId, range);
   }
 
   public async analyzeVisual(mediaId: string, range?: TimeRange): Promise<VisualAnalysis> {

--- a/packages/runtime/src/skills/builtin.ts
+++ b/packages/runtime/src/skills/builtin.ts
@@ -3,10 +3,11 @@ import type { TimeRange } from "../domain/primitives.js";
 import { planFillerRemoval } from "../speech/filler-removal.js";
 import { translateRationalRange } from "../timeline/rational-time.js";
 import { planDialogueGain, type DialogueNormalizationRequest } from "../audio/dialogue-normalization.js";
+import { planNoiseReduction, type NoiseReductionRequest } from "../audio/noise-reduction.js";
 import type { FillerRemovalTarget } from "../speech/filler-removal.js";
 
 export function builtinSkills(): SkillDefinition[] {
-  return [fillerRemovalSkill(), dialogueNormalizationSkill()];
+  return [fillerRemovalSkill(), dialogueNormalizationSkill(), noiseReductionSkill()];
 }
 
 function fillerRemovalSkill(): SkillDefinition {
@@ -146,6 +147,91 @@ function dialogueNormalizationSkill(): SkillDefinition {
     handler: {
       normalize: (input) => input as Record<string, unknown>,
       plan: async (context, input) => planDialogueSkill(context, input),
+    },
+  };
+}
+
+function noiseReductionSkill(): SkillDefinition {
+  return {
+    manifest: {
+      contractVersion: 1,
+      id: "audio-noise-reduction",
+      version: "1.0.0",
+      title: "Audio noise reduction",
+      description: "Detect unwanted background noise and apply a bounded, verified reduction to one audio occurrence.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          mediaId: { type: "string", minLength: 1 },
+          occurrenceId: { type: "string", minLength: 1 },
+          noiseThresholdDb: { type: "number" },
+          maxReductionDb: { type: "number", minimum: 0 },
+          minConfidence: { type: "number", minimum: 0, maximum: 1 },
+        },
+        required: ["mediaId", "occurrenceId", "noiseThresholdDb", "maxReductionDb", "minConfidence"],
+        additionalProperties: false,
+      },
+      requirements: {
+        type: "allOf",
+        requirements: [
+          { type: "editor", capability: "timelineSnapshotRead" },
+          { type: "editor", capability: "timelineWrite" },
+          { type: "editor", capability: "readAfterWrite" },
+          { type: "editor", capability: "rollback" },
+          { type: "editor", capability: "compositeTransactions" },
+          { type: "editor", capability: "noiseReduction" },
+          { type: "analyzer", capability: "audioNoise" },
+          { type: "operation", operation: "reduce-noise" },
+        ],
+      },
+    },
+    handler: {
+      normalize: (input) => input as Record<string, unknown>,
+      plan: async (context, input) => planNoiseSkill(context, input),
+    },
+  };
+}
+
+async function planNoiseSkill(context: SkillPlanningContext, input: Record<string, unknown>) {
+  if (!context.measureNoise) throw new Error("CAPABILITY_UNAVAILABLE: audio noise analysis");
+  const clip = context.project.timeline.clips.find((candidate) => candidate.id === input.occurrenceId);
+  if (!clip) throw new Error(`OCCURRENCE_NOT_FOUND: ${String(input.occurrenceId)}`);
+  if (clip.mediaId !== input.mediaId) {
+    throw new Error(`TARGET_MISMATCH: occurrence ${String(input.occurrenceId)} does not reference media ${String(input.mediaId)}`);
+  }
+  const request = input as unknown as NoiseReductionRequest;
+  const measurement = await context.measureNoise(request.mediaId, request.occurrenceId);
+  const plan = planNoiseReduction(measurement, request);
+  const timelineRanges = plan.decision === "APPLY"
+    ? plan.affectedRanges.map((range) => ({
+      start: clip.start + range.start,
+      end: clip.start + range.end,
+    }))
+    : [];
+  const verification = plan.decision === "APPLY" ? {
+    requireExpectedChange: true,
+    assertions: [{
+      type: "audio-noise" as const,
+      mediaId: request.mediaId,
+      maxNoiseFloorDb: request.noiseThresholdDb,
+      minConfidence: request.minConfidence,
+    }],
+  } : undefined;
+  return {
+    operations: plan.decision === "APPLY" ? timelineRanges.map((range) => ({
+      type: "reduce-noise" as const,
+      clipId: clip.id,
+      range,
+      reductionDb: plan.reductionDb,
+      baseRevision: context.baseRevision,
+    })) : [],
+    affectedRanges: structuredClone(timelineRanges),
+    warnings: plan.decision === "SKIP" ? [...plan.reasonCodes] : [],
+    ...(verification ? { verification } : {}),
+    details: {
+      measurement: structuredClone(measurement),
+      plan: structuredClone(plan),
+      timelineAffectedRanges: structuredClone(timelineRanges),
     },
   };
 }

--- a/packages/runtime/src/skills/requirements.ts
+++ b/packages/runtime/src/skills/requirements.ts
@@ -41,12 +41,15 @@ export const SKILL_EDITOR_CAPABILITIES = [
   "transitionPlacement",
   "audioAttachment",
   "audioMixing",
+  "noiseReduction",
+  "colorCorrection",
 ] as const satisfies readonly EditorSkillCapability[];
 
 export const SKILL_ANALYZER_CAPABILITIES = [
   "speechTranscribe",
   "speechVad",
   "audioLoudness",
+  "audioNoise",
   "visualTrack",
   "metadataDescribe",
 ] as const satisfies readonly AnalyzerSkillCapability[];

--- a/packages/runtime/src/skills/runtime.ts
+++ b/packages/runtime/src/skills/runtime.ts
@@ -100,6 +100,7 @@ export class SkillRuntime {
       baseRevision: structuredClone(before.revision),
       analyzeSpeech: (mediaId: string, range?: import("../domain/primitives.js").TimeRange) => this.analysis.analyzeSpeech(mediaId, range),
       measureAudio: (mediaId: string, occurrenceId: string) => this.analysis.measureAudio(mediaId, occurrenceId),
+      measureNoise: (mediaId: string, occurrenceId: string) => this.analysis.measureNoise(mediaId, occurrenceId),
     });
     const planned = await definition.handler.plan(handlerContext, normalizedInput);
     const plan: SkillPlan = {

--- a/packages/runtime/src/verification/verification.ts
+++ b/packages/runtime/src/verification/verification.ts
@@ -3,6 +3,7 @@ import type {
   AudioAudibilityAssertion,
   AudioCoverageAssertion,
   AudioLoudnessAssertion,
+  AudioNoiseAssertion,
   AudioSourceAssertion,
   DurationAssertion,
   StreamAssertion,
@@ -13,6 +14,7 @@ import type {
   VerificationReport,
   VerificationAssertion,
   VisualContentAssertion,
+  ColorCorrectionAssertion,
 } from "../domain/verification.js";
 
 export function assertValidVerificationPolicy(policy: VerificationPolicy): void {
@@ -66,6 +68,14 @@ function validateAssertion(assertion: VerificationAssertion, index: number): voi
     }
     return;
   }
+  if (assertion.type === "audio-noise") {
+    if (!Number.isFinite(assertion.maxNoiseFloorDb)
+      || assertion.minConfidence !== undefined
+      && (!Number.isFinite(assertion.minConfidence) || assertion.minConfidence < 0 || assertion.minConfidence > 1)) {
+      throw new Error(`INVALID_VERIFICATION_POLICY: ${path} has invalid noise values`);
+    }
+    return;
+  }
   if (assertion.type === "audio-source") {
     if (assertion.sourceDigest === undefined && assertion.source === undefined) {
       throw new Error(`INVALID_VERIFICATION_POLICY: ${path} requires sourceDigest or source`);
@@ -93,6 +103,12 @@ function validateAssertion(assertion: VerificationAssertion, index: number): voi
       || (assertion.requirement === "occurrence-present" && assertion.occurrenceId === undefined)
       || (assertion.requirement === "operation-present" && assertion.operationType === undefined)) {
       throw new Error(`INVALID_VERIFICATION_POLICY: ${path} is missing its required identifier`);
+    }
+    return;
+  }
+  if (assertion.type === "color-correction") {
+    if (!assertion.clipId.trim() || !assertion.expected || typeof assertion.expected !== "object") {
+      throw new Error(`INVALID_VERIFICATION_POLICY: ${path} has invalid color correction values`);
     }
     return;
   }
@@ -200,11 +216,13 @@ export class DefaultVerificationEngine implements VerificationEngine {
 function verifyAssertion(transaction: EditTransaction, assertion: VerificationAssertion): VerificationCheck {
   if (assertion.type === "audio-coverage") return verifyAudioCoverage(transaction, assertion);
   if (assertion.type === "audio-loudness") return verifyAudioLoudness(transaction, assertion);
+  if (assertion.type === "audio-noise") return verifyAudioNoise(transaction, assertion);
   if (assertion.type === "audio-source") return verifyAudioSource(transaction, assertion);
   if (assertion.type === "visual-content") return verifyVisualContent(transaction, assertion);
   if (assertion.type === "duration") return verifyDuration(transaction, assertion);
   if (assertion.type === "stream") return verifyStream(transaction, assertion);
   if (assertion.type === "structure") return verifyStructure(transaction, assertion);
+  if (assertion.type === "color-correction") return verifyColorCorrection(transaction, assertion);
   return verifyAudioAudibility(transaction, assertion);
 }
 
@@ -372,6 +390,58 @@ function verifyAudioLoudness(transaction: EditTransaction, assertion: AudioLoudn
   };
 }
 
+function verifyAudioNoise(transaction: EditTransaction, assertion: AudioNoiseAssertion): VerificationCheck {
+  const expected = {
+    mediaId: assertion.mediaId,
+    maxNoiseFloorDb: assertion.maxNoiseFloorDb,
+    ...(assertion.minConfidence !== undefined ? { minConfidence: assertion.minConfidence } : {}),
+  };
+  const media = transaction.attemptedAfter.media.find((candidate) => candidate.mediaId === assertion.mediaId);
+  if (!media) {
+    return {
+      name: assertion.type,
+      passed: false,
+      status: "failed",
+      expected,
+      observed: { mediaId: assertion.mediaId },
+      reason: "MEDIA_NOT_FOUND",
+      detail: `expected audio media ${assertion.mediaId}, but it was not observed`,
+    };
+  }
+  if (!media.noise) {
+    return {
+      name: assertion.type,
+      passed: false,
+      status: "unavailable",
+      expected,
+      observed: { mediaId: assertion.mediaId },
+      reason: "NOISE_ANALYZER_UNAVAILABLE",
+      detail: `noise analysis is unavailable for media ${assertion.mediaId}`,
+    };
+  }
+  const observed = {
+    mediaId: assertion.mediaId,
+    noiseFloorDb: media.noise.noiseFloorDb,
+    confidence: media.noise.confidence,
+    affectedRanges: media.noise.affectedRanges,
+    valid: media.noise.valid !== false,
+  };
+  const passed = observed.valid
+    && observed.noiseFloorDb <= assertion.maxNoiseFloorDb
+    && (assertion.minConfidence === undefined || observed.confidence >= assertion.minConfidence);
+  return {
+    name: assertion.type,
+    passed,
+    status: passed ? "passed" : "failed",
+    expected,
+    observed,
+    ...(passed ? {} : { reason: observed.valid ? "AUDIO_NOISE_OUT_OF_RANGE" : "NOISE_MEASUREMENT_INVALID" }),
+    detail: passed
+      ? `observed noise floor ${observed.noiseFloorDb} dB within the configured limit`
+      : `expected noise floor at or below ${assertion.maxNoiseFloorDb} dB with sufficient confidence`,
+  };
+}
+
 function verifyAudioSource(transaction: EditTransaction, assertion: AudioSourceAssertion): VerificationCheck {
   const expected = {
     mediaId: assertion.mediaId,
@@ -462,6 +532,41 @@ function verifyVisualContent(transaction: EditTransaction, assertion: VisualCont
     detail: passed
       ? `observed ${labelKind} content ${assertion.label} in media ${assertion.mediaId}`
       : `expected ${labelKind} content ${assertion.label} in media ${assertion.mediaId}`,
+  };
+}
+
+function verifyColorCorrection(transaction: EditTransaction, assertion: ColorCorrectionAssertion): VerificationCheck {
+  const clip = transaction.attemptedAfter.timeline.clips.find((candidate) => candidate.id === assertion.clipId);
+  const observed = clip?.colorCorrection;
+  const expected = { clipId: assertion.clipId, correction: assertion.expected };
+  if (!clip) {
+    return {
+      name: assertion.type,
+      passed: false,
+      status: "failed",
+      expected,
+      observed: { clipId: assertion.clipId },
+      reason: "CLIP_NOT_FOUND",
+      detail: `expected color correction target ${assertion.clipId}, but it was not observed`,
+    };
+  }
+  const passed = observed !== undefined
+    && observed.exposure === assertion.expected.exposure
+    && observed.contrast === assertion.expected.contrast
+    && observed.saturation === assertion.expected.saturation
+    && observed.temperature === assertion.expected.temperature
+    && observed.tint === assertion.expected.tint
+    && observed.preset === assertion.expected.preset;
+  return {
+    name: assertion.type,
+    passed,
+    status: passed ? "passed" : "failed",
+    expected,
+    observed: { clipId: assertion.clipId, correction: observed },
+    ...(passed ? {} : { reason: "COLOR_CORRECTION_MISMATCH" }),
+    detail: passed
+      ? `observed the requested color correction on clip ${assertion.clipId}`
+      : `the observed color correction on clip ${assertion.clipId} differed from the requested values`,
   };
 }
 

--- a/packages/testkit/src/in-memory-editor.ts
+++ b/packages/testkit/src/in-memory-editor.ts
@@ -119,10 +119,14 @@ export class InMemoryEditorAdapter implements EditorPort {
         transitionPlacement: true,
         audioAttachment: true,
         audioMixing: true,
+        noiseReduction: true,
+        colorCorrection: true,
         semanticOperations: {
           "rename-clip": true,
           "trim-clip": true,
           "set-gain": true,
+          "reduce-noise": true,
+          "set-color-correction": true,
           "ripple-delete": true,
           "add-marker": true,
           "media.import": true,
@@ -575,6 +579,32 @@ export class InMemoryEditorAdapter implements EditorPort {
         ...(operation.gainDb !== undefined ? { gainDb: operation.gainDb } : {}),
         fadeIn,
         fadeOut,
+      });
+    }
+    if (operation.type === "reduce-noise") {
+      const clip = snapshot.timeline.clips.find(({ id }) => id === operation.clipId);
+      if (!clip) throw new Error(`CLIP_NOT_FOUND: ${operation.clipId}`);
+      const media = clip.mediaId ? snapshot.media.find(({ mediaId }) => mediaId === clip.mediaId) : undefined;
+      if (clip.role !== "audio" && clip.role !== "music" && media?.mediaKind !== "audio") {
+        throw new Error("INVALID_OPERATION: noise reduction requires an audio clip");
+      }
+      if (!Number.isFinite(operation.reductionDb) || operation.reductionDb <= 0
+        || operation.range.start < clip.start
+        || operation.range.end > clip.start + clip.duration
+        || operation.range.end <= operation.range.start) {
+        throw new Error("INVALID_OPERATION: noise reduction range and adjustment must fit the clip");
+      }
+      return this.updateClip(snapshot, {
+        ...clip,
+        noiseReductionDb: (clip.noiseReductionDb ?? 0) + operation.reductionDb,
+      });
+    }
+    if (operation.type === "set-color-correction") {
+      const clip = snapshot.timeline.clips.find(({ id }) => id === operation.clipId);
+      if (!clip) throw new Error(`CLIP_NOT_FOUND: ${operation.clipId}`);
+      return this.updateClip(snapshot, {
+        ...clip,
+        colorCorrection: structuredClone(operation.correction),
       });
     }
     if (operation.type === "ripple-delete") {

--- a/tests/integration/mcp.test.ts
+++ b/tests/integration/mcp.test.ts
@@ -33,6 +33,9 @@ test("Phase 0 exposes read/write/diff through MCP stdio", async () => {
       tools.tools.map((tool) => tool.name).sort(),
       [
         "audio.analyze",
+        "audio.noise.analyze",
+        "audio.noise.reduce.execute",
+        "audio.noise.reduce.preview",
         "skill.execute",
         "skill.inspect",
         "skill.list",
@@ -113,7 +116,7 @@ test("Phase 0 exposes read/write/diff through MCP stdio", async () => {
     );
     const timelineEditTool = tools.tools.find((tool) => tool.name === "editor.timeline.edit");
     assert.deepEqual(Object.keys(timelineEditTool?.inputSchema.properties ?? {}).sort(), [
-      "baseRevision", "clipId", "duration", "durationTime", "gainDb", "marker", "name", "projectId", "range", "reason", "sequenceId", "timelineId", "type", "verification",
+      "baseRevision", "clipId", "duration", "durationTime", "gainDb", "marker", "name", "projectId", "range", "reason", "reductionDb", "sequenceId", "timelineId", "type", "verification",
     ]);
     assert.deepEqual(timelineEditTool?.inputSchema.required?.slice().sort(), ["baseRevision", "projectId", "sequenceId", "type"]);
     const artifactEditTool = tools.tools.find((tool) => tool.name === "artifact.edit");

--- a/tests/integration/noise-reduction.test.ts
+++ b/tests/integration/noise-reduction.test.ts
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import {
+  AgentVideoRuntime,
+  canonicalSnapshotDigest,
+  type NoiseAnalyzer,
+  type RuntimeCapabilities,
+} from "@framekit/runtime";
+import { InMemoryEditorAdapter } from "@framekit/testkit";
+import { createMcpServer } from "../../apps/mcp-server/src/server.js";
+
+function fixture(): InMemoryEditorAdapter {
+  return new InMemoryEditorAdapter({
+    projectId: "noise-project",
+    projectName: "Noise Reduction",
+    timelineId: "noise-timeline",
+    timelineName: "Main",
+    clips: [{
+      id: "noise-occurrence",
+      mediaId: "noise-media",
+      name: "Interview audio",
+      start: 0,
+      duration: 4,
+      track: 1,
+      role: "audio",
+    }],
+    media: [{
+      mediaId: "noise-media",
+      source: "/fixtures/interview.wav",
+      mediaKind: "audio",
+      duration: 4,
+      audio: { integratedLufs: -20, truePeakDb: -3, silenceMs: 0 },
+    }],
+  });
+}
+
+const noiseAnalyzer: NoiseAnalyzer = {
+  descriptor: { id: "fixture.noise", provider: "deterministic-testkit", version: "1" },
+  analyze: async ({ project, media }) => {
+    const clip = project.timeline.clips.find((candidate) => candidate.mediaId === media.mediaId);
+    const reductionDb = clip?.noiseReductionDb ?? 0;
+    return {
+      noiseFloorDb: -30 - reductionDb,
+      peakNoiseDb: -20 - reductionDb,
+      affectedRanges: [{ start: 1, end: 3 }],
+      recommendedReductionDb: 18,
+      confidence: 0.98,
+      valid: true,
+    };
+  },
+};
+
+function textFrom(value: unknown): string {
+  const content = (value as { content?: Array<{ type?: string; text?: string }> }).content;
+  assert.equal(content?.[0]?.type, "text");
+  return content?.[0]?.text ?? "";
+}
+
+function request(baseRevision: { id: string; sequence: number; timestamp: string }) {
+  return {
+    ...input(),
+    baseRevision,
+  };
+}
+
+function input() {
+  return {
+    mediaId: "noise-media",
+    occurrenceId: "noise-occurrence",
+    noiseThresholdDb: -45,
+    maxReductionDb: 18,
+    minConfidence: 0.8,
+  };
+}
+
+test("noise analysis previews affected ranges, verifies post-write measurement, and supports Undo", async () => {
+  const adapter = fixture();
+  const runtime = new AgentVideoRuntime(adapter, { noiseAnalyzer });
+  runtime.registerBuiltinSkills();
+  const before = await runtime.inspectProject();
+  const measurement = await runtime.analyzeNoise("noise-media", { start: 0, end: 4 });
+  assert.equal(measurement.noiseFloorDb, -30);
+  assert.deepEqual(measurement.affectedRanges, [{ start: 1, end: 3 }]);
+
+  const preview = await runtime.previewSkill({
+    skillId: "audio-noise-reduction",
+    baseRevision: before.revision,
+    input: input(),
+  });
+  assert.deepEqual(preview.plan.details?.timelineAffectedRanges, [{ start: 1, end: 3 }]);
+  assert.equal(preview.plan.operations[0]?.type, "reduce-noise");
+  assert.deepEqual(await runtime.inspectProject(), before);
+
+  const execution = await runtime.executeSkill(preview.previewToken);
+  assert.equal(execution.status, "VERIFIED");
+  assert.equal(execution.verification?.checks.some((check) => check.name === "audio-noise" && check.passed), true);
+  assert.equal(execution.diff?.modified.some((change) => change.itemId === "noise-occurrence"), true);
+  const after = await runtime.inspectProject();
+  assert.equal(after.timeline.clips.find((clip) => clip.id === "noise-occurrence")?.noiseReductionDb, 18);
+
+  const transactionId = execution.transactionIds[0];
+  assert.ok(transactionId);
+  const restored = await runtime.undo(transactionId);
+  assert.equal(canonicalSnapshotDigest(restored), canonicalSnapshotDigest(before));
+  assert.ok(restored.revision.sequence > before.revision.sequence);
+});
+
+test("noise reduction MCP tools expose analysis and token-backed preview/execute", async () => {
+  const runtime = new AgentVideoRuntime(fixture(), { noiseAnalyzer });
+  const server = createMcpServer(runtime);
+  const client = new Client({ name: "noise-reduction-test", version: "1.0.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  try {
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    const tools = await client.listTools();
+    assert.ok(tools.tools.some((tool) => tool.name === "audio.noise.analyze"));
+    const analysis = JSON.parse(textFrom(await client.callTool({
+      name: "audio.noise.analyze",
+      arguments: { mediaId: "noise-media" },
+    }))) as { noiseFloorDb: number };
+    assert.equal(analysis.noiseFloorDb, -30);
+    const before = JSON.parse(textFrom(await client.callTool({ name: "project.inspect", arguments: {} }))) as {
+      revision: { id: string; sequence: number; timestamp: string };
+    };
+    const preview = JSON.parse(textFrom(await client.callTool({
+      name: "audio.noise.reduce.preview",
+      arguments: request(before.revision),
+    }))) as { previewToken: string; plan: { details?: { timelineAffectedRanges?: unknown[] } } };
+    assert.deepEqual(preview.plan.details?.timelineAffectedRanges, [{ start: 1, end: 3 }]);
+    const execution = JSON.parse(textFrom(await client.callTool({
+      name: "audio.noise.reduce.execute",
+      arguments: { previewToken: preview.previewToken },
+    }))) as { status: string; verification?: { checks: Array<{ name: string; passed: boolean }> } };
+    assert.equal(execution.status, "VERIFIED");
+    assert.equal(execution.verification?.checks.some((check) => check.name === "audio-noise" && check.passed), true);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
+
+test("noise reduction fails closed without an analyzer or effect capability", async () => {
+  const noAnalyzer = new AgentVideoRuntime(fixture());
+  noAnalyzer.registerBuiltinSkills();
+  await assert.rejects(noAnalyzer.analyzeNoise("noise-media"), /CAPABILITY_UNAVAILABLE: audio noise analysis/);
+  const unavailable = await noAnalyzer.listSkillAvailability();
+  const noiseSkill = unavailable.find((skill) => skill.manifest.id === "audio-noise-reduction");
+  assert.equal(noiseSkill?.availability.available, false);
+  assert.ok(noiseSkill?.availability.reasonCodes.includes("MISSING_ANALYZER_CAPABILITY"));
+
+  const blockedAdapter = fixture();
+  const originalGetCapabilities = blockedAdapter.getCapabilities.bind(blockedAdapter);
+  blockedAdapter.getCapabilities = async (): Promise<RuntimeCapabilities> => {
+    const capabilities = await originalGetCapabilities();
+    return {
+      ...capabilities,
+      editor: {
+        ...capabilities.editor,
+        noiseReduction: false,
+        semanticOperations: { ...capabilities.editor.semanticOperations, "reduce-noise": false },
+      },
+    };
+  };
+  const blocked = new AgentVideoRuntime(blockedAdapter, { noiseAnalyzer });
+  blocked.registerBuiltinSkills();
+  const before = await blocked.inspectProject();
+  await assert.rejects(
+    blocked.previewSkill({ skillId: "audio-noise-reduction", baseRevision: before.revision, input: input() }),
+    /SKILL_REQUIREMENTS_UNMET/,
+  );
+});

--- a/tests/integration/semantic-media.test.ts
+++ b/tests/integration/semantic-media.test.ts
@@ -316,6 +316,7 @@ test("unconfigured analysis returns unavailable statuses without descriptions", 
     [
       { capability: "speech", status: "unavailable" },
       { capability: "audio", status: "unavailable" },
+      { capability: "noise", status: "unavailable" },
       { capability: "visual", status: "unavailable" },
       { capability: "metadata", status: "unavailable" },
     ],

--- a/tests/release-gate/release-gate.test.ts
+++ b/tests/release-gate/release-gate.test.ts
@@ -48,7 +48,7 @@ test("generic MCP Skill surface discovers both release workflows", async () => {
     const listed = await client.callTool({ name: "skill.list", arguments: {} });
     const content = listed.content as Array<{ type: string; text?: string }>;
     const payload = JSON.parse(content[0]?.text ?? "null") as Array<{ id: string; version: string }>;
-    assert.deepEqual(payload.map((skill) => skill.id), ["dialogue-normalization", "filler-removal"]);
+    assert.deepEqual(payload.map((skill) => skill.id), ["audio-noise-reduction", "dialogue-normalization", "filler-removal"]);
     assert.ok(payload.every((skill) => skill.version === "1.0.0"));
 
     const inspected = await client.callTool({

--- a/tests/release-gate/runner.ts
+++ b/tests/release-gate/runner.ts
@@ -197,7 +197,7 @@ async function runWorkflow(workflow: ReleaseGateWorkflow): Promise<ReleaseGateWo
     await server.connect(serverTransport);
     await client.connect(clientTransport);
     const skills = parseJson(await client.callTool({ name: "skill.list", arguments: {} })) as Array<{ id: string }>;
-    assert.deepEqual(skills.map((skill) => skill.id), ["dialogue-normalization", "filler-removal"]);
+    assert.deepEqual(skills.map((skill) => skill.id), ["audio-noise-reduction", "dialogue-normalization", "filler-removal"]);
     before = parseJson(await client.callTool({ name: "project.inspect", arguments: {} })) as ProjectSnapshot;
     previewed = true;
     const previewResult = await client.callTool({


### PR DESCRIPTION
## Summary
- add configured noise analysis with revision-bound measurements and affected ranges
- add bounded `audio-noise-reduction` Skill preview/execute flow with post-write verification and rollback
- expose dedicated audio noise MCP tools and deterministic testkit coverage
- advertise native noise reduction explicitly and fail closed when unavailable

## Validation
- `PATH=/Users/shotomorisaki/.nix-profile/bin:$PATH pnpm run build`
- `PATH=/Users/shotomorisaki/.nix-profile/bin:$PATH pnpm run test` (463 passed)
- `PATH=/Users/shotomorisaki/.nix-profile/bin:$PATH pnpm run check:boundaries`
- `git diff --check`

Refs #12