### PR TITLE
Release for v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v0.1.4](https://github.com/morshoto/framekit/compare/v0.1.3...v0.1.4) - 2026-09-10
+
+- feat: add guarded native Final Cut transitions by @morshoto in https://github.com/morshoto/framekit/pull/142
+- test: add deterministic Basic Editing MVP gate by @morshoto in https://github.com/morshoto/framekit/pull/143
+- test: add live project selection acceptance gate by @morshoto in https://github.com/morshoto/framekit/pull/144
+- test: require explicit targets in live canonical evidence by @morshoto in https://github.com/morshoto/framekit/pull/145
+- chore(deps): update github actions by @renovate[bot] in https://github.com/morshoto/framekit/pull/160
+- chore(deps): update pnpm to v12 by @renovate[bot] in https://github.com/morshoto/framekit/pull/161
+
 ## [v0.1.3](https://github.com/morshoto/framekit/compare/v0.1.2...v0.1.3) - 2026-09-08
 
 - chore(deps): pin dependencies by @renovate[bot] in https://github.com/morshoto/framekit/pull/122

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@morshoto/framekit",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "packageManager": "pnpm@12.3.4",
   "private": false,
   "type": "module",

--- a/plugins/framekit/.codex-plugin/plugin.json
+++ b/plugins/framekit/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "framekit",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Connect Codex to Framekit's MCP tools for Final Cut Pro",
   "author": {
     "name": "Framekit Contributors",


### PR DESCRIPTION
This pull request is for the next release as v0.1.4 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.4 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.3" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* feat: add guarded native Final Cut transitions by @morshoto in https://github.com/morshoto/framekit/pull/142
* test: add deterministic Basic Editing MVP gate by @morshoto in https://github.com/morshoto/framekit/pull/143
* test: add live project selection acceptance gate by @morshoto in https://github.com/morshoto/framekit/pull/144
* test: require explicit targets in live canonical evidence by @morshoto in https://github.com/morshoto/framekit/pull/145
* chore(deps): update github actions by @renovate[bot] in https://github.com/morshoto/framekit/pull/160
* chore(deps): update pnpm to v12 by @renovate[bot] in https://github.com/morshoto/framekit/pull/161


**Full Changelog**: https://github.com/morshoto/framekit/compare/v0.1.3...tagpr-from-v0.1.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application and plugin to version 0.1.4.
  * Added changelog entries covering guarded native Final Cut transitions and validation gates.
  * Updated the package manager tooling to pnpm 12.3.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->