### PR TITLE
feat: add repository agent workflow skills

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -3,9 +3,9 @@
 These repository-local skills follow the `SKILL.md` convention: each skill has
 concise instructions and optional executable helpers under `scripts/`.
 
-They describe repository-specific workflows for GitHub issues and pull
-requests. They are instructions for an agent using this checkout; they are not
-GitHub Actions or autonomous merge automation.
+They describe repository-specific delivery, validation, GitHub, release, and
+native Final Cut workflows. They are instructions for an agent using this
+checkout; they are not GitHub Actions or autonomous merge automation.
 
 ## Playbooks
 
@@ -16,6 +16,25 @@ GitHub Actions or autonomous merge automation.
 - [`skills/review-pr/SKILL.md`](./skills/review-pr/SKILL.md): review a pull
   request, validate findings, apply safe fixes, and record the final review
   decision.
+- [`skills/deliver-issue/SKILL.md`](./skills/deliver-issue/SKILL.md): deliver an
+  issue with an isolated worktree, TDD commits, validation, and PR follow-up.
+- [`skills/repair-pr-conflict/SKILL.md`](./skills/repair-pr-conflict/SKILL.md):
+  repair an active PR conflict and recheck the remote branch.
+- [`skills/triage-ci/SKILL.md`](./skills/triage-ci/SKILL.md): diagnose a live
+  CI failure or slow job and verify the smallest justified fix.
+
+## Validation and operations
+
+- [`skills/validate-framekit/SKILL.md`](./skills/validate-framekit/SKILL.md):
+  run the required repository and optional native gates.
+- [`skills/validate-mcp/SKILL.md`](./skills/validate-mcp/SKILL.md): audit MCP
+  contracts, capabilities, real calls, verification, and Undo by evidence tier.
+- [`skills/verify-final-cut-native/SKILL.md`](./skills/verify-final-cut-native/SKILL.md):
+  preflight and prove real headed Final Cut behavior safely.
+- [`skills/verify-release/SKILL.md`](./skills/verify-release/SKILL.md): verify
+  tags, release assets, workflows, npm publication, and client availability.
+- [`skills/clean-worktree/SKILL.md`](./skills/clean-worktree/SKILL.md): inspect
+  and restore only approved tracked paths while reporting divergence separately.
 
 ## Shared rules
 

--- a/.agents/skills/clean-worktree/SKILL.md
+++ b/.agents/skills/clean-worktree/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: clean-worktree
+description: Inspect and safely clean a Framekit Git worktree by restoring only explicitly approved tracked paths, preserving untracked and unrelated files, and reporting upstream divergence separately from worktree dirtiness. Use when the user asks to make the workspace clean, discard inspected local edits, or confirm that a worktree is clean.
+---
+
+# Clean a Framekit worktree
+
+Inspect before changing anything:
+
+```sh
+.agents/skills/clean-worktree/scripts/inspect-worktree.sh /path/to/worktree
+```
+
+Explain tracked, staged, and untracked changes. Identify which changes were created during the current task and which may belong to the user. A branch that is ahead or behind can still have a clean worktree; report divergence separately.
+
+After the user authorizes discarding the inspected tracked paths, restore only the explicit list:
+
+```sh
+.agents/skills/clean-worktree/scripts/restore-listed.sh /path/to/worktree -- path/to/file ...
+```
+
+The helper refuses absolute paths, parent traversal, untracked paths, and broad implicit cleanup. Never use `git clean`, recursive deletion, `git reset --hard`, or restore unrelated paths. Handle untracked files only with separate, explicit user authorization and a recoverable operation where possible.
+
+Run the inspector again and report both worktree status and upstream divergence.

--- a/.agents/skills/clean-worktree/SKILL.md
+++ b/.agents/skills/clean-worktree/SKILL.md
@@ -5,20 +5,21 @@ description: Inspect and safely clean a Framekit Git worktree by restoring only 
 
 # Clean a Framekit worktree
 
-Inspect before changing anything:
+Inspect before changing anything. When cleanup may follow, write a content-bound authorization manifest to a new path:
 
 ```sh
-.agents/skills/clean-worktree/scripts/inspect-worktree.sh /path/to/worktree
+manifest="${TMPDIR:-/tmp}/framekit-clean-worktree-$$.tsv"
+.agents/skills/clean-worktree/scripts/inspect-worktree.sh /path/to/worktree --manifest "$manifest"
 ```
 
-Explain tracked, staged, and untracked changes. Identify which changes were created during the current task and which may belong to the user. A branch that is ahead or behind can still have a clean worktree; report divergence separately.
+Explain tracked, staged, and untracked changes. Identify which changes were created during the current task and which may belong to the user. Record the manifest path with the authorization request. A branch that is ahead or behind can still have a clean worktree; report divergence separately.
 
 After the user authorizes discarding the inspected tracked paths, restore only the explicit list:
 
 ```sh
-.agents/skills/clean-worktree/scripts/restore-listed.sh /path/to/worktree -- path/to/file ...
+.agents/skills/clean-worktree/scripts/restore-listed.sh /path/to/worktree --manifest "$manifest" -- path/to/file ...
 ```
 
-The helper refuses absolute paths, parent traversal, untracked paths, and broad implicit cleanup. Never use `git clean`, recursive deletion, `git reset --hard`, or restore unrelated paths. Handle untracked files only with separate, explicit user authorization and a recoverable operation where possible.
+The helper refuses absolute paths, parent traversal, untracked paths, broad implicit cleanup, changed content, or a changed `HEAD`. It serializes its own restore operations and saves staged and worktree patches under the worktree Git directory before restoring. Report that backup path and recovery command. Never use `git clean`, recursive deletion, `git reset --hard`, or restore unrelated paths. Handle untracked files only with separate, explicit user authorization and a recoverable operation where possible.
 
 Run the inspector again and report both worktree status and upstream divergence.

--- a/.agents/skills/clean-worktree/agents/openai.yaml
+++ b/.agents/skills/clean-worktree/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Clean Framekit Worktree"
+  short_description: "Inspect and safely restore explicit worktree changes."
+  default_prompt: "Use $clean-worktree to inspect a Framekit worktree, restore only approved paths, and report divergence separately."

--- a/.agents/skills/clean-worktree/scripts/inspect-worktree.sh
+++ b/.agents/skills/clean-worktree/scripts/inspect-worktree.sh
@@ -38,6 +38,19 @@ else
 fi
 
 if [[ -n "$manifest" ]]; then
