### PR TITLE
fix: reject inverted analysis ranges

### DIFF
--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -34,6 +34,9 @@ const rationalTimeSchema = z.object({
 const rangeSchema = z.object({
   start: z.number().nonnegative(),
   end: z.number().positive(),
+}).refine((range) => range.end > range.start, {
+  message: "end must be greater than start",
+  path: ["end"],
 });
 const mediaIndexQuerySchema = z.object({
   query: z.string().optional(),

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -216,6 +216,10 @@ by media ID and source range. Each shot includes its exact source identity,
 usable range, confidence, matched properties, and rationale. The planner is
 read-only; it produces planning data and does not add clips to a timeline.
 
+Range-taking analysis and planning tools require `end` to be greater than
+`start`. An invalid range returns an MCP input-validation error before the tool
+handler or analyzer runs.
+
 ## Music mixing workflow
 
 `music.add` is the high-level guarded entry point for the issue-11 music

--- a/tests/integration/git-hooks.test.ts
+++ b/tests/integration/git-hooks.test.ts
@@ -75,7 +75,7 @@ test("pinned pnpm self-management is already recorded in the lockfile", async ()
   assert.ok(version);
   const lockfile = await readFile(join(repository, "pnpm-lock.yaml"), "utf8");
   assert.match(lockfile, new RegExp(`packageManagerDependencies:\\s*\\n\\s+(?:['"]@pnpm/exe['"]|pnpm):\\s*\\n\\s+specifier:\\s*${version.replaceAll(".", "\\.")}`));
-  assert.match(lockfile, new RegExp(`@pnpm/exe@${version.replaceAll(".", "\\.")}`));
+  assert.match(lockfile, new RegExp(`(?:@pnpm/exe|pnpm)@${version.replaceAll(".", "\\.")}`));
 });
 
 test("pre-commit hook forces headless fixture validation", async () => {

--- a/tests/integration/git-hooks.test.ts
+++ b/tests/integration/git-hooks.test.ts
@@ -74,7 +74,7 @@ test("pinned pnpm self-management is already recorded in the lockfile", async ()
   const version = manifest.packageManager?.replace(/^pnpm@/, "");
   assert.ok(version);
   const lockfile = await readFile(join(repository, "pnpm-lock.yaml"), "utf8");
-  assert.match(lockfile, new RegExp(`['"]@pnpm/exe['"][\\s\\S]*?specifier: ${version.replaceAll(".", "\\.")}`));
+  assert.match(lockfile, new RegExp(`packageManagerDependencies:\\s*\\n\\s+(?:['"]@pnpm/exe['"]|pnpm):\\s*\\n\\s+specifier:\\s*${version.replaceAll(".", "\\.")}`));
   assert.match(lockfile, new RegExp(`@pnpm/exe@${version.replaceAll(".", "\\.")}`));
 });
 

--- a/tests/integration/range-validation.test.ts
+++ b/tests/integration/range-validation.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import {
+  AgentVideoRuntime,
+  type VisualAnalyzer,
+} from "@framekit/runtime";
+import {
+  FixtureVisualAnalyzer,
+  InMemoryEditorAdapter,
+} from "@framekit/testkit";
+import { createMcpServer } from "../../apps/mcp-server/src/server.js";
+
+function textFrom(result: unknown): string {
+  const content = (result as { content?: unknown }).content;
+  assert.ok(Array.isArray(content));
+  const text = (content[0] as { text?: unknown } | undefined)?.text;
+  assert.equal(typeof text, "string");
+  return text as string;
+}
+
+function createRangeRuntime(counters: { projectReads: number; visualCalls: number }): AgentVideoRuntime {
+  const adapter = new InMemoryEditorAdapter({
+    projectId: "range-validation-project",
+    projectName: "Range Validation",
+    timelineId: "range-validation-timeline",
+    timelineName: "Main Edit",
+    clips: [],
+    media: [{
+      mediaId: "media-1",
+      source: "interview.mov",
+      visual: {
+        scenes: [{ id: "scene-1", start: 0, end: 10, label: "interview" }],
+        subjects: [],
+        keyframes: [],
+      },
+    }],
+  });
+  const readProject = adapter.readProject.bind(adapter);
+  adapter.readProject = async () => {
+    counters.projectReads += 1;
+    return readProject();
+  };
+  const fixtureAnalyzer = new FixtureVisualAnalyzer();
+  const visualAnalyzer: VisualAnalyzer = {
+    descriptor: fixtureAnalyzer.descriptor,
+    analyze: async (input, range) => {
+      counters.visualCalls += 1;
+      return fixtureAnalyzer.analyze(input, range);
+    },
+  };
+  return new AgentVideoRuntime(adapter, { visualAnalyzer });
+}
+
+async function connectRangeServer(counters: { projectReads: number; visualCalls: number }) {
+  const server = createMcpServer(createRangeRuntime(counters));
+  const client = new Client({ name: "range-validation-test", version: "0.1.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  return { client, server };
+}
+
+test("analysis and planning tools reject non-increasing ranges before execution", async () => {
+  const counters = { projectReads: 0, visualCalls: 0 };
+  const { client, server } = await connectRangeServer(counters);
+  const invalidRanges = [
+    { start: 5, end: 1 },
+    { start: 1, end: 1 },
+  ];
+
+  try {
+    for (const range of invalidRanges) {
+      for (const request of [
+        { name: "media.index", arguments: { range } },
+        { name: "rough-cut.plan", arguments: { range } },
+        { name: "visual.analyze", arguments: { mediaId: "media-1", range } },
+      ]) {
+        const result = await client.callTool(request);
+        assert.equal(result.isError, true, request.name);
+        assert.match(textFrom(result), /end must be greater than start/);
+      }
+    }
+    assert.equal(counters.projectReads, 0);
+    assert.equal(counters.visualCalls, 0);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
+
+test("analysis and planning tools accept strictly increasing ranges", async () => {
+  const counters = { projectReads: 0, visualCalls: 0 };
+  const { client, server } = await connectRangeServer(counters);
+
+  try {
+    const range = { start: 1, end: 5 };
+    const index = await client.callTool({ name: "media.index", arguments: { range } });
+    assert.equal(index.isError, undefined);
+    const plan = await client.callTool({ name: "rough-cut.plan", arguments: { range } });
+    assert.equal(plan.isError, undefined);
+    const visual = await client.callTool({
+      name: "visual.analyze",
+      arguments: { mediaId: "media-1", range },
+    });
+    assert.equal(visual.isError, undefined);
+    assert.equal(counters.projectReads, 3);
+    assert.equal(counters.visualCalls, 1);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});


### PR DESCRIPTION
<!-- Request PR review -->
- [x] Request PR review
- [ ] If you are unable to review, please set it as a draft.
- [x] Github issue: Closes: #135

## Summary

Reject inverted and zero-length ranges at the shared MCP schema boundary.
`media.index`, `rough-cut.plan`, and `visual.analyze` now return an input
validation error before project reads or analyzer execution. Strictly increasing
ranges remain supported.

## Validation

```bash
pnpm install --frozen-lockfile
pnpm run build
pnpm run test
pnpm run check:boundaries
```

All gates passed locally; the full suite reports 480 passing tests. Native
Xcode checks were skipped because no native files changed.

## TDD evidence

- Red: `6adb0ca` adds the failing MCP regression tests.
- Green: `e87d673` enforces `end > start` in the shared schema.
- Documentation: `537a431` records the public range-validation contract.
- CI portability: `07649e3` and `b2698f8` stabilize the pnpm lockfile assertion across runners.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Public MCP behavior is documented in `docs/mcp/tools.md`.
- [x] Existing adapters and test fixtures remain compatible.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [x] Documentation reflects the changed MCP validation behavior.
