### PR TITLE
fix: make tagged release retries idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing release tag to retry (for example, v0.1.3)
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -16,7 +22,7 @@ jobs:
   tagpr:
     runs-on: ubuntu-latest
     outputs:
-      release-tag: ${{ steps.existing-tag.outputs.tag || steps.run-tagpr.outputs.tag }}
+      release-tag: ${{ steps.requested-tag.outputs.tag || steps.existing-tag.outputs.tag || steps.run-tagpr.outputs.tag }}
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -25,8 +31,27 @@ jobs:
           token: ${{ secrets.TAGPR_TOKEN }}
           persist-credentials: false
 
+      - id: requested-tag
+        name: Resolve requested release tag
+        env:
+          REQUESTED_TAG: ${{ inputs.release_tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${REQUESTED_TAG}" ]; then
+            echo "tag=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! git check-ref-format "refs/tags/${REQUESTED_TAG}" \
+            || ! git rev-parse --verify --quiet "refs/tags/${REQUESTED_TAG}^{commit}" >/dev/null; then
+            echo "Requested release tag does not exist: ${REQUESTED_TAG}" >&2
+            exit 1
+          fi
+          echo "tag=${REQUESTED_TAG}" >> "$GITHUB_OUTPUT"
+
       - id: existing-tag
         name: Detect release tag on HEAD
+        if: steps.requested-tag.outputs.tag == ''
         shell: bash
         run: |
           set -euo pipefail
@@ -40,7 +65,7 @@ jobs:
 
       - id: run-tagpr
         name: Run tagpr
-        if: steps.existing-tag.outputs.tag == ''
+        if: steps.requested-tag.outputs.tag == '' && steps.existing-tag.outputs.tag == ''
         uses: Songmu/tagpr@7ebae2dcc300132baa7cc9dd108c8923b07fc366 # v1
         env:
           GITHUB_TOKEN: ${{ secrets.TAGPR_TOKEN }}
@@ -56,6 +81,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
+          ref: ${{ needs.tagpr.outputs.release-tag }}
           persist-credentials: false
 
       - name: Validate release package
@@ -80,8 +106,36 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - id: npm-status
+        name: Check npm publication status
+        env:
+          RELEASE_TAG: ${{ needs.tagpr.outputs.release-tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected_version="${RELEASE_TAG#v}"
+          package_name="$(node -p "require('./package.json').name")"
+          error_log="${RUNNER_TEMP}/npm-view-error.log"
+          if published_version="$(npm view "${package_name}@${expected_version}" version 2>"${error_log}")"; then
+            if [ "${published_version}" != "${expected_version}" ]; then
+              echo "Unexpected npm version: ${published_version}" >&2
+              exit 1
+            fi
+            echo "published=true" >> "$GITHUB_OUTPUT"
+          elif grep -Eq 'E404|404 Not Found' "${error_log}"; then
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          else
+            cat "${error_log}" >&2
+            exit 1
+          fi
+
       - name: Publish npm package
-        run: npm publish --access public
+        if: steps.npm-status.outputs.published != 'true'
+        run: |
+          if ! npm publish --access public; then
+            echo "::error::npm publish failed. For E404 or ENEEDAUTH, verify that @morshoto/framekit trusts morshoto/framekit release.yml and allows direct npm publish."
+            exit 1
+          fi
 
       - name: Verify npm publication
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write
@@ -45,6 +49,10 @@ jobs:
           if ! git check-ref-format "refs/tags/${REQUESTED_TAG}" \
             || ! git rev-parse --verify --quiet "refs/tags/${REQUESTED_TAG}^{commit}" >/dev/null; then
             echo "Requested release tag does not exist: ${REQUESTED_TAG}" >&2
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "refs/tags/${REQUESTED_TAG}^{commit}" origin/main; then
+            echo "Requested release tag is not reachable from main: ${REQUESTED_TAG}" >&2
             exit 1
           fi
           echo "tag=${REQUESTED_TAG}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,7 @@ jobs:
           expected_version="${RELEASE_TAG#v}"
           package_name="$(node -p "require('./package.json').name")"
           error_log="${RUNNER_TEMP}/npm-view-error.log"
-          if published_version="$(npm view "${package_name}@${expected_version}" version 2>"${error_log}")"; then
+          if published_version="$(npm view --prefer-online "${package_name}@${expected_version}" version 2>"${error_log}")"; then
             if [ "${published_version}" != "${expected_version}" ]; then
               echo "Unexpected npm version: ${published_version}" >&2
               exit 1
@@ -144,21 +144,55 @@ jobs:
           fi
       - name: Publish npm package
         if: steps.npm-status.outputs.published != 'true'
+        env:
+          RELEASE_TAG: ${{ needs.tagpr.outputs.release-tag }}
+        shell: bash
         run: |
-          if ! npm publish --access public; then
-            echo "::error::npm publish failed. For E404 or ENEEDAUTH, verify that @morshoto/framekit trusts morshoto/framekit release.yml and allows direct npm publish."
-            exit 1
+          set -euo pipefail
+          expected_version="${RELEASE_TAG#v}"
+          package_name="$(node -p "require('./package.json').name")"
+          error_log="${RUNNER_TEMP}/npm-publish-error.log"
+          if npm publish --access public 2>"${error_log}"; then
+            exit 0
           fi
+          cat "${error_log}" >&2
+          if grep -Eq 'EPUBLISHCONFLICT|previously published versions' "${error_log}"; then
+            echo "npm ${package_name}@${expected_version} was published by an earlier attempt; verification will confirm it."
+            exit 0
+          fi
+          echo "::error::npm publish failed. For E404 or ENEEDAUTH, verify that @morshoto/framekit trusts morshoto/framekit release.yml and allows direct npm publish."
+          exit 1
 
       - name: Verify npm publication
         env:
           RELEASE_TAG: ${{ needs.tagpr.outputs.release-tag }}
         run: |
-          set -eu
+          set -euo pipefail
           expected_version="${RELEASE_TAG#v}"
           package_name="$(node -p "require('./package.json').name")"
-          published_version="$(npm view "${package_name}@${expected_version}" version)"
-          test "${published_version}" = "${expected_version}"
+          error_log="${RUNNER_TEMP}/npm-verify-error.log"
+          max_attempts=6
+          for attempt in $(seq 1 "${max_attempts}"); do
+            if published_version="$(npm view --prefer-online "${package_name}@${expected_version}" version 2>"${error_log}")"; then
+              if [ "${published_version}" != "${expected_version}" ]; then
+                echo "Unexpected npm version: ${published_version}" >&2
+                exit 1
+              fi
+              echo "Verified ${package_name}@${expected_version} on attempt ${attempt}."
+              exit 0
+            fi
+            if ! grep -Eq 'E404|404 Not Found|No match found for version' "${error_log}"; then
+              cat "${error_log}" >&2
+              exit 1
+            fi
+            if [ "${attempt}" -lt "${max_attempts}" ]; then
+              delay=$((attempt * 5))
+              echo "npm ${package_name}@${expected_version} is not visible yet; retrying in ${delay}s (attempt ${attempt}/${max_attempts})."
+              sleep "${delay}"
+            fi
+          done
+          cat "${error_log}" >&2
+          exit 1
 
       - name: Publish GitHub release
         env:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -55,9 +55,10 @@ gh workflow run release.yml \
   -f release_tag=v0.1.3
 ```
 
-The manual run verifies that the tag exists, checks out that exact tag, and
-skips `npm publish` if the matching version is already present. Registry errors
-other than a missing version fail closed.
+The manual run verifies that the tag exists and points to a commit reachable
+from `main`, checks out that exact tag, and skips `npm publish` if the matching
+version is already present. Registry errors other than a missing version fail
+closed.
 
 The npm Trusted Publisher relationship is configured in npm account settings;
 repository permissions alone cannot create or repair that relationship. The

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -11,7 +11,7 @@ Configure npm Trusted Publishing for `@morshoto/framekit` with these values:
 - Organization or user: `morshoto`
 - Repository: `framekit`
 - Workflow filename: `release.yml`
-- Allowed action: `npm publish`
+- Allowed action: direct `npm publish` (not only `npm stage publish`)
 
 The same trust relationship can be configured from an authenticated npm CLI
 session after the package exists on the registry:
@@ -44,6 +44,20 @@ be repaired without presenting an incomplete release as public.
 
 If a retry finds a draft release whose tag is shown as `untagged-*`, the
 workflow associates that draft with the release tag before publishing it.
+
+After repairing the npm Trusted Publisher relationship, retry an existing tag
+without creating a new commit or version:
+
+```sh
+gh workflow run release.yml \
+  --repo morshoto/framekit \
+  --ref main \
+  -f release_tag=v0.1.3
+```
+
+The manual run verifies that the tag exists, checks out that exact tag, and
+skips `npm publish` if the matching version is already present. Registry errors
+other than a missing version fail closed.
 
 The npm Trusted Publisher relationship is configured in npm account settings;
 repository permissions alone cannot create or repair that relationship. The

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -57,8 +57,11 @@ gh workflow run release.yml \
 
 The manual run verifies that the tag exists and points to a commit reachable
 from `main`, checks out that exact tag, and skips `npm publish` if the matching
-version is already present. Registry errors other than a missing version fail
-closed.
+version is already present. After a publish, registry visibility is retried
+with bounded backoff. If a retry races with an earlier successful publish and
+npm reports that the version already exists, the workflow proceeds to that
+same verification path. Registry errors other than a missing version or an
+immutable-version conflict fail closed.
 
 The npm Trusted Publisher relationship is configured in npm account settings;
 repository permissions alone cannot create or repair that relationship. The

--- a/tests/integration/codex-plugin.test.ts
+++ b/tests/integration/codex-plugin.test.ts
@@ -130,7 +130,7 @@ test("tagpr releases publish the package consumed by the plugin", async () => {
   assert.match(workflow, /publish-npm:/);
   assert.match(
     workflow,
-    /publish-npm:[\s\S]*?actions\/checkout@(?:v7|[0-9a-f]{40}[ \t]+# v7)\s+with:\s+persist-credentials:\s+false/,
+    /publish-npm:[\s\S]*?actions\/checkout@(?:v7|[0-9a-f]{40}[ \t]+# v7)\s+with:\s+ref: \$\{\{ needs\.tagpr\.outputs\.release-tag \}\}\s+persist-credentials:\s+false/,
   );
   assert.match(workflow, /needs:\s+tagpr/);
   assert.match(workflow, /needs\.tagpr\.outputs\.release-tag != ''/);

--- a/tests/integration/release-workflow.test.ts
+++ b/tests/integration/release-workflow.test.ts
@@ -147,13 +147,44 @@ test("release retries do not republish an existing npm version", async () => {
 
   const statusStep = workflow.slice(workflow.lastIndexOf("- id: npm-status", statusCheck), publication);
   assert.match(statusStep, /id: npm-status/);
-  assert.match(statusStep, /npm view "\$\{package_name\}@\$\{expected_version\}" version/);
+  assert.match(statusStep, /npm view --prefer-online "\$\{package_name\}@\$\{expected_version\}" version/);
   assert.match(statusStep, /E404\|404 Not Found/);
   assert.match(statusStep, /published=true/);
   assert.match(statusStep, /published=false/);
 
   const publicationStep = workflow.slice(publication, verification);
   assert.match(publicationStep, /if: steps\.npm-status\.outputs\.published != 'true'/);
+});
+
+test("release verification retries transient npm registry visibility", async () => {
+  const workflow = await readFile(resolve(repository, ".github/workflows/release.yml"), "utf8");
+  const statusCheck = workflow.slice(
+    workflow.indexOf("name: Check npm publication status"),
+    workflow.indexOf("name: Publish npm package"),
+  );
+  const verification = workflow.slice(
+    workflow.indexOf("name: Verify npm publication"),
+    workflow.indexOf("name: Publish GitHub release"),
+  );
+
+  assert.match(statusCheck, /npm view --prefer-online "\$\{package_name\}@\$\{expected_version\}" version/);
+  assert.match(verification, /max_attempts=6/);
+  assert.match(verification, /for attempt in \$\(seq 1 "\$\{max_attempts\}"\)/);
+  assert.match(verification, /npm view --prefer-online "\$\{package_name\}@\$\{expected_version\}" version/);
+  assert.match(verification, /No match found for version/);
+  assert.match(verification, /sleep "\$\{delay\}"/);
+});
+
+test("release retries tolerate a duplicate npm publish after a visibility race", async () => {
+  const workflow = await readFile(resolve(repository, ".github/workflows/release.yml"), "utf8");
+  const publication = workflow.indexOf("name: Publish npm package");
+  const verification = workflow.indexOf("name: Verify npm publication");
+  const publicationStep = workflow.slice(publication, verification);
+
+  assert.match(publicationStep, /npm publish --access public/);
+  assert.match(publicationStep, /EPUBLISHCONFLICT|previously published versions/);
+  assert.match(publicationStep, /verification will confirm/i);
+  assert.match(publicationStep, /exit 0/);
 });
 
 test("release workflow validates the built MCP server version before publishing", async () => {

--- a/tests/integration/release-workflow.test.ts
+++ b/tests/integration/release-workflow.test.ts
@@ -79,7 +79,10 @@ test("release workflow validates the package before publishing", async () => {
   assert.notEqual(validation, -1);
   assert.ok(validation < publication, "release validation must run before npm publish");
   assert.match(workflow, /GITHUB_REPOSITORY: \$\{\{ github\.repository \}\}/);
-  assert.match(workflow, /release-tag: \$\{\{ steps\.existing-tag\.outputs\.tag \|\| steps\.run-tagpr\.outputs\.tag \}\}/);
+  assert.match(
+    workflow,
+    /release-tag: \$\{\{ steps\.requested-tag\.outputs\.tag \|\| steps\.existing-tag\.outputs\.tag \|\| steps\.run-tagpr\.outputs\.tag \}\}/,
+  );
   const tagDetection = workflow.slice(
     workflow.indexOf("name: Detect release tag on HEAD"),
     workflow.indexOf("name: Run tagpr"),
@@ -89,13 +92,61 @@ test("release workflow validates the package before publishing", async () => {
   assert.match(tagDetection, /\$\{#tags\[@\]\} > 1/);
   assert.match(tagDetection, /Multiple release tags point to HEAD/);
   assert.doesNotMatch(tagDetection, /head -n 1/);
-  assert.match(workflow, /if: steps\.existing-tag\.outputs\.tag == ''/);
+  assert.match(workflow, /if: steps\.requested-tag\.outputs\.tag == ''/);
   assert.match(
     workflow,
     /tagpr:[\s\S]*?actions\/checkout@(?:v7|[0-9a-f]{40}[ \t]+# v7)[\s\S]*?token: \$\{\{ secrets\.TAGPR_TOKEN \}\}[\s\S]*?persist-credentials: false/,
   );
   assert.match(workflow, /RELEASE_TAG: \$\{\{ needs\.tagpr\.outputs\.release-tag \}\}/);
   assert.match(workflow, /releases\/\$\{release_id\}/);
+});
+
+test("release workflow can retry an exact existing tag", async () => {
+  const workflow = await readFile(resolve(repository, ".github/workflows/release.yml"), "utf8");
+
+  assert.match(
+    workflow,
+    /workflow_dispatch:[\s\S]*?release_tag:[\s\S]*?required: true[\s\S]*?type: string/,
+  );
+
+  const requestedTag = workflow.slice(
+    workflow.indexOf("name: Resolve requested release tag"),
+    workflow.indexOf("name: Detect release tag on HEAD"),
+  );
+  assert.match(requestedTag, /REQUESTED_TAG: \$\{\{ inputs\.release_tag \}\}/);
+  assert.match(requestedTag, /refs\/tags\/\$\{REQUESTED_TAG\}\^\{commit\}/);
+  assert.match(requestedTag, /tag=\$\{REQUESTED_TAG\}/);
+  assert.match(
+    workflow,
+    /if: steps\.requested-tag\.outputs\.tag == '' && steps\.existing-tag\.outputs\.tag == ''/,
+  );
+
+  const publishJob = workflow.slice(workflow.indexOf("publish-npm:"));
+  assert.match(
+    publishJob,
+    /name: Check out repository[\s\S]*?ref: \$\{\{ needs\.tagpr\.outputs\.release-tag \}\}/,
+  );
+});
+
+test("release retries do not republish an existing npm version", async () => {
+  const workflow = await readFile(resolve(repository, ".github/workflows/release.yml"), "utf8");
+  const statusCheck = workflow.indexOf("name: Check npm publication status");
+  const publication = workflow.indexOf("name: Publish npm package");
+  const verification = workflow.indexOf("name: Verify npm publication");
+
+  assert.notEqual(statusCheck, -1);
+  assert.ok(statusCheck < publication, "npm status must be checked before publishing");
+  assert.ok(publication < verification, "npm publication must precede verification");
+
+  const statusStep = workflow.slice(workflow.lastIndexOf("- id: npm-status", statusCheck), publication);
+  assert.match(statusStep, /id: npm-status/);
+  assert.match(statusStep, /npm view "\$\{package_name\}@\$\{expected_version\}" version/);
+  assert.match(statusStep, /E404\|404 Not Found/);
+  assert.match(statusStep, /published=true/);
+  assert.match(statusStep, /published=false/);
+
+  const publicationStep = workflow.slice(publication, verification);
+  assert.match(publicationStep, /if: steps\.npm-status\.outputs\.published != 'true'/);
 });
 
 test("release documentation provides the exact npm trust command", async () => {

--- a/tests/integration/release-workflow.test.ts
+++ b/tests/integration/release-workflow.test.ts
@@ -113,8 +113,15 @@ test("release workflow can retry an exact existing tag", async () => {
     workflow.indexOf("name: Resolve requested release tag"),
     workflow.indexOf("name: Detect release tag on HEAD"),
   );
+  assert.match(workflow, /concurrency:\s+group: release\s+cancel-in-progress: false/);
+  assert.match(workflow, /fetch-depth: 0/);
   assert.match(requestedTag, /REQUESTED_TAG: \$\{\{ inputs\.release_tag \}\}/);
   assert.match(requestedTag, /refs\/tags\/\$\{REQUESTED_TAG\}\^\{commit\}/);
+  assert.match(
+    requestedTag,
+    /git merge-base --is-ancestor "refs\/tags\/\$\{REQUESTED_TAG\}\^\{commit\}" origin\/main/,
+  );
+  assert.match(requestedTag, /Requested release tag is not reachable from main/);
   assert.match(requestedTag, /tag=\$\{REQUESTED_TAG\}/);
   assert.match(
     workflow,


### PR DESCRIPTION
## Summary

- add a manual `workflow_dispatch` retry input for an exact existing release tag
- validate the requested tag and check out that tag for packaging
- avoid republishing an already published immutable npm version
- retry transient npm registry visibility with `--prefer-online` and bounded backoff
- treat an npm duplicate-version conflict as an earlier successful publish, then verify it
- keep unrelated npm errors fail closed and document the recovery path

This updates the existing tagged-release retry PR for release run
34546026612. That run successfully published `@morshoto/framekit@0.1.5`,
then immediately received an npm `E404` while the new version was still
propagating through the registry. A rerun then correctly failed because npm
does not permit republishing `0.1.5`.

## Validation

- focused release workflow tests: 11 passed
- `pnpm install --frozen-lockfile`: passed
- `pnpm run build`: passed
- `pnpm run test`: 544 passed
- `pnpm run check:boundaries`: passed
- native Xcode checks: not required; no native files changed

## Safety

- existing release tags are validated and must be reachable from `main`
- exact npm version checks run before and after publication
- only expected missing-version and immutable-version conflicts are recoverable
- no credentials, private media, generated artifacts, or MCP contract changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added safer release retries for existing tags, including validation that tags are based on the main branch.
  - Release packages are built and validated before publication.
  - Publication now verifies registry availability, retries temporary delays, and handles already-published versions safely.
  - Releases now validate the MCP server version before publishing.

- **Documentation**
  - Updated npm Trusted Publishing permissions and guidance for retrying releases and local validation.

- **Tests**
  - Expanded coverage for tag validation, serialized releases, package publication retries, and version checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->