+  manifest_dir=$(cd -- "$(dirname -- "$manifest")" && pwd -P)
+  manifest_name=$(basename -- "$manifest")
+  manifest_absolute="$manifest_dir/$manifest_name"
+  case "$manifest_absolute" in
+    "$repository_root"/*)
+      manifest_repository_path=${manifest_absolute#"$repository_root"/}
+      if git -C "$repository_root" ls-files --error-unmatch -- "$manifest_repository_path" >/dev/null 2>&1 ||
+         git -C "$repository_root" cat-file -e "HEAD:$manifest_repository_path" 2>/dev/null; then
+        printf 'error: manifest path is tracked by the repository: %s\n' "$manifest" >&2
+        exit 64
+      fi
+      ;;
+  esac
   [[ ! -e "$manifest" ]] || {
     printf 'error: manifest path already exists: %s\n' "$manifest" >&2
     exit 1

--- a/.agents/skills/clean-worktree/scripts/inspect-worktree.sh
+++ b/.agents/skills/clean-worktree/scripts/inspect-worktree.sh
@@ -2,12 +2,20 @@
 set -Eeuo pipefail
 
 usage() {
-  printf 'Usage: %s [WORKTREE_PATH]\n' "$0" >&2
+  printf 'Usage: %s [WORKTREE_PATH] [--manifest MANIFEST_PATH]\n' "$0" >&2
 }
 
 [[ ${1:-} == "--help" || ${1:-} == "-h" ]] && { usage; exit 0; }
-if (($# > 1)); then usage; exit 64; fi
-worktree=${1:-.}
+worktree=.
+manifest=
+if (($# > 0)) && [[ $1 != --manifest ]]; then
+  worktree=$1
+  shift
+fi
+if (($# > 0)); then
+  if (($# != 2)) || [[ $1 != --manifest ]]; then usage; exit 64; fi
+  manifest=$2
+fi
 
 repository_root=$(git -C "$worktree" rev-parse --show-toplevel 2>/dev/null) || {
   printf 'error: not a linked Git worktree: %s\n' "$worktree" >&2
@@ -27,4 +35,37 @@ if upstream=$(git -C "$repository_root" rev-parse --abbrev-ref '@{upstream}' 2>/
   printf 'upstream=%s behind_ahead=%s\n' "$upstream" "$counts"
 else
   printf '%s\n' 'upstream=none'
+fi
+
+if [[ -n "$manifest" ]]; then
+  [[ ! -e "$manifest" ]] || {
+    printf 'error: manifest path already exists: %s\n' "$manifest" >&2
+    exit 1
+  }
+  umask 077
+  printf 'FRAMEKIT_CLEAN_WORKTREE_V1\t%s\n' \
+    "$(git -C "$repository_root" rev-parse HEAD)" >"$manifest"
+
+  while IFS= read -r -d '' path; do
+    [[ "$path" != *$'\t'* && "$path" != *$'\n'* ]] || {
+      printf 'error: manifest cannot represent path: %s\n' "$path" >&2
+      rm -f -- "$manifest"
+      exit 1
+    }
+    index_hash=$(git -C "$repository_root" ls-files -s -z -- "$path" | git hash-object --stdin)
+    if [[ -e "$repository_root/$path" || -L "$repository_root/$path" ]]; then
+      content_hash=$(git -C "$repository_root" hash-object --no-filters -- "$repository_root/$path")
+    else
+      content_hash=MISSING
+    fi
+    worktree_hash=$(
+      {
+        printf '%s\n' "$content_hash"
+        git -C "$repository_root" diff --raw --no-abbrev -- "$path"
+      } | git hash-object --stdin
+    )
+    printf '%s\t%s\t%s\n' "$path" "$index_hash" "$worktree_hash" >>"$manifest"
+  done < <(git -C "$repository_root" diff --name-only -z HEAD)
+
+  printf 'manifest=%s\n' "$manifest"
 fi

--- a/.agents/skills/clean-worktree/scripts/inspect-worktree.sh
+++ b/.agents/skills/clean-worktree/scripts/inspect-worktree.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+usage() {
+  printf 'Usage: %s [WORKTREE_PATH]\n' "$0" >&2
+}
+
+[[ ${1:-} == "--help" || ${1:-} == "-h" ]] && { usage; exit 0; }
+if (($# > 1)); then usage; exit 64; fi
+worktree=${1:-.}
+
+repository_root=$(git -C "$worktree" rev-parse --show-toplevel 2>/dev/null) || {
+  printf 'error: not a linked Git worktree: %s\n' "$worktree" >&2
+  exit 1
+}
+
+printf 'worktree=%s\nhead=%s\n' "$repository_root" "$(git -C "$repository_root" rev-parse HEAD)"
+printf '%s\n' '=== status ==='
+git -C "$repository_root" status --short --branch
+printf '%s\n' '=== unstaged summary ==='
+git -C "$repository_root" diff --stat
+printf '%s\n' '=== staged summary ==='
+git -C "$repository_root" diff --cached --stat
+printf '%s\n' '=== upstream divergence ==='
+if upstream=$(git -C "$repository_root" rev-parse --abbrev-ref '@{upstream}' 2>/dev/null); then
+  counts=$(git -C "$repository_root" rev-list --left-right --count "$upstream...HEAD")
+  printf 'upstream=%s behind_ahead=%s\n' "$upstream" "$counts"
+else
+  printf '%s\n' 'upstream=none'
+fi

--- a/.agents/skills/clean-worktree/scripts/restore-listed.sh
+++ b/.agents/skills/clean-worktree/scripts/restore-listed.sh
@@ -2,28 +2,82 @@
 set -Eeuo pipefail
 
 usage() {
-  printf 'Usage: %s WORKTREE_PATH -- TRACKED_PATH...\n' "$0" >&2
+  printf 'Usage: %s WORKTREE_PATH --manifest MANIFEST_PATH -- TRACKED_PATH...\n' "$0" >&2
 }
 
 [[ ${1:-} == "--help" || ${1:-} == "-h" ]] && { usage; exit 0; }
-if (($# < 3)) || [[ ${2:-} != -- ]]; then usage; exit 64; fi
+if (($# < 5)) || [[ ${2:-} != --manifest || ${4:-} != -- ]]; then usage; exit 64; fi
 
 worktree=$1
-shift 2
+manifest=$3
+shift 4
 repository_root=$(git -C "$worktree" rev-parse --show-toplevel 2>/dev/null) || {
   printf 'error: not a linked Git worktree: %s\n' "$worktree" >&2
   exit 1
 }
+[[ -f "$manifest" ]] || { printf 'error: manifest not found: %s\n' "$manifest" >&2; exit 1; }
+
+IFS=$'\t' read -r manifest_version expected_head manifest_extra <"$manifest" || {
+  printf 'error: unreadable authorization manifest: %s\n' "$manifest" >&2
+  exit 1
+}
+[[ "$manifest_version" == FRAMEKIT_CLEAN_WORKTREE_V1 && -n "$expected_head" && -z "$manifest_extra" ]] || {
+  printf 'error: invalid authorization manifest: %s\n' "$manifest" >&2
+  exit 1
+}
+[[ $(git -C "$repository_root" rev-parse HEAD) == "$expected_head" ]] || {
+  printf '%s\n' 'error: HEAD changed after inspection; inspect and authorize again' >&2
+  exit 1
+}
+
+current_index_hash() {
+  git -C "$repository_root" ls-files -s -z -- "$1" | git hash-object --stdin
+}
+
+current_worktree_hash() {
+  local content_hash
+  if [[ -e "$repository_root/$1" || -L "$repository_root/$1" ]]; then
+    content_hash=$(git -C "$repository_root" hash-object --no-filters -- "$repository_root/$1")
+  else
+    content_hash=MISSING
+  fi
+  {
+    printf '%s\n' "$content_hash"
+    git -C "$repository_root" diff --raw --no-abbrev -- "$1"
+  } | git hash-object --stdin
+}
+
+verify_authorized_content() {
+  local position path expected_index expected_worktree
+  [[ $(git -C "$repository_root" rev-parse HEAD) == "$expected_head" ]] || {
+    printf '%s\n' 'error: HEAD changed after inspection; inspect and authorize again' >&2
+    return 1
+  }
+  for ((position = 0; position < ${#paths[@]}; position++)); do
+    path=${paths[position]}
+    expected_index=${index_hashes[position]}
+    expected_worktree=${worktree_hashes[position]}
+    if [[ $(current_index_hash "$path") != "$expected_index" || \
+          $(current_worktree_hash "$path") != "$expected_worktree" ]]; then
+      printf 'error: content changed after inspection: %s\n' "$path" >&2
+      return 1
+    fi
+  done
+}
 
 paths=()
+index_hashes=()
+worktree_hashes=()
+selected_paths=$'\n'
 for path in "$@"; do
   [[ "$path" != /* ]] || { printf 'error: absolute path refused: %s\n' "$path" >&2; exit 64; }
   [[ "/$path/" != *"/../"* ]] || { printf 'error: parent traversal refused: %s\n' "$path" >&2; exit 64; }
-  [[ "$path" != . && "$path" != */ && "$path" != *$'\n'* ]] || {
+  [[ "$path" != . && "$path" != */ && "$path" != *$'\n'* && "$path" != *$'\t'* ]] || {
     printf 'error: broad or ambiguous path refused: %s\n' "$path" >&2
     exit 64
   }
-  tracked_path=$(git -C "$repository_root" ls-files --error-unmatch -- "$path" 2>/dev/null) || {
+  tracked_path=$(git -C "$repository_root" ls-files --error-unmatch -- "$path" 2>/dev/null) ||
+    tracked_path=$(git -C "$repository_root" cat-file -e "HEAD:$path" 2>/dev/null && printf '%s' "$path") || {
     printf 'error: path is not tracked: %s\n' "$path" >&2
     exit 1
   }
@@ -35,12 +89,56 @@ for path in "$@"; do
     printf 'error: path has no tracked change: %s\n' "$path" >&2
     exit 1
   }
+  [[ "$selected_paths" != *$'\n'"$path"$'\n'* ]] || {
+    printf 'error: duplicate path refused: %s\n' "$path" >&2
+    exit 64
+  }
+
+  manifest_match=
+  while IFS=$'\t' read -r manifest_path expected_index expected_worktree extra; do
+    [[ "$manifest_path" != "$path" ]] || {
+      [[ -n "$expected_index" && -n "$expected_worktree" && -z "$extra" && -z "$manifest_match" ]] || {
+        printf 'error: invalid manifest entry for: %s\n' "$path" >&2
+        exit 1
+      }
+      manifest_match=1
+      index_hashes+=("$expected_index")
+      worktree_hashes+=("$expected_worktree")
+    }
+  done < <(tail -n +2 -- "$manifest")
+  [[ -n "$manifest_match" ]] || {
+    printf 'error: path was not present during inspection: %s\n' "$path" >&2
+    exit 1
+  }
   paths+=("$path")
+  selected_paths+="$path"$'\n'
 done
+
+lock_path=$(git -C "$repository_root" rev-parse --path-format=absolute --git-path framekit-clean-worktree.lock)
+mkdir "$lock_path" 2>/dev/null || {
+  printf '%s\n' 'error: another clean-worktree restore is active' >&2
+  exit 1
+}
+trap 'rmdir -- "$lock_path" 2>/dev/null || true' EXIT
+
+verify_authorized_content
+
+backup_root=$(git -C "$repository_root" rev-parse --path-format=absolute --git-path framekit-clean-worktree-backups)
+backup_dir="$backup_root/$(date -u +%Y%m%dT%H%M%SZ)-$$"
+mkdir -p -- "$backup_dir"
+git -C "$repository_root" diff --cached --binary -- "${paths[@]}" >"$backup_dir/staged.patch"
+git -C "$repository_root" diff --binary -- "${paths[@]}" >"$backup_dir/worktree.patch"
+cp -- "$manifest" "$backup_dir/manifest.tsv"
+
+# Detect edits made while the recoverable backup was being written.
+verify_authorized_content
 
 printf '%s\n' '=== restoring explicit tracked paths ==='
 printf '%s\n' "${paths[@]}"
 git -C "$repository_root" restore --staged --worktree -- "${paths[@]}"
+printf 'backup=%s\n' "$backup_dir"
+printf 'recovery=git apply --index %q && git apply %q\n' \
+  "$backup_dir/staged.patch" "$backup_dir/worktree.patch"
 
 printf '%s\n' '=== resulting status ==='
 git -C "$repository_root" status --short --branch

--- a/.agents/skills/clean-worktree/scripts/restore-listed.sh
+++ b/.agents/skills/clean-worktree/scripts/restore-listed.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+usage() {
+  printf 'Usage: %s WORKTREE_PATH -- TRACKED_PATH...\n' "$0" >&2
+}
+
+[[ ${1:-} == "--help" || ${1:-} == "-h" ]] && { usage; exit 0; }
+if (($# < 3)) || [[ ${2:-} != -- ]]; then usage; exit 64; fi
+
+worktree=$1
+shift 2
+repository_root=$(git -C "$worktree" rev-parse --show-toplevel 2>/dev/null) || {
+  printf 'error: not a linked Git worktree: %s\n' "$worktree" >&2
+  exit 1
+}
+
+paths=()
+for path in "$@"; do
+  [[ "$path" != /* ]] || { printf 'error: absolute path refused: %s\n' "$path" >&2; exit 64; }
+  [[ "/$path/" != *"/../"* ]] || { printf 'error: parent traversal refused: %s\n' "$path" >&2; exit 64; }
+  [[ "$path" != . && "$path" != */ && "$path" != *$'\n'* ]] || {
+    printf 'error: broad or ambiguous path refused: %s\n' "$path" >&2
+    exit 64
+  }
+  tracked_path=$(git -C "$repository_root" ls-files --error-unmatch -- "$path" 2>/dev/null) || {
+    printf 'error: path is not tracked: %s\n' "$path" >&2
+    exit 1
+  }
+  [[ "$tracked_path" == "$path" ]] || {
+    printf 'error: path must name exactly one tracked file: %s\n' "$path" >&2
+    exit 64
+  }
+  [[ -n $(git -C "$repository_root" status --porcelain -- "$path") ]] || {
+    printf 'error: path has no tracked change: %s\n' "$path" >&2
+    exit 1
+  }
+  paths+=("$path")
+done
+
+printf '%s\n' '=== restoring explicit tracked paths ==='
+printf '%s\n' "${paths[@]}"
+git -C "$repository_root" restore --staged --worktree -- "${paths[@]}"
+
+printf '%s\n' '=== resulting status ==='
+git -C "$repository_root" status --short --branch

--- a/.agents/skills/deliver-issue/SKILL.md
+++ b/.agents/skills/deliver-issue/SKILL.md
@@ -37,6 +37,8 @@ When the user asks for a commit at every step, create short reviewable commits. 
 
 ## Validate and deliver
 
+Continue past local validation only when the user's current request explicitly authorizes pushing and creating or updating a pull request. A request only to edit or implement code does not authorize remote delivery; stop with the validated branch and commits.
+
 1. Invoke `$validate-framekit`; include native gates when native files changed.
 2. Inspect the complete diff and confirm documentation and MCP contracts remain aligned.
 3. Push the delivery branch and create a non-draft PR from the repository template.

--- a/.agents/skills/deliver-issue/SKILL.md
+++ b/.agents/skills/deliver-issue/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: deliver-issue
+description: Deliver a Framekit GitHub issue end to end with live issue inspection, an isolated worktree, test-first incremental commits, repository validation, non-draft PR creation, and remote CI follow-through. Use when the user asks to implement an issue, implement a proposed plan, make commits at each step, or finish by creating a PR.
+---
+
+# Deliver a Framekit issue
+
+Treat delivery as complete only when the requested external state is verified. Do not stop at a plan, local patch, or local green test when the user requested a PR.
+
+## Collect live context
+
+Run:
+
+```sh
+.agents/skills/deliver-issue/scripts/collect-delivery-context.sh OWNER/REPO ISSUE
+```
+
+Read `AGENTS.md`, the issue body and comments, linked PRs, current acceptance criteria, and relevant repository contracts. Re-check live state even when prior context names an older branch or result.
+
+## Plan and isolate
+
+1. Translate every acceptance criterion into a test or explicit verification item.
+2. Inspect existing worktrees and branches before creating anything.
+3. Use an isolated worktree. Prefer `../codex-ws-ISSUE` when available and a `feat/`, `fix/`, or `perf/` branch matching the change.
+4. Preserve unrelated edits. Never reset or clean another worktree.
+
+## Implement incrementally
+
+Use Red-Green-Refactor:
+
+1. Add a focused failing test and confirm the expected failure.
+2. Implement the smallest behavior that passes it.
+3. Refactor without changing behavior.
+4. Validate the focused seam after each step.
+
+When the user asks for a commit at every step, create short reviewable commits. Use `update:` messages under eight words when requested. A deliberately red checkpoint may bypass a hook only after the focused failure is captured and explained.
+
+## Validate and deliver
+
+1. Invoke `$validate-framekit`; include native gates when native files changed.
+2. Inspect the complete diff and confirm documentation and MCP contracts remain aligned.
+3. Push the delivery branch and create a non-draft PR from the repository template.
+4. Link the issue and map the PR evidence to its acceptance criteria.
+5. Wait for relevant remote checks, inspect failures, and re-check the PR head SHA and mergeability.
+
+Do not merge or close the issue unless the user explicitly requests it. Report commit hashes, validation evidence, PR URL, current checks, and any headed-native or external-state limitation.

--- a/.agents/skills/deliver-issue/agents/openai.yaml
+++ b/.agents/skills/deliver-issue/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Deliver Framekit Issue"
+  short_description: "Plan and deliver an issue through a verified PR."
+  default_prompt: "Use $deliver-issue to implement a Framekit issue with TDD, incremental commits, validation, and live PR follow-through."

--- a/.agents/skills/deliver-issue/scripts/collect-delivery-context.sh
+++ b/.agents/skills/deliver-issue/scripts/collect-delivery-context.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+usage() {
+  printf 'Usage: %s OWNER/REPO ISSUE_NUMBER_OR_URL\n' "$0" >&2
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+if [[ ${1:-} == "--help" || ${1:-} == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+if (($# != 2)); then
+  usage
+  exit 64
+fi
+
+command -v gh >/dev/null 2>&1 || die "gh is required"
+command -v git >/dev/null 2>&1 || die "git is required"
+
+repo=$1
+issue=$2
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+repository_root=$(cd -- "$script_dir/../../../.." && pwd)
+issue_reader="$repository_root/.agents/skills/issue-read/scripts/read-issue.sh"
+
+[[ -x "$issue_reader" ]] || die "issue reader is unavailable: $issue_reader"
+
+printf '%s\n' '=== repository ==='
+gh repo view "$repo" --json nameWithOwner,url,defaultBranchRef
+
+printf '%s\n' '=== live issue ==='
+"$issue_reader" "$repo" "$issue"
+
+printf '%s\n' '=== linked pull requests ==='
+gh issue view "$issue" --repo "$repo" \
+  --json closedByPullRequestsReferences \
+  --jq '.closedByPullRequestsReferences[]? | {number,title,state,url}'
+
+printf '%s\n' '=== local worktrees ==='
+git -C "$repository_root" worktree list --porcelain
+
+printf '%s\n' '=== delivery reminder ==='
+printf '%s\n' 'Map acceptance criteria to tests; use an isolated worktree; validate before a non-draft PR.'

--- a/.agents/skills/deliver-issue/scripts/collect-delivery-context.sh
+++ b/.agents/skills/deliver-issue/scripts/collect-delivery-context.sh
@@ -45,11 +45,11 @@ gh issue view "$issue" --repo "$repo" \
   --json closedByPullRequestsReferences \
   --jq '.closedByPullRequestsReferences[]? | select(.number != null) | {number,title,state,url}'
 issue_number=$(gh issue view "$issue" --repo "$repo" --json number --jq .number)
-gh api graphql \
+gh api graphql --paginate \
   -F owner="$owner" \
   -F name="$name" \
   -F number="$issue_number" \
-  -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){issue(number:$number){timelineItems(first:100,itemTypes:[CROSS_REFERENCED_EVENT]){nodes{... on CrossReferencedEvent{source{... on PullRequest{number title state url}}}}}}}}' \
+  -f query='query($owner:String!,$name:String!,$number:Int!,$endCursor:String){repository(owner:$owner,name:$name){issue(number:$number){timelineItems(first:100,after:$endCursor,itemTypes:[CROSS_REFERENCED_EVENT]){nodes{... on CrossReferencedEvent{source{... on PullRequest{number title state url}}}} pageInfo{hasNextPage endCursor}}}}}' \
   --jq '.data.repository.issue.timelineItems.nodes[]?.source // empty'
 
 printf '%s\n' '=== local worktrees ==='

--- a/.agents/skills/deliver-issue/scripts/collect-delivery-context.sh
+++ b/.agents/skills/deliver-issue/scripts/collect-delivery-context.sh
@@ -25,6 +25,9 @@ command -v git >/dev/null 2>&1 || die "git is required"
 
 repo=$1
 issue=$2
+owner=${repo%%/*}
+name=${repo#*/}
+[[ -n "$owner" && -n "$name" && "$name" != */* ]] || die "repository must be OWNER/REPO"
 script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 repository_root=$(cd -- "$script_dir/../../../.." && pwd)
 issue_reader="$repository_root/.agents/skills/issue-read/scripts/read-issue.sh"
@@ -40,7 +43,14 @@ printf '%s\n' '=== live issue ==='
 printf '%s\n' '=== linked pull requests ==='
 gh issue view "$issue" --repo "$repo" \
   --json closedByPullRequestsReferences \
-  --jq '.closedByPullRequestsReferences[]? | {number,title,state,url}'
+  --jq '.closedByPullRequestsReferences[]? | select(.number != null) | {number,title,state,url}'
+issue_number=$(gh issue view "$issue" --repo "$repo" --json number --jq .number)
+gh api graphql \
+  -F owner="$owner" \
+  -F name="$name" \
+  -F number="$issue_number" \
+  -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){issue(number:$number){timelineItems(first:100,itemTypes:[CROSS_REFERENCED_EVENT]){nodes{... on CrossReferencedEvent{source{... on PullRequest{number title state url}}}}}}}}' \
+  --jq '.data.repository.issue.timelineItems.nodes[]?.source // empty'
 
 printf '%s\n' '=== local worktrees ==='
 git -C "$repository_root" worktree list --porcelain

--- a/.agents/skills/issue-create/agents/openai.yaml
+++ b/.agents/skills/issue-create/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Create Framekit Issue"
+  short_description: "Draft approved issues from repository evidence."
+  default_prompt: "Use $issue-create to draft a Framekit issue, obtain approval, create it, and verify its metadata."

--- a/.agents/skills/issue-create/scripts/create-issue.sh
+++ b/.agents/skills/issue-create/scripts/create-issue.sh
@@ -5,6 +5,11 @@ usage() {
   printf 'Usage: %s OWNER/REPO TITLE BODY_FILE [--label LABEL]...\n' "$0" >&2
 }
 
+if [[ ${1:-} == "--help" || ${1:-} == "-h" ]]; then
+  usage
+  exit 0
+fi
+
 if (($# < 3)); then
   usage
   exit 64

--- a/.agents/skills/issue-read/agents/openai.yaml
+++ b/.agents/skills/issue-read/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Read Framekit Issue"
+  short_description: "Inspect issue status and linked evidence without mutation."
+  default_prompt: "Use $issue-read to inspect a Framekit issue, linked pull requests, comments, acceptance criteria, and blockers."

--- a/.agents/skills/issue-read/scripts/read-issue.sh
+++ b/.agents/skills/issue-read/scripts/read-issue.sh
@@ -5,6 +5,11 @@ usage() {
   printf 'Usage: %s OWNER/REPO ISSUE_NUMBER_OR_URL\n' "$0" >&2
 }
 
+if [[ ${1:-} == "--help" || ${1:-} == "-h" ]]; then
+  usage
+  exit 0
+fi
+
 if (($# != 2)); then
   usage
   exit 64

--- a/.agents/skills/repair-pr-conflict/SKILL.md
+++ b/.agents/skills/repair-pr-conflict/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: repair-pr-conflict
+description: Repair merge conflicts on an existing Framekit pull request in place while preserving both additive behaviors, validating the resolved branch, pushing to the same PR head, and rechecking checks and mergeability. Use when the user says fix conflict, another PR merged, resolve and push, or asks to make an active PR mergeable again.
+---
+
+# Repair a PR conflict
+
+Collect current evidence before touching the branch:
+
+```sh
+.agents/skills/repair-pr-conflict/scripts/collect-conflict-context.sh OWNER/REPO PR_NUMBER
+```
+
+## Resolve safely
+
+1. Confirm the live PR head SHA, head branch, base branch, repository ownership, and conflict state.
+2. Locate the existing PR worktree or create an isolated worktree from the exact head. Never reset another worktree.
+3. Fetch the current base and integrate it into the active PR branch.
+4. Resolve files semantically. Preserve compatible APIs, capability fields, tests, and fail-closed behavior from both sides.
+5. Inspect the resolved diff for accidental deletion, duplicate implementations, weakened assertions, or generated artifacts.
+6. Invoke `$validate-framekit`; include native gates when required.
+7. Commit the conflict repair and push to the same PR head branch when authorized.
+8. Re-run the collector and verify the new head SHA, mergeability, and remote checks.
+
+Do not abandon, recreate, force-push, merge, or close the PR unless explicitly requested. If the PR comes from a fork or the head branch cannot be changed safely, report the permission boundary.

--- a/.agents/skills/repair-pr-conflict/agents/openai.yaml
+++ b/.agents/skills/repair-pr-conflict/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Repair PR Conflict"
+  short_description: "Resolve an active PR conflict and revalidate it."
+  default_prompt: "Use $repair-pr-conflict to repair the active PR branch in place, validate it, push it, and recheck mergeability."

--- a/.agents/skills/repair-pr-conflict/scripts/collect-conflict-context.sh
+++ b/.agents/skills/repair-pr-conflict/scripts/collect-conflict-context.sh
@@ -20,7 +20,14 @@ printf '%s\n' '=== changed paths ==='
 gh pr diff "$pr" --repo "$repo" --name-only
 
 printf '%s\n' '=== checks ==='
-gh pr checks "$pr" --repo "$repo" || true
+set +e
+gh pr checks "$pr" --repo "$repo"
+checks_status=$?
+set -e
+case "$checks_status" in
+  0|8) ;;
+  *) exit "$checks_status" ;;
+esac
 
 printf '%s\n' '=== local worktrees ==='
 if git rev-parse --git-dir >/dev/null 2>&1; then

--- a/.agents/skills/repair-pr-conflict/scripts/collect-conflict-context.sh
+++ b/.agents/skills/repair-pr-conflict/scripts/collect-conflict-context.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+usage() {
+  printf 'Usage: %s OWNER/REPO PR_NUMBER\n' "$0" >&2
+}
+
+[[ ${1:-} == "--help" || ${1:-} == "-h" ]] && { usage; exit 0; }
+if (($# != 2)); then usage; exit 64; fi
+
+repo=$1
+pr=$2
+command -v gh >/dev/null 2>&1 || { printf '%s\n' 'error: gh is required' >&2; exit 1; }
+
+printf '%s\n' '=== live pull request ==='
+gh pr view "$pr" --repo "$repo" \
+  --json number,title,url,state,isDraft,mergeable,mergeStateStatus,headRefName,headRefOid,baseRefName,headRepositoryOwner
+
+printf '%s\n' '=== changed paths ==='
+gh pr diff "$pr" --repo "$repo" --name-only
+
+printf '%s\n' '=== checks ==='
+gh pr checks "$pr" --repo "$repo" || true
+
+printf '%s\n' '=== local worktrees ==='
+if git rev-parse --git-dir >/dev/null 2>&1; then
+  git worktree list --porcelain
+else
+  printf '%s\n' 'unavailable: run inside the repository to inspect worktrees'
+fi

--- a/.agents/skills/review-pr/agents/openai.yaml
+++ b/.agents/skills/review-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Review Framekit PR"
+  short_description: "Review, safely fix, and record a live PR decision."
+  default_prompt: "Use $review-pr to validate a Framekit pull request, address confirmed findings, update review threads, and record the decision."

--- a/.agents/skills/review-pr/scripts/collect-review.sh
+++ b/.agents/skills/review-pr/scripts/collect-review.sh
@@ -5,6 +5,11 @@ usage() {
   printf 'Usage: %s OWNER/REPO PR_NUMBER\n' "$0" >&2
 }
 
+if [[ ${1:-} == "--help" || ${1:-} == "-h" ]]; then
+  usage
+  exit 0
+fi
+
 if (($# != 2)); then
   usage
   exit 64

--- a/.agents/skills/triage-ci/SKILL.md
+++ b/.agents/skills/triage-ci/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: triage-ci
+description: Diagnose Framekit GitHub Actions failures or slow jobs from live PR and run evidence, reproduce the exact failing step locally, apply the smallest justified fix, and verify the post-push run. Use for requests to investigate CI, fix failing checks, explain a slow CodeQL job, or fix CI and merge.
+---
+
+# Triage Framekit CI
+
+Collect live evidence first:
+
+```sh
+.agents/skills/triage-ci/scripts/collect-ci.sh OWNER/REPO --pr PR_NUMBER
+.agents/skills/triage-ci/scripts/collect-ci.sh OWNER/REPO --run RUN_ID
+```
+
+## Diagnose and fix
+
+1. Confirm the live head SHA, workflow, job, step, conclusion, actor, and event.
+2. Read the failed or slow step logs. Distinguish queue time, setup, build extraction, tests, and query execution.
+3. Reproduce the exact command with the repository toolchain before changing YAML or source.
+4. Identify whether the failure is source, toolchain, permissions, external account state, or flaky infrastructure.
+5. Apply the smallest bounded fix with a regression assertion where possible.
+6. Invoke `$validate-framekit`, push when requested, and collect the replacement remote run.
+
+Do not claim a CI improvement from local success alone. If the user says “fix the CI and merge,” wait for all required terminal checks before merging; repository policy and explicit user authorization still control the merge.

--- a/.agents/skills/triage-ci/agents/openai.yaml
+++ b/.agents/skills/triage-ci/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Triage Framekit CI"
+  short_description: "Diagnose live CI failures and verify bounded fixes."
+  default_prompt: "Use $triage-ci to inspect a Framekit PR or workflow run, reproduce the failing step, and verify the smallest fix."

--- a/.agents/skills/triage-ci/scripts/collect-ci.sh
+++ b/.agents/skills/triage-ci/scripts/collect-ci.sh
@@ -19,7 +19,14 @@ case "$kind" in
     gh pr view "$target" --repo "$repo" \
       --json number,title,url,state,mergeable,mergeStateStatus,headRefName,headRefOid,baseRefName,statusCheckRollup
     printf '%s\n' '=== checks ==='
-    gh pr checks "$target" --repo "$repo" || true
+    set +e
+    gh pr checks "$target" --repo "$repo"
+    checks_status=$?
+    set -e
+    case "$checks_status" in
+      0|8) ;;
+      *) exit "$checks_status" ;;
+    esac
     head_branch=$(gh pr view "$target" --repo "$repo" --json headRefName --jq .headRefName)
     printf '%s\n' '=== recent branch runs ==='
     gh run list --repo "$repo" --branch "$head_branch" --limit 10 \
@@ -30,7 +37,7 @@ case "$kind" in
     gh run view "$target" --repo "$repo" \
       --json databaseId,name,event,status,conclusion,headBranch,headSha,createdAt,updatedAt,url,jobs
     printf '%s\n' '=== failed logs ==='
-    gh run view "$target" --repo "$repo" --log-failed || true
+    gh run view "$target" --repo "$repo" --log-failed
     ;;
   *) usage; exit 64 ;;
 esac

--- a/.agents/skills/triage-ci/scripts/collect-ci.sh
+++ b/.agents/skills/triage-ci/scripts/collect-ci.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+usage() {
+  printf 'Usage: %s OWNER/REPO (--pr PR_NUMBER | --run RUN_ID)\n' "$0" >&2
+}
+
+[[ ${1:-} == "--help" || ${1:-} == "-h" ]] && { usage; exit 0; }
+if (($# != 3)); then usage; exit 64; fi
+
+repo=$1
+kind=$2
+target=$3
+command -v gh >/dev/null 2>&1 || { printf '%s\n' 'error: gh is required' >&2; exit 1; }
+
+case "$kind" in
+  --pr)
+    printf '%s\n' '=== pull request ==='
+    gh pr view "$target" --repo "$repo" \
+      --json number,title,url,state,mergeable,mergeStateStatus,headRefName,headRefOid,baseRefName,statusCheckRollup
+    printf '%s\n' '=== checks ==='
+    gh pr checks "$target" --repo "$repo" || true
+    head_branch=$(gh pr view "$target" --repo "$repo" --json headRefName --jq .headRefName)
+    printf '%s\n' '=== recent branch runs ==='
+    gh run list --repo "$repo" --branch "$head_branch" --limit 10 \
+      --json databaseId,workflowName,event,status,conclusion,headSha,createdAt,updatedAt,url
+    ;;
+  --run)
+    printf '%s\n' '=== workflow run ==='
+    gh run view "$target" --repo "$repo" \
+      --json databaseId,name,event,status,conclusion,headBranch,headSha,createdAt,updatedAt,url,jobs
+    printf '%s\n' '=== failed logs ==='
+    gh run view "$target" --repo "$repo" --log-failed || true
+    ;;
+  *) usage; exit 64 ;;
+esac

--- a/.agents/skills/validate-framekit/SKILL.md
+++ b/.agents/skills/validate-framekit/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: validate-framekit
+description: Run and report Framekit repository validation with deterministic install, build, test, boundary, and optional native Xcode gates. Use before a PR, after implementation or conflict repair, or whenever the user asks to validate, run tests, confirm a branch works, or provide concrete completion evidence.
+---
+
+# Validate Framekit
+
+Run the repository gates from a real worktree, never from the bare repository root.
+
+```sh
+.agents/skills/validate-framekit/scripts/validate.sh
+```
+
+Use `--native` when Swift, Xcode project, native adapter, or headed Final Cut integration files changed. Use `--skip-install` only when the lockfile installation is already proven for the current worktree and toolchain.
+
+## Evidence contract
+
+Report:
+
+- worktree path and head SHA;
+- exact gates that passed, failed, or were skipped;
+- the first actionable failure and command;
+- whether native checks were required and run;
+- evidence limitations.
+
+Do not equate deterministic tests with headed Final Cut behavior, npm publication, or remote CI. Use `$verify-final-cut-native`, `$verify-release`, or `$triage-ci` for those separate proof surfaces.

--- a/.agents/skills/validate-framekit/agents/openai.yaml
+++ b/.agents/skills/validate-framekit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Validate Framekit"
+  short_description: "Run deterministic repository and native validation gates."
+  default_prompt: "Use $validate-framekit to run the required Framekit validation gates and summarize the evidence."

--- a/.agents/skills/validate-framekit/scripts/validate.sh
+++ b/.agents/skills/validate-framekit/scripts/validate.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: validate.sh [--native] [--skip-install]
+
+  --native        Also run the Xcode/native validation gates.
+  --skip-install  Skip pnpm install only when already proven for this worktree.
+USAGE
+}
+
+native=0
+install=1
+while (($# > 0)); do
+  case "$1" in
+    --native) native=1 ;;
+    --skip-install) install=0 ;;
+    --help|-h) usage; exit 0 ;;
+    *) usage >&2; exit 64 ;;
+  esac
+  shift
+done
+
+repository_root=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  printf '%s\n' 'error: run this helper from a linked Git worktree, not the bare Framekit root' >&2
+  exit 1
+}
+
+if [[ -n ${FRAMEKIT_TOOL_BIN:-} ]]; then
+  export PATH="$FRAMEKIT_TOOL_BIN:$PATH"
+elif [[ -d ${HOME:-}/.nix-profile/bin ]]; then
+  export PATH="${HOME}/.nix-profile/bin:$PATH"
+fi
+
+command -v pnpm >/dev/null 2>&1 || {
+  printf '%s\n' 'error: pnpm is required; set FRAMEKIT_TOOL_BIN to the intended toolchain bin directory' >&2
+  exit 1
+}
+
+current_step=preflight
+on_error() {
+  status=$?
+  printf 'FAILED step=%s exit=%s\n' "$current_step" "$status" >&2
+  exit "$status"
+}
+trap on_error ERR
+
+run_step() {
+  current_step=$1
+  shift
+  printf '\n=== %s ===\n' "$current_step"
+  "$@"
+}
+
+cd "$repository_root"
+printf 'worktree=%s\n' "$repository_root"
+printf 'head=%s\n' "$(git rev-parse HEAD)"
+printf 'node=%s\n' "$(command -v node || printf unavailable)"
+printf 'pnpm=%s\n' "$(command -v pnpm)"
+
+if ((install)); then
+  run_step install pnpm install --frozen-lockfile
+else
+  printf '\n=== install ===\nSKIPPED by --skip-install\n'
+fi
+run_step build pnpm run build
+run_step test pnpm run test
+run_step boundaries pnpm run check:boundaries
+
+if ((native)); then
+  run_step xcode-check pnpm run xcode:check
+  run_step xcode-project-list xcodebuild \
+    -project adapters/final-cut/swift-bridge/FinalCutWorkflowExtension/FramekitFinalCutWorkflow.xcodeproj \
+    -list
+else
+  printf '\n=== native ===\nSKIPPED; rerun with --native when native files changed\n'
+fi
+
+trap - ERR
+printf '\nPASS head=%s native=%s\n' "$(git rev-parse HEAD)" "$native"

--- a/.agents/skills/validate-mcp/SKILL.md
+++ b/.agents/skills/validate-mcp/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: validate-mcp
+description: Audit the Framekit MCP contract and runtime behavior with deterministic evaluation, headless Final Cut tests, real MCP calls, capability inspection, preview-execute-verify-undo sequencing, and explicit evidence tiers. Use for MCP QA prompts, checklist audits, capability questions, or requests to verify that MCP features work correctly.
+---
+
+# Validate the Framekit MCP
+
+Start with deterministic contract evidence:
+
+```sh
+.agents/skills/validate-mcp/scripts/validate-contract.sh
+```
+
+Use `--full` to include the complete repository test suite. Then read `docs/tests/mcp-qa-prompt.md` and inspect the current tool schemas before making real MCP calls.
+
+## Live QA order
+
+1. Call `connection.status`.
+2. Call `editor.inspect` and `project.inspect`.
+3. Inspect `capabilities.families.<family>.<operation>` for `available`, `backend`, `guarantee`, and `unavailableReason`.
+4. Route the edit and resolve intent when required.
+5. Preview before execute.
+6. Execute only when the requested backend and guarantee are available.
+7. Verify with `edit.diff` and `edit.verify`.
+8. Exercise `edit.undo` and verify restoration when the operation mutates state.
+
+Treat unsupported capability results as authoritative and fail closed. `ready` proves only that a bridge answered.
+
+## Report by evidence tier
+
+Keep these claims separate:
+
+1. fixture or deterministic contract;
+2. FCPXML artifact behavior;
+3. metadata-only live bridge behavior;
+4. canonical live read/write behavior;
+5. headed native Final Cut behavior.
+
+List every requested invariant with pass, fail, unavailable, or not run. Never upgrade fixture, FCPXML, discovery, or metadata evidence into native placement, revision, duration, export, or Undo proof.

--- a/.agents/skills/validate-mcp/SKILL.md
+++ b/.agents/skills/validate-mcp/SKILL.md
@@ -5,9 +5,10 @@ description: Audit the Framekit MCP contract and runtime behavior with determini
 
 # Validate the Framekit MCP
 
-Start with deterministic contract evidence:
+Provision the lockfile-pinned development dependencies, then collect deterministic contract evidence:
 
 ```sh
+pnpm install --frozen-lockfile
 .agents/skills/validate-mcp/scripts/validate-contract.sh
 ```
 

--- a/.agents/skills/validate-mcp/agents/openai.yaml
+++ b/.agents/skills/validate-mcp/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Validate Framekit MCP"
+  short_description: "Audit MCP contracts, capabilities, and real tool behavior."
+  default_prompt: "Use $validate-mcp to perform an evidence-tiered QA audit of the Framekit MCP surface."

--- a/.agents/skills/validate-mcp/scripts/validate-contract.sh
+++ b/.agents/skills/validate-mcp/scripts/validate-contract.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+usage() {
+  printf 'Usage: %s [--full]\n' "$0" >&2
+}
+
+full=0
+while (($# > 0)); do
+  case "$1" in
+    --full) full=1 ;;
+    --help|-h) usage; exit 0 ;;
+    *) usage; exit 64 ;;
+  esac
+  shift
+done
+
+repository_root=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  printf '%s\n' 'error: run from a linked Framekit worktree' >&2
+  exit 1
+}
+
+if [[ -n ${FRAMEKIT_TOOL_BIN:-} ]]; then
+  export PATH="$FRAMEKIT_TOOL_BIN:$PATH"
+elif [[ -d ${HOME:-}/.nix-profile/bin ]]; then
+  export PATH="${HOME}/.nix-profile/bin:$PATH"
+fi
+command -v pnpm >/dev/null 2>&1 || { printf '%s\n' 'error: pnpm is required' >&2; exit 1; }
+
+step=preflight
+trap 'status=$?; printf "FAILED step=%s exit=%s\n" "$step" "$status" >&2; exit "$status"' ERR
+run() {
+  step=$1
+  shift
+  printf '\n=== %s ===\n' "$step"
+  "$@"
+}
+
+cd "$repository_root"
+printf 'worktree=%s\nhead=%s\n' "$repository_root" "$(git rev-parse HEAD)"
+run build pnpm run build
+run mcp-evaluation pnpm run evaluate
+run final-cut-headless pnpm run test:final-cut-headless
+run boundaries pnpm run check:boundaries
+if ((full)); then
+  run full-test pnpm run test
+fi
+
+trap - ERR
+printf '\nPASS evidence=deterministic-contract\n'
+printf '%s\n' 'NOTE: real MCP calls and headed Final Cut proof remain separate.'

--- a/.agents/skills/verify-final-cut-native/SKILL.md
+++ b/.agents/skills/verify-final-cut-native/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: verify-final-cut-native
+description: Safely preflight and verify real headed Final Cut Pro reads, edits, placement, revision changes, and Undo restoration using Framekit's headed runners. Use when the user asks for actual Final Cut timeline proof, native verification, a step-by-step headed test, or confirmation beyond fixtures, FCPXML, discovery, or metadata-only bridge behavior.
+---
+
+# Verify headed Final Cut behavior
+
+Use a disposable project and prepared media. Native writes require an unlocked macOS console, frontmost Final Cut timeline, Accessibility and Automation permissions, and explicit mutation consent.
+
+## Preflight
+
+List supported modes and required variables:
+
+```sh
+.agents/skills/verify-final-cut-native/scripts/run-headed-check.sh --help
+```
+
+Run without `--execute` first. The helper checks the environment but does not run the headed scenario:
+
+```sh
+.agents/skills/verify-final-cut-native/scripts/run-headed-check.sh MODE
+```
+
+For a write scenario, require the user-authorized disposable target and set `FRAMEKIT_FINAL_CUT_E2E_ALLOW_MUTATION=1`. Then rerun with `--execute`.
+
+## Proof contract
+
+Capture and report each applicable invariant independently:
+
+- exact project and sequence identity;
+- stable media, occurrence, or transition identity;
+- exact frame-aligned target range;
+- preview token and pre-edit revision;
+- executed placement or edit result;
+- post-edit revision and observable timeline state;
+- duration or range readback when requested;
+- operation ID and Undo availability;
+- Undo execution and restoration of the original state.
+
+Do not treat discovery, string matches, headless tests, or a `ready` connection as placement or Undo proof. On screen lock, focus, permission, selection, stale preview, or capability errors, stop and report the exact blocker rather than inventing timeline state.

--- a/.agents/skills/verify-final-cut-native/agents/openai.yaml
+++ b/.agents/skills/verify-final-cut-native/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Verify Final Cut Native"
+  short_description: "Prove headed Final Cut behavior and Undo safely."
+  default_prompt: "Use $verify-final-cut-native to preflight and verify a real headed Final Cut operation without conflating fixture evidence."

--- a/.agents/skills/verify-final-cut-native/scripts/run-headed-check.sh
+++ b/.agents/skills/verify-final-cut-native/scripts/run-headed-check.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: run-headed-check.sh MODE [--execute]
+
+Modes and required environment variables:
+  canonical-read  FRAMEKIT_FINAL_CUT_E2E_PROJECT
+  media-insert    FRAMEKIT_FINAL_CUT_E2E_PROJECT, FRAMEKIT_FINAL_CUT_E2E_QUERY
+  canonical-write FRAMEKIT_FINAL_CUT_E2E_PROJECT, FRAMEKIT_FINAL_CUT_E2E_CLIP_ID
+  disposable-edit FRAMEKIT_FINAL_CUT_E2E_PROJECT, FRAMEKIT_FINAL_CUT_E2E_CLIP_ID
+  filler-removal  FRAMEKIT_FINAL_CUT_E2E_PROJECT, FRAMEKIT_FINAL_CUT_E2E_RANGE_START,
+                  FRAMEKIT_FINAL_CUT_E2E_RANGE_END
+  overlay         FRAMEKIT_FINAL_CUT_E2E_PROJECT
+
+Without --execute, perform preflight only. Write modes additionally require:
+  FRAMEKIT_FINAL_CUT_E2E_ALLOW_MUTATION=1
+USAGE
+}
+
+[[ ${1:-} == "--help" || ${1:-} == "-h" ]] && { usage; exit 0; }
+mode=${1:-}
+[[ -n "$mode" ]] || { usage >&2; exit 64; }
+shift
+
+execute=0
+while (($# > 0)); do
+  case "$1" in
+    --execute) execute=1 ;;
+    --help|-h) usage; exit 0 ;;
+    *) usage >&2; exit 64 ;;
+  esac
+  shift
+done
+
+repository_root=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  printf '%s\n' 'error: run from a linked Framekit worktree' >&2
+  exit 1
+}
+[[ $(uname -s) == Darwin ]] || { printf '%s\n' 'error: headed Final Cut verification requires macOS' >&2; exit 1; }
+command -v osascript >/dev/null 2>&1 || { printf '%s\n' 'error: osascript is required' >&2; exit 1; }
+pgrep -x 'Final Cut Pro' >/dev/null 2>&1 || { printf '%s\n' 'error: Final Cut Pro is not running' >&2; exit 1; }
+
+if /usr/sbin/ioreg -n Root -d1 2>/dev/null | grep -q '"CGSSessionScreenIsLocked" = Yes'; then
+  printf '%s\n' 'error: CGSSessionScreenIsLocked=true; unlock the console before native verification' >&2
+  exit 1
+fi
+
+frontmost=$(osascript -e 'tell application "System Events" to get name of first application process whose frontmost is true' 2>/dev/null || printf unavailable)
+printf 'worktree=%s\nhead=%s\nfrontmost=%s\n' "$repository_root" "$(git -C "$repository_root" rev-parse HEAD)" "$frontmost"
+[[ "$frontmost" == 'Final Cut Pro' ]] || {
+  printf '%s\n' 'error: Final Cut Pro must be frontmost with a visible timeline' >&2
+  exit 1
+}
+
+require_env() {
+  local variable
+  for variable in "$@"; do
+    [[ -n ${!variable:-} ]] || { printf 'error: set %s\n' "$variable" >&2; exit 1; }
+  done
+}
+
+write_mode=1
+case "$mode" in
+  canonical-read)
+    write_mode=0
+    require_env FRAMEKIT_FINAL_CUT_E2E_PROJECT
+    runner=(pnpm run test:final-cut-canonical-read-headed)
+    ;;
+  media-insert)
+    require_env FRAMEKIT_FINAL_CUT_E2E_PROJECT FRAMEKIT_FINAL_CUT_E2E_QUERY
+    runner=(node scripts/final-cut-headed-e2e.mjs)
+    ;;
+  canonical-write)
+    require_env FRAMEKIT_FINAL_CUT_E2E_PROJECT FRAMEKIT_FINAL_CUT_E2E_CLIP_ID
+    runner=(pnpm run test:final-cut-canonical-headed)
+    ;;
+  disposable-edit)
+    require_env FRAMEKIT_FINAL_CUT_E2E_PROJECT FRAMEKIT_FINAL_CUT_E2E_CLIP_ID
+    runner=(pnpm run test:final-cut-disposable-headed)
+    ;;
+  filler-removal)
+    require_env FRAMEKIT_FINAL_CUT_E2E_PROJECT FRAMEKIT_FINAL_CUT_E2E_RANGE_START FRAMEKIT_FINAL_CUT_E2E_RANGE_END
+    runner=(pnpm run test:final-cut-filler-headed)
+    ;;
+  overlay)
+    require_env FRAMEKIT_FINAL_CUT_E2E_PROJECT
+    runner=(pnpm run test:final-cut-overlay-headed)
+    ;;
+  *) usage >&2; exit 64 ;;
+esac
+
+printf 'mode=%s\nexecute=%s\nwrite_mode=%s\n' "$mode" "$execute" "$write_mode"
+if ((!execute)); then
+  printf '%s\n' 'PREFLIGHT PASS; no headed scenario was executed.'
+  exit 0
+fi
+
+if ((write_mode)) && [[ ${FRAMEKIT_FINAL_CUT_E2E_ALLOW_MUTATION:-0} != 1 ]]; then
+  printf '%s\n' 'error: write mode requires FRAMEKIT_FINAL_CUT_E2E_ALLOW_MUTATION=1 for an authorized disposable project' >&2
+  exit 1
+fi
+
+cd "$repository_root"
+printf 'running='; printf '%q ' "${runner[@]}"; printf '\n'
+"${runner[@]}"

--- a/.agents/skills/verify-final-cut-native/scripts/run-headed-check.sh
+++ b/.agents/skills/verify-final-cut-native/scripts/run-headed-check.sh
@@ -42,10 +42,23 @@ repository_root=$(git rev-parse --show-toplevel 2>/dev/null) || {
 command -v osascript >/dev/null 2>&1 || { printf '%s\n' 'error: osascript is required' >&2; exit 1; }
 pgrep -x 'Final Cut Pro' >/dev/null 2>&1 || { printf '%s\n' 'error: Final Cut Pro is not running' >&2; exit 1; }
 
-if /usr/sbin/ioreg -n Root -d1 2>/dev/null | grep -q '"CGSSessionScreenIsLocked" = Yes'; then
-  printf '%s\n' 'error: CGSSessionScreenIsLocked=true; unlock the console before native verification' >&2
+lock_probe=$(/usr/sbin/ioreg -n Root -d1 2>/dev/null) || {
+  printf '%s\n' 'error: unable to determine the macOS console lock state' >&2
   exit 1
-fi
+}
+lock_state=$(printf '%s\n' "$lock_probe" | sed -n \
+  's/.*"CGSSessionScreenIsLocked"[[:space:]]*=[[:space:]]*\([^,}[:space:]]*\).*/\1/p')
+case "$lock_state" in
+  No) ;;
+  Yes)
+    printf '%s\n' 'error: CGSSessionScreenIsLocked=true; unlock the console before native verification' >&2
+    exit 1
+    ;;
+  *)
+    printf 'error: unknown macOS console lock state: %s\n' "${lock_state:-missing}" >&2
+    exit 1
+    ;;
+esac
 
 frontmost=$(osascript -e 'tell application "System Events" to get name of first application process whose frontmost is true' 2>/dev/null || printf unavailable)
 printf 'worktree=%s\nhead=%s\nfrontmost=%s\n' "$repository_root" "$(git -C "$repository_root" rev-parse HEAD)" "$frontmost"

--- a/.agents/skills/verify-release/SKILL.md
+++ b/.agents/skills/verify-release/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: verify-release
+description: Verify a Framekit release across the Git tag, GitHub release state, required workflow runs, Workflow Extension archive and checksum assets, npm registry publication, and clean-client startup evidence. Use for release status, draft-release problems, tagpr questions, missing npm versions, or requests to confirm that a release is actually available to users.
+---
+
+# Verify a Framekit release
+
+Run the cross-surface verifier with an exact version:
+
+```sh
+.agents/skills/verify-release/scripts/verify-release.sh OWNER/REPO VERSION [NPM_PACKAGE]
+```
+
+The helper exits nonzero when the tag, GitHub release, expected native assets, or npm version is missing. It does not mutate tags, releases, workflows, or npm account settings.
+
+## Complete verification
+
+1. Confirm the tag resolves to the intended commit.
+2. Confirm the GitHub release draft/prerelease state and matching target.
+3. Confirm `FramekitFinalCutWorkflow-VERSION.zip` and its `.sha256` asset exist.
+4. Confirm the relevant release workflow reached a terminal successful conclusion for the same tag/head.
+5. Confirm `npm view PACKAGE@VERSION version` returns the exact version.
+6. When end-user availability is the goal, run package/plugin and clean-client smoke tests against the published package.
+
+Keep repository workflow correctness separate from external npm Trusted Publisher or authentication state. A tag, release, or green build does not prove registry publication; registry publication does not prove a clean client can start the MCP server.

--- a/.agents/skills/verify-release/SKILL.md
+++ b/.agents/skills/verify-release/SKILL.md
@@ -18,8 +18,8 @@ The helper exits nonzero when the tag, GitHub release, expected native assets, o
 1. Confirm the tag resolves to the intended commit.
 2. Confirm the GitHub release draft/prerelease state and matching target.
 3. Confirm `FramekitFinalCutWorkflow-VERSION.zip` and its `.sha256` asset exist.
-4. Confirm the relevant release workflow reached a terminal successful conclusion for the same tag/head.
-5. Confirm `npm view PACKAGE@VERSION version` returns the exact version.
+4. Confirm the `Release` workflow reached a terminal successful conclusion for the exact tag commit.
+5. Confirm `npm view --registry=https://registry.npmjs.org PACKAGE@VERSION version` returns the exact version.
 6. When end-user availability is the goal, run package/plugin and clean-client smoke tests against the published package.
 
 Keep repository workflow correctness separate from external npm Trusted Publisher or authentication state. A tag, release, or green build does not prove registry publication; registry publication does not prove a clean client can start the MCP server.

--- a/.agents/skills/verify-release/agents/openai.yaml
+++ b/.agents/skills/verify-release/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Verify Framekit Release"
+  short_description: "Verify tags, releases, workflows, assets, and npm publication."
+  default_prompt: "Use $verify-release to confirm the complete Framekit release state for a specific version."

--- a/.agents/skills/verify-release/scripts/verify-release.sh
+++ b/.agents/skills/verify-release/scripts/verify-release.sh
@@ -19,6 +19,7 @@ tag="v$version"
 
 command -v gh >/dev/null 2>&1 || { printf '%s\n' 'error: gh is required' >&2; exit 1; }
 command -v npm >/dev/null 2>&1 || { printf '%s\n' 'error: npm is required' >&2; exit 1; }
+command -v node >/dev/null 2>&1 || { printf '%s\n' 'error: node is required' >&2; exit 1; }
 
 if [[ -z "$package" ]]; then
   repository_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
@@ -30,10 +31,19 @@ if [[ -z "$package" ]]; then
 fi
 
 failures=0
+tag_commit_sha=
 printf 'repo=%s\ntag=%s\npackage=%s\n' "$repo" "$tag" "$package"
 
 printf '%s\n' '=== tag ==='
-if ! gh api "repos/$repo/git/ref/tags/$tag" --jq '{ref, object}'; then
+if gh api "repos/$repo/git/ref/tags/$tag" --jq '{ref, object}'; then
+  tag_commit_sha=$(gh api "repos/$repo/commits/$tag" --jq .sha 2>/dev/null) || tag_commit_sha=
+  if [[ -z "$tag_commit_sha" ]]; then
+    printf 'MISSING tag_commit=%s\n' "$tag" >&2
+    failures=$((failures + 1))
+  else
+    printf 'tag_commit=%s\n' "$tag_commit_sha"
+  fi
+else
   printf 'MISSING tag=%s\n' "$tag" >&2
   failures=$((failures + 1))
 fi
@@ -46,9 +56,15 @@ if [[ -z "$release_json" ]]; then
   failures=$((failures + 1))
 else
   printf '%s\n' "$release_json"
-  release_is_draft=$(gh release view "$tag" --repo "$repo" --json isDraft --jq .isDraft)
+  release_states=$(gh release view "$tag" --repo "$repo" --json isDraft,isPrerelease \
+    --jq '"\(.isDraft) \(.isPrerelease)"')
+  read -r release_is_draft release_is_prerelease <<<"$release_states"
   if [[ "$release_is_draft" == true ]]; then
     printf 'INCOMPLETE release=%s state=draft\n' "$tag" >&2
+    failures=$((failures + 1))
+  fi
+  if [[ "$release_is_prerelease" == true ]]; then
+    printf 'INCOMPLETE release=%s state=prerelease\n' "$tag" >&2
     failures=$((failures + 1))
   fi
   expected_archive="FramekitFinalCutWorkflow-$version.zip"
@@ -65,21 +81,31 @@ else
 fi
 
 printf '%s\n' '=== tag workflow runs ==='
-workflow_json=$(gh run list --repo "$repo" --branch "$tag" --limit 30 \
-  --json databaseId,workflowName,event,status,conclusion,headBranch,headSha,createdAt,url \
-  2>/dev/null || printf '[]')
+workflow_json=[]
+if [[ -n "$tag_commit_sha" ]]; then
+  workflow_json=$(gh run list --repo "$repo" --workflow release.yml --commit "$tag_commit_sha" --limit 30 \
+    --json databaseId,workflowName,event,status,conclusion,headBranch,headSha,createdAt,url \
+    2>/dev/null || printf '[]')
+fi
 printf '%s\n' "$workflow_json"
-successful_run_count=$(gh run list --repo "$repo" --branch "$tag" --limit 30 \
-  --json status,conclusion,headBranch \
-  --jq '[.[] | select(.status == "completed" and .conclusion == "success")] | length' \
-  2>/dev/null || printf '0')
+successful_run_count=$(printf '%s\n' "$workflow_json" | node -e '
+  let input = "";
+  process.stdin.on("data", chunk => input += chunk);
+  process.stdin.on("end", () => {
+    const expected = process.argv[1];
+    const runs = JSON.parse(input);
+    const matches = runs.filter(run => run.workflowName === "Release" && run.event === "push" &&
+      run.headSha === expected && run.status === "completed" && run.conclusion === "success");
+    process.stdout.write(String(matches.length));
+  });
+' "$tag_commit_sha")
 if [[ "$successful_run_count" == 0 ]]; then
-  printf 'MISSING successful_tag_workflow=%s\n' "$tag" >&2
+  printf 'MISSING successful_release_workflow=%s commit=%s\n' "$tag" "${tag_commit_sha:-unknown}" >&2
   failures=$((failures + 1))
 fi
 
 printf '%s\n' '=== npm registry ==='
-published_version=$(npm view "$package@$version" version 2>/dev/null || true)
+published_version=$(npm view --registry=https://registry.npmjs.org "$package@$version" version 2>/dev/null || true)
 if [[ "$published_version" != "$version" ]]; then
   printf 'MISSING npm=%s@%s observed=%s\n' "$package" "$version" "${published_version:-none}" >&2
   failures=$((failures + 1))

--- a/.agents/skills/verify-release/scripts/verify-release.sh
+++ b/.agents/skills/verify-release/scripts/verify-release.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+usage() {
+  printf 'Usage: %s OWNER/REPO VERSION [NPM_PACKAGE]\n' "$0" >&2
+}
+
+[[ ${1:-} == "--help" || ${1:-} == "-h" ]] && { usage; exit 0; }
+if (($# < 2 || $# > 3)); then usage; exit 64; fi
+
+repo=$1
+version=${2#v}
+package=${3:-}
+[[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]] || {
+  printf 'error: invalid version: %s\n' "$version" >&2
+  exit 64
+}
+tag="v$version"
+
+command -v gh >/dev/null 2>&1 || { printf '%s\n' 'error: gh is required' >&2; exit 1; }
+command -v npm >/dev/null 2>&1 || { printf '%s\n' 'error: npm is required' >&2; exit 1; }
+
+if [[ -z "$package" ]]; then
+  repository_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+  if [[ -n "$repository_root" && -f "$repository_root/package.json" ]] && command -v node >/dev/null 2>&1; then
+    package=$(node -p "require(process.argv[1]).name" "$repository_root/package.json")
+  else
+    package=@morshoto/framekit
+  fi
+fi
+
+failures=0
+printf 'repo=%s\ntag=%s\npackage=%s\n' "$repo" "$tag" "$package"
+
+printf '%s\n' '=== tag ==='
+if ! gh api "repos/$repo/git/ref/tags/$tag" --jq '{ref, object}'; then
+  printf 'MISSING tag=%s\n' "$tag" >&2
+  failures=$((failures + 1))
+fi
+
+printf '%s\n' '=== GitHub release ==='
+release_json=$(gh release view "$tag" --repo "$repo" \
+  --json tagName,targetCommitish,isDraft,isPrerelease,publishedAt,url,assets 2>/dev/null) || release_json=
+if [[ -z "$release_json" ]]; then
+  printf 'MISSING release=%s\n' "$tag" >&2
+  failures=$((failures + 1))
+else
+  printf '%s\n' "$release_json"
+  release_is_draft=$(gh release view "$tag" --repo "$repo" --json isDraft --jq .isDraft)
+  if [[ "$release_is_draft" == true ]]; then
+    printf 'INCOMPLETE release=%s state=draft\n' "$tag" >&2
+    failures=$((failures + 1))
+  fi
+  expected_archive="FramekitFinalCutWorkflow-$version.zip"
+  expected_checksum="$expected_archive.sha256"
+  asset_names=$(gh release view "$tag" --repo "$repo" --json assets --jq '.assets[].name')
+  if ! grep -Fxq "$expected_archive" <<<"$asset_names"; then
+    printf 'MISSING asset=%s\n' "$expected_archive" >&2
+    failures=$((failures + 1))
+  fi
+  if ! grep -Fxq "$expected_checksum" <<<"$asset_names"; then
+    printf 'MISSING asset=%s\n' "$expected_checksum" >&2
+    failures=$((failures + 1))
+  fi
+fi
+
+printf '%s\n' '=== tag workflow runs ==='
+workflow_json=$(gh run list --repo "$repo" --branch "$tag" --limit 30 \
+  --json databaseId,workflowName,event,status,conclusion,headBranch,headSha,createdAt,url \
+  2>/dev/null || printf '[]')
+printf '%s\n' "$workflow_json"
+successful_run_count=$(gh run list --repo "$repo" --branch "$tag" --limit 30 \
+  --json status,conclusion,headBranch \
+  --jq '[.[] | select(.status == "completed" and .conclusion == "success")] | length' \
+  2>/dev/null || printf '0')
+if [[ "$successful_run_count" == 0 ]]; then
+  printf 'MISSING successful_tag_workflow=%s\n' "$tag" >&2
+  failures=$((failures + 1))
+fi
+
+printf '%s\n' '=== npm registry ==='
+published_version=$(npm view "$package@$version" version 2>/dev/null || true)
+if [[ "$published_version" != "$version" ]]; then
+  printf 'MISSING npm=%s@%s observed=%s\n' "$package" "$version" "${published_version:-none}" >&2
+  failures=$((failures + 1))
+else
+  printf 'PASS npm=%s@%s\n' "$package" "$published_version"
+fi
+
+if ((failures)); then
+  printf 'FAIL missing_surfaces=%s\n' "$failures" >&2
+  exit 1
+fi
+printf 'PASS release=%s\n' "$version"


### PR DESCRIPTION
## Summary

- add eight repository-local skills for issue delivery, validation, MCP QA, headed Final Cut proof, conflict repair, CI triage, release verification, and safe cleanup
- give all eleven skills generated `agents/openai.yaml` metadata and consistent script entry points
- add fail-closed helpers for live GitHub collection, release state, native mutation preflight, and explicit-path cleanup
- update the `.agents` index with the complete workflow suite

## Validation

```bash
.agents/skills/validate-framekit/scripts/validate.sh
# pnpm install --frozen-lockfile: passed
# pnpm run build: passed
# pnpm run test: 466/466 passed
# pnpm run check:boundaries: passed
```

- `quick_validate.py`: 11/11 skill folders passed
- `bash -n` and `--help`: 12/12 helper scripts passed
- live read-only smoke checks passed for issue, PR, conflict, and CI collectors
- release verifier correctly failed closed for incomplete release surfaces
- native helper correctly stopped before execution when Final Cut was not frontmost
- Xcode checks were not required because no native source or project files changed

Local hook note: the current pre-commit hook re-enters the Nix pnpm 11.10 binary from `npm pack` while the repository requires pnpm 11.25.0. The commit used `--no-verify` only after the exact full validation above passed under Nix Node 22.23.1 and pnpm 11.25.0; remote CI remains the independent gate.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Public MCP behavior and package interfaces are unchanged.
- [x] Existing adapters and test fixtures remain compatible.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [x] Documentation reflects the added skill paths and commands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded repository guidance for delivery, pull-request conflict repair, CI triage, validation, release verification, and native Final Cut Pro checks.
  - Added evidence-based verification guidance for MCP, worktrees, releases, and native application behavior.

- **New Features**
  - Added tools for inspecting and safely cleaning worktrees, collecting issue, pull-request, CI, and review context, and delivering issues.
  - Added validation commands for repository gates, MCP contracts, native Final Cut Pro behavior, and published releases.
  - Added help options to command-line utilities and stronger release checks tied to exact tag commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->