### PR TITLE
feat: add the basic color correction Skill

### DIFF
--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -91,6 +91,19 @@ const reduceNoiseSchema = z.object({
   reductionDb: z.number().finite().positive(),
   baseRevision: revisionSchema,
 });
+const colorCorrectionSchema = z.object({
+  type: z.literal("set-color-correction"),
+  clipId: z.string().min(1),
+  correction: z.object({
+    exposure: z.number().finite().min(-4).max(4),
+    contrast: z.number().finite().min(-1).max(1),
+    saturation: z.number().finite().min(-1).max(1),
+    temperature: z.number().finite().min(-100).max(100),
+    tint: z.number().finite().min(-100).max(100),
+    preset: z.enum(["neutral", "warm", "cool", "high-contrast"]).optional(),
+  }),
+  baseRevision: revisionSchema,
+});
 const rippleDeleteSchema = z.object({ type: z.literal("ripple-delete"), timelineId: z.string().min(1), range: rangeSchema, reason: z.string().optional(), baseRevision: revisionSchema });
 const addMarkerSchema = z.object({ type: z.literal("add-marker"), timelineId: z.string().min(1), marker: markerSchema, baseRevision: revisionSchema });
 const roughCutImportSchema = z.object({
@@ -116,6 +129,7 @@ const editOperationSchema = z.discriminatedUnion("type", [
   trimClipSchema,
   setGainSchema,
   reduceNoiseSchema,
+  colorCorrectionSchema,
   rippleDeleteSchema,
   addMarkerSchema,
 ]);
@@ -144,6 +158,18 @@ const verificationAssertionSchema = z.discriminatedUnion("type", [
     mediaId: z.string().min(1),
     maxNoiseFloorDb: z.number().finite(),
     minConfidence: z.number().finite().min(0).max(1).optional(),
+  }),
+  z.object({
+    type: z.literal("color-correction"),
+    clipId: z.string().min(1),
+    expected: z.object({
+      exposure: z.number().finite().min(-4).max(4),
+      contrast: z.number().finite().min(-1).max(1),
+      saturation: z.number().finite().min(-1).max(1),
+      temperature: z.number().finite().min(-100).max(100),
+      tint: z.number().finite().min(-100).max(100),
+      preset: z.enum(["neutral", "warm", "cool", "high-contrast"]).optional(),
+    }),
   }),
   z.object({
     type: z.literal("audio-source"),
@@ -186,13 +212,14 @@ const verificationPolicySchema = z.object({
   assertions: z.array(verificationAssertionSchema).optional(),
 }).strict();
 const editToolInputSchema = z.object({
-  type: z.enum(["rename-clip", "trim-clip", "set-gain", "reduce-noise", "ripple-delete", "add-marker"]),
+  type: z.enum(["rename-clip", "trim-clip", "set-gain", "reduce-noise", "set-color-correction", "ripple-delete", "add-marker"]),
   clipId: z.string().min(1).optional(),
   name: z.string().min(1).optional(),
   duration: z.number().positive().optional(),
   durationTime: rationalTimeSchema.optional(),
   gainDb: z.number().finite().optional(),
   reductionDb: z.number().finite().positive().optional(),
+  correction: colorCorrectionSchema.shape.correction.optional(),
   timelineId: z.string().min(1).optional(),
   range: rangeSchema.optional(),
   reason: z.string().optional(),
@@ -219,6 +246,7 @@ const workflowOperationSchema = z.discriminatedUnion("type", [
   trimClipSchema,
   setGainSchema,
   reduceNoiseSchema,
+  colorCorrectionSchema,
   rippleDeleteSchema,
   addMarkerSchema,
   z.object({
@@ -364,6 +392,16 @@ const noiseReductionInputSchema = {
   noiseThresholdDb: z.number().finite(),
   maxReductionDb: z.number().finite().positive(),
   minConfidence: z.number().finite().min(0).max(1),
+};
+const colorCorrectionInputSchema = {
+  clipId: z.string().trim().min(1),
+  baseRevision: revisionValueSchema,
+  preset: z.enum(["neutral", "warm", "cool", "high-contrast"]).optional(),
+  exposure: z.number().finite().min(-4).max(4).optional(),
+  contrast: z.number().finite().min(-1).max(1).optional(),
+  saturation: z.number().finite().min(-1).max(1).optional(),
+  temperature: z.number().finite().min(-100).max(100).optional(),
+  tint: z.number().finite().min(-100).max(100).optional(),
 };
 const nativeEditSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("rename-selected-clip"), name: z.string().min(1) }),
@@ -1188,6 +1226,23 @@ export function createMcpServer(runtime: AgentVideoRuntime, options: McpServerOp
 
   server.registerTool("audio.noise.reduce.execute", {
     description: "Execute one previewed noise-reduction adjustment and return post-write measurement verification and rollback state.",
+    inputSchema: { previewToken: z.string().min(1) },
+  }, async ({ previewToken }) => jsonResult(await runtime.executeSkill(previewToken)));
+
+  server.registerTool("color.correction.preview", {
+    description: "Preview a clip-scoped basic color correction with before/after values without mutating the editor.",
+    inputSchema: colorCorrectionInputSchema,
+  }, async (request) => {
+    const { baseRevision, ...input } = request;
+    return skillPreviewResult(await runtime.previewSkill({
+      skillId: "color-correction",
+      baseRevision,
+      input,
+    }));
+  });
+
+  server.registerTool("color.correction.execute", {
+    description: "Execute one previewed basic color correction and return the target verification, diff, and rollback state.",
     inputSchema: { previewToken: z.string().min(1) },
   }, async ({ previewToken }) => jsonResult(await runtime.executeSkill(previewToken)));
 

--- a/docs/mcp/skills.md
+++ b/docs/mcp/skills.md
@@ -28,6 +28,7 @@ Skills currently exposed by the generic surface are:
 | `filler-removal` | 1.0.0 | speech analysis, safe deletion, re-analysis, verification, rollback |
 | `dialogue-normalization` | 1.0.0 | dialogue measurement, bounded gain, re-measurement, verification, rollback |
 | `audio-noise-reduction` | 1.0.0 | noise analysis, affected-range preview, bounded reduction, re-analysis, verification, rollback |
+| `color-correction` | 1.0.0 | clip-scoped exposure, contrast, saturation, white balance, presets, verification, rollback |
 
 ## Execution contract
 
@@ -58,6 +59,13 @@ measurements, affected ranges, and a bounded reduction adjustment. The runtime
 re-analyzes the edited range after execution and rolls back when the configured
 noise-floor threshold is not met. Missing analyzer or effect capability fails
 closed before mutation.
+
+`color-correction` accepts exposure, contrast, saturation, temperature/tint
+white-balance controls, and the `neutral`, `warm`, `cool`, and `high-contrast`
+presets. It records the before and after correction in the preview details and
+verifies the requested values on the intended clip after execution. It requires
+the editor's explicit color-correction capability; advanced grading and
+unsupported native effects are outside this Skill.
 
 Both workflows require canonical read, supported timeline write, read-after-write,
 analysis, and rollback capabilities. Missing capabilities fail closed before

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -85,6 +85,8 @@ this routing tool.
 | `audio.noise.analyze` | Noise-floor analysis and affected ranges | Requires a configured noise analyzer |
 | `audio.noise.reduce.preview` | Preview a bounded noise-reduction adjustment for one audio occurrence | Requires noise analysis, native noise-reduction capability, and canonical transaction guarantees |
 | `audio.noise.reduce.execute` | Execute the noise preview and return post-write measurement verification/rollback evidence | Use `edit.undo` with the returned transaction ID for a later reversal |
+| `color.correction.preview` | Preview exposure, contrast, saturation, white balance, or a basic preset on one clip | Requires explicit clip targeting and advertised color-correction capability |
+| `color.correction.execute` | Execute the color preview and return before/after diff, verification, and rollback evidence | Use `edit.undo` with the returned transaction ID for a later reversal |
 | `visual.analyze` | Scenes, subjects, motion, and keyframes | Fixture or configured local JSON provider |
 | `media.understand` | Combined speech, audio, visual, and metadata understanding | Returns per-capability analyzed or unavailable statuses |
 | `rough-cut.plan` | Explainable read-only shot plan from semantic media ranges | Requires analyzed usable ranges; never mutates the timeline |

--- a/packages/runtime/src/color-correction.ts
+++ b/packages/runtime/src/color-correction.ts
@@ -1,0 +1,85 @@
+import type { ContextRevision } from "./domain/primitives.js";
+import type { EditOperation } from "./domain/editing.js";
+import type { Clip, ColorCorrection, ColorCorrectionPreset } from "./domain/project.js";
+import type { TimelineDiff } from "./domain/diff.js";
+
+export interface ColorCorrectionRequest {
+  clipId: string;
+  baseRevision: ContextRevision;
+  preset?: ColorCorrectionPreset;
+  exposure?: number;
+  contrast?: number;
+  saturation?: number;
+  temperature?: number;
+  tint?: number;
+}
+
+export interface ColorCorrectionPlan {
+  decision: "APPLY" | "NO_OP";
+  clipId: string;
+  before: ColorCorrection;
+  after: ColorCorrection;
+  changedFields: Array<keyof ColorCorrection>;
+  reasonCodes: Array<"APPLY_COLOR_CORRECTION" | "ALREADY_MATCHES">;
+}
+
+export interface ColorCorrectionPreview {
+  plan: ColorCorrectionPlan;
+  operation?: EditOperation;
+  expectedDiff?: TimelineDiff;
+  previewToken?: string;
+  warnings: string[];
+  expiresAt?: string;
+}
+
+export const COLOR_CORRECTION_PRESETS: Record<ColorCorrectionPreset, ColorCorrection> = {
+  neutral: { exposure: 0, contrast: 0, saturation: 0, temperature: 0, tint: 0, preset: "neutral" },
+  warm: { exposure: 0.1, contrast: 0, saturation: 0.1, temperature: 15, tint: 0, preset: "warm" },
+  cool: { exposure: 0.1, contrast: 0, saturation: 0, temperature: -15, tint: 0, preset: "cool" },
+  "high-contrast": { exposure: 0, contrast: 0.25, saturation: 0.05, temperature: 0, tint: 0, preset: "high-contrast" },
+};
+
+export function planColorCorrection(clip: Clip, request: ColorCorrectionRequest): ColorCorrectionPlan {
+  const before = normalizeCorrection(clip.colorCorrection);
+  const preset = request.preset ? COLOR_CORRECTION_PRESETS[request.preset] : before;
+  const after: ColorCorrection = {
+    exposure: request.exposure ?? preset.exposure,
+    contrast: request.contrast ?? preset.contrast,
+    saturation: request.saturation ?? preset.saturation,
+    temperature: request.temperature ?? preset.temperature,
+    tint: request.tint ?? preset.tint,
+    ...(request.preset ? { preset: request.preset } : clip.colorCorrection?.preset ? { preset: clip.colorCorrection.preset } : {}),
+  };
+  validateCorrection(after);
+  const changedFields = (Object.keys(after) as Array<keyof ColorCorrection>)
+    .filter((field) => after[field] !== before[field]);
+  return {
+    decision: changedFields.length > 0 ? "APPLY" : "NO_OP",
+    clipId: clip.id,
+    before,
+    after,
+    changedFields,
+    reasonCodes: changedFields.length > 0 ? ["APPLY_COLOR_CORRECTION"] : ["ALREADY_MATCHES"],
+  };
+}
+
+export function normalizeCorrection(correction?: ColorCorrection): ColorCorrection {
+  return {
+    exposure: correction?.exposure ?? 0,
+    contrast: correction?.contrast ?? 0,
+    saturation: correction?.saturation ?? 0,
+    temperature: correction?.temperature ?? 0,
+    tint: correction?.tint ?? 0,
+    ...(correction?.preset ? { preset: correction.preset } : {}),
+  };
+}
+
+function validateCorrection(correction: ColorCorrection): void {
+  if (!Number.isFinite(correction.exposure) || correction.exposure < -4 || correction.exposure > 4
+    || !Number.isFinite(correction.contrast) || correction.contrast < -1 || correction.contrast > 1
+    || !Number.isFinite(correction.saturation) || correction.saturation < -1 || correction.saturation > 1
+    || !Number.isFinite(correction.temperature) || correction.temperature < -100 || correction.temperature > 100
+    || !Number.isFinite(correction.tint) || correction.tint < -100 || correction.tint > 100) {
+    throw new Error("INVALID_OPERATION: color correction values are outside the supported basic range");
+  }
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -9,6 +9,7 @@ export * from "./timeline/snapshot-digest.js";
 export * from "./speech/filler-removal.js";
 export * from "./audio/dialogue-normalization.js";
 export * from "./audio/noise-reduction.js";
+export * from "./color-correction.js";
 export * from "./domain/skills.js";
 export * from "./skills/requirements.js";
 export * from "./skills/index.js";

--- a/packages/runtime/src/skills/builtin.ts
+++ b/packages/runtime/src/skills/builtin.ts
@@ -4,10 +4,11 @@ import { planFillerRemoval } from "../speech/filler-removal.js";
 import { translateRationalRange } from "../timeline/rational-time.js";
 import { planDialogueGain, type DialogueNormalizationRequest } from "../audio/dialogue-normalization.js";
 import { planNoiseReduction, type NoiseReductionRequest } from "../audio/noise-reduction.js";
+import { planColorCorrection, type ColorCorrectionRequest } from "../color-correction.js";
 import type { FillerRemovalTarget } from "../speech/filler-removal.js";
 
 export function builtinSkills(): SkillDefinition[] {
-  return [fillerRemovalSkill(), dialogueNormalizationSkill(), noiseReductionSkill()];
+  return [fillerRemovalSkill(), dialogueNormalizationSkill(), noiseReductionSkill(), colorCorrectionSkill()];
 }
 
 function fillerRemovalSkill(): SkillDefinition {
@@ -232,6 +233,81 @@ async function planNoiseSkill(context: SkillPlanningContext, input: Record<strin
       measurement: structuredClone(measurement),
       plan: structuredClone(plan),
       timelineAffectedRanges: structuredClone(timelineRanges),
+    },
+  };
+}
+
+function colorCorrectionSkill(): SkillDefinition {
+  return {
+    manifest: {
+      contractVersion: 1,
+      id: "color-correction",
+      version: "1.0.0",
+      title: "Basic color correction",
+      description: "Apply a clip-scoped basic color correction with before/after verification.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          clipId: { type: "string", minLength: 1 },
+          preset: { type: "string", enum: ["neutral", "warm", "cool", "high-contrast"] },
+          exposure: { type: "number", minimum: -4, maximum: 4 },
+          contrast: { type: "number", minimum: -1, maximum: 1 },
+          saturation: { type: "number", minimum: -1, maximum: 1 },
+          temperature: { type: "number", minimum: -100, maximum: 100 },
+          tint: { type: "number", minimum: -100, maximum: 100 },
+        },
+        required: ["clipId"],
+        additionalProperties: false,
+      },
+      requirements: {
+        type: "allOf",
+        requirements: [
+          { type: "editor", capability: "timelineSnapshotRead" },
+          { type: "editor", capability: "timelineWrite" },
+          { type: "editor", capability: "readAfterWrite" },
+          { type: "editor", capability: "rollback" },
+          { type: "editor", capability: "compositeTransactions" },
+          { type: "editor", capability: "colorCorrection" },
+          { type: "operation", operation: "set-color-correction" },
+        ],
+      },
+    },
+    handler: {
+      normalize: (input) => input as Record<string, unknown>,
+      plan: async (context, input) => planColorSkill(context, input),
+    },
+  };
+}
+
+async function planColorSkill(context: SkillPlanningContext, input: Record<string, unknown>) {
+  const clip = context.project.timeline.clips.find((candidate) => candidate.id === input.clipId);
+  if (!clip) throw new Error(`CLIP_NOT_FOUND: ${String(input.clipId)}`);
+  const request = input as unknown as ColorCorrectionRequest;
+  const plan = planColorCorrection(clip, request);
+  const affectedRange = { start: clip.start, end: clip.start + clip.duration };
+  const verification = plan.decision === "APPLY" ? {
+    requireExpectedChange: true,
+    assertions: [{
+      type: "color-correction" as const,
+      clipId: clip.id,
+      expected: structuredClone(plan.after),
+    }],
+  } : undefined;
+  return {
+    operations: plan.decision === "APPLY" ? [{
+      type: "set-color-correction" as const,
+      clipId: clip.id,
+      correction: structuredClone(plan.after),
+      baseRevision: context.baseRevision,
+    }] : [],
+    affectedRanges: plan.decision === "APPLY" ? [affectedRange] : [],
+    warnings: [],
+    ...(verification ? { verification } : {}),
+    details: {
+      before: structuredClone(plan.before),
+      after: structuredClone(plan.after),
+      changedFields: [...plan.changedFields],
+      reasonCodes: [...plan.reasonCodes],
     },
   };
 }

--- a/tests/integration/color-correction.test.ts
+++ b/tests/integration/color-correction.test.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import {
+  AgentVideoRuntime,
+  canonicalSnapshotDigest,
+  type RuntimeCapabilities,
+} from "@framekit/runtime";
+import { InMemoryEditorAdapter } from "@framekit/testkit";
+import { createMcpServer } from "../../apps/mcp-server/src/server.js";
+
+function fixture(): InMemoryEditorAdapter {
+  return new InMemoryEditorAdapter({
+    projectId: "color-project",
+    projectName: "Color Correction",
+    timelineId: "color-timeline",
+    timelineName: "Main",
+    clips: [
+      { id: "target-clip", mediaId: "target-media", name: "Target", start: 0, duration: 4, track: 0, role: "video" },
+      { id: "other-clip", mediaId: "other-media", name: "Other", start: 4, duration: 4, track: 0, role: "video" },
+    ],
+    media: [
+      { mediaId: "target-media", source: "/fixtures/target.mov", mediaKind: "video", duration: 4 },
+      { mediaId: "other-media", source: "/fixtures/other.mov", mediaKind: "video", duration: 4 },
+    ],
+  });
+}
+
+function input() {
+  return {
+    clipId: "target-clip",
+    preset: "warm" as const,
+    exposure: 0.5,
+    contrast: 0.2,
+    saturation: 0.15,
+    temperature: 25,
+    tint: -3,
+  };
+}
+
+function textFrom(value: unknown): string {
+  const content = (value as { content?: Array<{ type?: string; text?: string }> }).content;
+  assert.equal(content?.[0]?.type, "text");
+  return content?.[0]?.text ?? "";
+}
+
+test("color correction previews before/after values, targets one clip, verifies, and supports Undo", async () => {
+  const adapter = fixture();
+  const runtime = new AgentVideoRuntime(adapter);
+  runtime.registerBuiltinSkills();
+  const before = await runtime.inspectProject();
+  const preview = await runtime.previewSkill({
+    skillId: "color-correction",
+    baseRevision: before.revision,
+    input: input(),
+  });
+  assert.deepEqual(preview.plan.details?.before, {
+    exposure: 0,
+    contrast: 0,
+    saturation: 0,
+    temperature: 0,
+    tint: 0,
+  });
+  assert.deepEqual(preview.plan.details?.after, {
+    exposure: 0.5,
+    contrast: 0.2,
+    saturation: 0.15,
+    temperature: 25,
+    tint: -3,
+    preset: "warm",
+  });
+  assert.equal(preview.plan.operations[0]?.type, "set-color-correction");
+  assert.equal((preview.plan.operations[0] as { clipId: string }).clipId, "target-clip");
+  assert.deepEqual(await runtime.inspectProject(), before);
+
+  const execution = await runtime.executeSkill(preview.previewToken);
+  assert.equal(execution.status, "VERIFIED");
+  assert.equal(execution.verification?.checks.some((check) => check.name === "color-correction" && check.passed), true);
+  assert.deepEqual(execution.diff?.modified.map((change) => change.itemId), ["target-clip"]);
+  const after = await runtime.inspectProject();
+  assert.deepEqual(after.timeline.clips.find((clip) => clip.id === "target-clip")?.colorCorrection, {
+    exposure: 0.5,
+    contrast: 0.2,
+    saturation: 0.15,
+    temperature: 25,
+    tint: -3,
+    preset: "warm",
+  });
+  assert.equal(after.timeline.clips.find((clip) => clip.id === "other-clip")?.colorCorrection, undefined);
+
+  const transactionId = execution.transactionIds[0];
+  assert.ok(transactionId);
+  const restored = await runtime.undo(transactionId);
+  assert.equal(canonicalSnapshotDigest(restored), canonicalSnapshotDigest(before));
+});
+
+test("color correction MCP tools use the generic token contract", async () => {
+  const server = createMcpServer(new AgentVideoRuntime(fixture()));
+  const client = new Client({ name: "color-correction-test", version: "1.0.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  try {
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    const before = JSON.parse(textFrom(await client.callTool({ name: "project.inspect", arguments: {} }))) as {
+      revision: { id: string; sequence: number; timestamp: string };
+    };
+    const preview = JSON.parse(textFrom(await client.callTool({
+      name: "color.correction.preview",
+      arguments: { ...input(), baseRevision: before.revision },
+    }))) as { previewToken: string; plan: { details?: { before?: unknown; after?: unknown } } };
+    assert.equal((preview.plan.details?.after as { temperature?: number }).temperature, 25);
+    const execution = JSON.parse(textFrom(await client.callTool({
+      name: "color.correction.execute",
+      arguments: { previewToken: preview.previewToken },
+    }))) as { status: string };
+    assert.equal(execution.status, "VERIFIED");
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
+
+test("color correction fails closed when the editor does not advertise the effect", async () => {
+  const adapter = fixture();
+  const originalGetCapabilities = adapter.getCapabilities.bind(adapter);
+  adapter.getCapabilities = async (): Promise<RuntimeCapabilities> => {
+    const capabilities = await originalGetCapabilities();
+    return {
+      ...capabilities,
+      editor: {
+        ...capabilities.editor,
+        colorCorrection: false,
+        semanticOperations: { ...capabilities.editor.semanticOperations, "set-color-correction": false },
+      },
+    };
+  };
+  const runtime = new AgentVideoRuntime(adapter);
+  runtime.registerBuiltinSkills();
+  const before = await runtime.inspectProject();
+  const availability = await runtime.inspectSkillAvailability("color-correction");
+  assert.equal(availability.availability.available, false);
+  assert.ok(availability.availability.reasonCodes.includes("MISSING_EDITOR_CAPABILITY"));
+  await assert.rejects(
+    runtime.previewSkill({ skillId: "color-correction", baseRevision: before.revision, input: input() }),
+    /SKILL_REQUIREMENTS_UNMET/,
+  );
+});

--- a/tests/integration/mcp.test.ts
+++ b/tests/integration/mcp.test.ts
@@ -36,6 +36,8 @@ test("Phase 0 exposes read/write/diff through MCP stdio", async () => {
         "audio.noise.analyze",
         "audio.noise.reduce.execute",
         "audio.noise.reduce.preview",
+        "color.correction.execute",
+        "color.correction.preview",
         "skill.execute",
         "skill.inspect",
         "skill.list",
@@ -116,7 +118,7 @@ test("Phase 0 exposes read/write/diff through MCP stdio", async () => {
     );
     const timelineEditTool = tools.tools.find((tool) => tool.name === "editor.timeline.edit");
     assert.deepEqual(Object.keys(timelineEditTool?.inputSchema.properties ?? {}).sort(), [
-      "baseRevision", "clipId", "duration", "durationTime", "gainDb", "marker", "name", "projectId", "range", "reason", "reductionDb", "sequenceId", "timelineId", "type", "verification",
+      "baseRevision", "clipId", "correction", "duration", "durationTime", "gainDb", "marker", "name", "projectId", "range", "reason", "reductionDb", "sequenceId", "timelineId", "type", "verification",
     ]);
     assert.deepEqual(timelineEditTool?.inputSchema.required?.slice().sort(), ["baseRevision", "projectId", "sequenceId", "type"]);
     const artifactEditTool = tools.tools.find((tool) => tool.name === "artifact.edit");

--- a/tests/integration/release-gate-docs.test.ts
+++ b/tests/integration/release-gate-docs.test.ts
@@ -24,6 +24,8 @@ test("Skill documentation describes only the generic MCP workflow", async () => 
   }
   assert.match(documentation, /filler-removal/);
   assert.match(documentation, /dialogue-normalization/);
+  assert.match(documentation, /audio-noise-reduction/);
+  assert.match(documentation, /color-correction/);
   assert.match(documentation, /Final Cut-specific commands/i);
   assert.match(documentation, /preview/);
   assert.match(documentation, /rollback/);

--- a/tests/release-gate/release-gate.test.ts
+++ b/tests/release-gate/release-gate.test.ts
@@ -48,7 +48,7 @@ test("generic MCP Skill surface discovers both release workflows", async () => {
     const listed = await client.callTool({ name: "skill.list", arguments: {} });
     const content = listed.content as Array<{ type: string; text?: string }>;
     const payload = JSON.parse(content[0]?.text ?? "null") as Array<{ id: string; version: string }>;
-    assert.deepEqual(payload.map((skill) => skill.id), ["audio-noise-reduction", "dialogue-normalization", "filler-removal"]);
+    assert.deepEqual(payload.map((skill) => skill.id), ["audio-noise-reduction", "color-correction", "dialogue-normalization", "filler-removal"]);
     assert.ok(payload.every((skill) => skill.version === "1.0.0"));
 
     const inspected = await client.callTool({

--- a/tests/release-gate/runner.ts
+++ b/tests/release-gate/runner.ts
@@ -197,7 +197,7 @@ async function runWorkflow(workflow: ReleaseGateWorkflow): Promise<ReleaseGateWo
     await server.connect(serverTransport);
     await client.connect(clientTransport);
     const skills = parseJson(await client.callTool({ name: "skill.list", arguments: {} })) as Array<{ id: string }>;
-    assert.deepEqual(skills.map((skill) => skill.id), ["audio-noise-reduction", "dialogue-normalization", "filler-removal"]);
+    assert.deepEqual(skills.map((skill) => skill.id), ["audio-noise-reduction", "color-correction", "dialogue-normalization", "filler-removal"]);
     before = parseJson(await client.callTool({ name: "project.inspect", arguments: {} })) as ProjectSnapshot;
     previewed = true;
     const previewResult = await client.callTool({


### PR DESCRIPTION
## Summary
- add clip-scoped basic color correction for exposure, contrast, saturation, temperature, and tint
- add neutral, warm, cool, and high-contrast presets with before/after preview details
- verify the intended clip after execution and retain generic diff/Undo evidence
- expose dedicated color correction MCP preview/execute tools and fail closed without the advertised capability

## Validation
- `PATH=/Users/shotomorisaki/.nix-profile/bin:$PATH pnpm run build`
- `PATH=/Users/shotomorisaki/.nix-profile/bin:$PATH pnpm run test` (466 passed)
- `PATH=/Users/shotomorisaki/.nix-profile/bin:$PATH pnpm run check:boundaries`
- `git diff --check`

Refs #15