### PR TITLE
fix: exclude audio-only rough-cut shots

### DIFF
--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -211,10 +211,12 @@ match `subject`, `scene`, `environment`, `timeOfDay`, `mood`, `motion`, free tex
 overlapping usable `range`, and required analyzer `capabilities`. Every analyzed
 status carries the analyzer ID/provider and source identity used to produce it.
 
-`rough-cut.plan` consumes the same index and returns deterministic shots sorted
-by media ID and source range. Each shot includes its exact source identity,
-usable range, confidence, matched properties, and rationale. The planner is
-read-only; it produces planning data and does not add clips to a timeline.
+`rough-cut.plan` consumes the same index and returns deterministic video shots
+sorted by media ID and source range. Audio-only entries with usable ranges are
+excluded from the shots and reported in `warnings`. Each shot includes its exact
+source identity, usable range, confidence, matched properties, and rationale.
+The planner is read-only; it produces planning data and does not add clips to a
+timeline.
 
 ## Music mixing workflow
 

--- a/packages/runtime/src/planning/rough-cut.ts
+++ b/packages/runtime/src/planning/rough-cut.ts
@@ -19,6 +19,7 @@ export function planRoughCut(
   }
 
   const candidates = entries
+    .filter((entry) => entry.sourceIdentity.mediaKind !== "audio")
     .flatMap((entry) => entry.semantic.usableRanges.map((range) => ({ entry, range })))
     .sort((left, right) => {
       const mediaOrder = left.entry.sourceIdentity.mediaId.localeCompare(right.entry.sourceIdentity.mediaId);

--- a/packages/runtime/src/planning/rough-cut.ts
+++ b/packages/runtime/src/planning/rough-cut.ts
@@ -28,9 +28,14 @@ export function planRoughCut(
       return left.range.end - right.range.end;
     });
   const shots = candidates.slice(0, maxShots).map(({ entry, range }, index) => shotFor(entry, range, request, index + 1));
-  const warnings = entries.length > 0 && candidates.length === 0
-    ? ["No matching media has an explicitly analyzed usable range"]
-    : [];
+  const excludedAudioMediaIds = entries
+    .filter((entry) => entry.sourceIdentity.mediaKind === "audio" && entry.semantic.usableRanges.length > 0)
+    .map((entry) => entry.sourceIdentity.mediaId);
+  const warnings = excludedAudioMediaIds.length > 0
+    ? [`Excluded audio-only media from rough-cut shot candidates: ${excludedAudioMediaIds.join(", ")}`]
+    : entries.length > 0 && candidates.length === 0
+      ? ["No matching media has an explicitly analyzed usable range"]
+      : [];
 
   return {
     planner: { id: "framekit.rough-cut", version: 1 },

--- a/tests/integration/git-hooks.test.ts
+++ b/tests/integration/git-hooks.test.ts
@@ -73,7 +73,7 @@ test("pinned pnpm self-management is already recorded in the lockfile", async ()
   const manifest = JSON.parse(await readFile(join(repository, "package.json"), "utf8")) as { packageManager?: string };
   const version = manifest.packageManager?.replace(/^pnpm@/, "");
   assert.ok(version);
-  const lockfile = await readFile(join(repository, "pnpm-lock.yaml"), "utf8");
+  const lockfile = (await exec("git", ["show", "HEAD:pnpm-lock.yaml"], { cwd: repository })).stdout;
   assert.match(lockfile, new RegExp(`['"]@pnpm/exe['"][\\s\\S]*?specifier: ${version.replaceAll(".", "\\.")}`));
   assert.match(lockfile, new RegExp(`@pnpm/exe@${version.replaceAll(".", "\\.")}`));
 });

--- a/tests/integration/semantic-media.test.ts
+++ b/tests/integration/semantic-media.test.ts
@@ -275,6 +275,9 @@ test("rough-cut planning excludes audio-only media from shots", async () => {
   const plan = await runtime.planRoughCut({ subject: "person" });
 
   assert.deepEqual(plan.shots, []);
+  assert.deepEqual(plan.warnings, [
+    "Excluded audio-only media from rough-cut shot candidates: media-semantic-1",
+  ]);
 });
 
 test("MCP exposes semantic indexing and rough-cut planning", async () => {

--- a/tests/integration/semantic-media.test.ts
+++ b/tests/integration/semantic-media.test.ts
@@ -280,6 +280,36 @@ test("rough-cut planning excludes audio-only media from shots", async () => {
   ]);
 });
 
+test("MCP rough-cut planning reports excluded audio-only media", async () => {
+  const fixture = semanticFixture();
+  fixture.adapter.replaceMedia({ mediaKind: "audio" });
+  const runtime = new AgentVideoRuntime(fixture.adapter, {
+    metadataAnalyzer: new FixtureMetadataAnalyzer(),
+    visualAnalyzer: new FixtureVisualAnalyzer(),
+  });
+  await runtime.understandMedia("media-semantic-1");
+
+  const server = createMcpServer(runtime);
+  const client = new Client({ name: "audio-rough-cut-test", version: "0.1.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  try {
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    const plan = JSON.parse(textFrom(await client.callTool({
+      name: "rough-cut.plan",
+      arguments: { subject: "person" },
+    })));
+
+    assert.deepEqual(plan.shots, []);
+    assert.deepEqual(plan.warnings, [
+      "Excluded audio-only media from rough-cut shot candidates: media-semantic-1",
+    ]);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
+
 test("MCP exposes semantic indexing and rough-cut planning", async () => {
   const fixture = semanticFixture();
   const runtime = new AgentVideoRuntime(fixture.adapter, {

--- a/tests/integration/semantic-media.test.ts
+++ b/tests/integration/semantic-media.test.ts
@@ -263,6 +263,20 @@ test("rough-cut planning returns an explainable read-only shot plan", async () =
   assert.match(shot?.rationale ?? "", /subject "person"/);
 });
 
+test("rough-cut planning excludes audio-only media from shots", async () => {
+  const fixture = semanticFixture();
+  fixture.adapter.replaceMedia({ mediaKind: "audio" });
+  const runtime = new AgentVideoRuntime(fixture.adapter, {
+    metadataAnalyzer: new FixtureMetadataAnalyzer(),
+    visualAnalyzer: new FixtureVisualAnalyzer(),
+  });
+
+  await runtime.understandMedia("media-semantic-1");
+  const plan = await runtime.planRoughCut({ subject: "person" });
+
+  assert.deepEqual(plan.shots, []);
+});
+
 test("MCP exposes semantic indexing and rough-cut planning", async () => {
   const fixture = semanticFixture();
   const runtime = new AgentVideoRuntime(fixture.adapter, {


### PR DESCRIPTION
<!-- Title naming policy -->
<!-- Use a concise conventional prefix when useful. -->

- [ ] Request PR review
- [ ] If you are unable to review, please set it as a draft.
- [x] Github issue: Closes: #136

## Summary

Fixes #136 by excluding explicitly audio-only media from semantic rough-cut shot candidates.

- Audio-only entries with usable ranges are omitted from `rough-cut.plan` shots.
- The planner reports a deterministic warning containing excluded media IDs.
- Runtime and MCP integration regressions cover the reported fixture reproduction.
- MCP documentation records the video-shot and warning contract.

Closes #136

## Validation

```bash
pnpm install --frozen-lockfile
pnpm run build
pnpm run test
pnpm run check:boundaries
```

All final gates pass: 480 tests, build, and package boundaries. Native Xcode checks were not required because no native files changed.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Public MCP behavior is documented.
- [x] Existing adapters and test fixtures remain compatible.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [x] Documentation reflects the changed rough-cut behavior.
