### PR TITLE
fix: reject non-positive rational trim durations

### DIFF
--- a/packages/runtime/src/editing/edit-service.ts
+++ b/packages/runtime/src/editing/edit-service.ts
@@ -23,6 +23,7 @@ import { MediaAnalysisService } from "../application/media-analysis-service.js";
 import { ProjectService } from "../application/project-service.js";
 import type { RuntimeOptions } from "../application/runtime-options.js";
 import { TransactionStore } from "../application/transaction-store.js";
+import { parseRational } from "../timeline/rational-time.js";
 import { assertValidVerificationPolicy } from "../verification/verification.js";
 
 export class EditService {
@@ -80,6 +81,7 @@ export class EditService {
     if (operation.baseRevision && !sameRevision(operation.baseRevision, before.revision)) {
       throw new Error("STALE_CONTEXT: operation base revision does not match current editor state");
     }
+    assertValidWorkflowOperation(operation);
 
     this.assertSurfaceCapability(target, capabilities.editor);
     if (!capabilities.editor.timelineSnapshotRead || !capabilities.editor.readAfterWrite || !capabilities.editor.rollback) {
@@ -189,6 +191,7 @@ export class EditService {
       throw new Error("STALE_CONTEXT: preview base revision does not match current editor state");
     }
     if (request.operations.length === 0) throw new Error("INVALID_OPERATION: composite edit requires operations");
+    request.operations.forEach(assertValidWorkflowOperation);
     await this.assertCompositeCapabilities(request.operations, target.kind, capabilities.editor);
     if (!this.adapter.previewTransaction) {
       throw new Error("CAPABILITY_UNAVAILABLE: editor composite transaction preview");
@@ -232,6 +235,7 @@ export class EditService {
       throw new Error("STALE_CONTEXT: preview base revision does not match current editor state");
     }
     this.assertTarget(preview.target, before);
+    preview.operations.forEach(assertValidWorkflowOperation);
     await this.assertCompositeCapabilities(preview.operations, preview.target.kind);
     if (!this.adapter.applyTransaction) {
       throw new Error("CAPABILITY_UNAVAILABLE: editor composite transaction execution");
@@ -470,5 +474,17 @@ export class EditService {
     for (const [previewToken, preview] of this.editPreviews) {
       if (now > Date.parse(preview.expiresAt)) this.editPreviews.delete(previewToken);
     }
+  }
+}
+
+function assertValidWorkflowOperation(operation: WorkflowOperation): void {
+  if (operation.type !== "trim-clip") return;
+  if (!Number.isFinite(operation.duration) || operation.duration <= 0) {
+    throw new Error("INVALID_OPERATION: clip duration must be positive");
+  }
+  if (!operation.durationTime) return;
+  const duration = parseRational(operation.durationTime, "INVALID_OPERATION");
+  if (duration.value <= 0n) {
+    throw new Error("INVALID_OPERATION: clip duration must be positive");
   }
 }

--- a/tests/integration/composite-transactions.test.ts
+++ b/tests/integration/composite-transactions.test.ts
@@ -26,6 +26,31 @@ function createCompositeRuntime(options: ConstructorParameters<typeof AgentVideo
   return { adapter, runtime: new AgentVideoRuntime(adapter, options) };
 }
 
+function createTrimRuntime() {
+  const adapter = new InMemoryEditorAdapter({
+    projectId: "project-trim",
+    projectName: "Trim Fixture",
+    timelineId: "timeline-trim",
+    timelineName: "Main Edit",
+    clips: [{
+      id: "clip-video",
+      mediaId: "media-video",
+      name: "Video",
+      start: 0,
+      duration: 10,
+      track: 0,
+    }],
+    media: [{
+      mediaId: "media-video",
+      source: "/fixtures/video.mov",
+      mediaKind: "video",
+      duration: 10,
+      sourceDigest: "sha256:video",
+    }],
+  });
+  return { adapter, runtime: new AgentVideoRuntime(adapter) };
+}
+
 function workflowOperations(): WorkflowOperation[] {
   return [
     {
@@ -201,6 +226,60 @@ test("composite operations reject non-finite imported and placement timing", asy
     const operations = workflowOperations();
     mutate(operations);
     await assert.rejects(runtime.previewEdit({ baseRevision: before.revision, operations }), /INVALID_OPERATION/);
+    assert.deepEqual(await runtime.inspectProject(), before);
+  }
+});
+
+test("single trim rejects non-positive rational durations before adapter mutation", async () => {
+  for (const value of ["0", "-1"]) {
+    const { adapter, runtime } = createTrimRuntime();
+    const before = await runtime.inspectProject();
+    let applyCalls = 0;
+    const apply = adapter.apply.bind(adapter);
+    adapter.apply = async (...args) => {
+      applyCalls += 1;
+      return apply(...args);
+    };
+
+    await assert.rejects(
+      runtime.edit({
+        type: "trim-clip",
+        clipId: "clip-video",
+        duration: 10,
+        durationTime: { value, timescale: "1" },
+        baseRevision: before.revision,
+      }),
+      /INVALID_OPERATION: clip duration must be positive/,
+    );
+    assert.equal(applyCalls, 0);
+    assert.deepEqual(await runtime.inspectProject(), before);
+  }
+});
+
+test("composite trim preview rejects non-positive rational durations before adapter preview", async () => {
+  for (const value of ["0", "-1"]) {
+    const { adapter, runtime } = createTrimRuntime();
+    const before = await runtime.inspectProject();
+    let previewCalls = 0;
+    const previewTransaction = adapter.previewTransaction.bind(adapter);
+    adapter.previewTransaction = async (...args) => {
+      previewCalls += 1;
+      return previewTransaction(...args);
+    };
+
+    await assert.rejects(
+      runtime.previewEdit({
+        baseRevision: before.revision,
+        operations: [{
+          type: "trim-clip",
+          clipId: "clip-video",
+          duration: 10,
+          durationTime: { value, timescale: "1" },
+        }],
+      }),
+      /INVALID_OPERATION: clip duration must be positive/,
+    );
+    assert.equal(previewCalls, 0);
     assert.deepEqual(await runtime.inspectProject(), before);
   }
 });

--- a/tests/integration/composite-transactions.test.ts
+++ b/tests/integration/composite-transactions.test.ts
@@ -284,6 +284,47 @@ test("composite trim preview rejects non-positive rational durations before adap
   }
 });
 
+test("MCP rejects non-positive rational trim durations before adapter mutation", async () => {
+  const { adapter, runtime } = createTrimRuntime();
+  const server = createMcpServer(runtime);
+  const client = new Client({ name: "trim-duration-test", version: "0.1.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  try {
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+    const before = await runtime.inspectProject();
+    let applyCalls = 0;
+    const apply = adapter.apply.bind(adapter);
+    adapter.apply = async (...args) => {
+      applyCalls += 1;
+      return apply(...args);
+    };
+
+    for (const value of ["0", "-1"]) {
+      const result = await client.callTool({
+        name: "editor.timeline.edit",
+        arguments: {
+          projectId: before.projectId,
+          sequenceId: before.timeline.id,
+          type: "trim-clip",
+          clipId: "clip-video",
+          duration: 10,
+          durationTime: { value, timescale: "1" },
+          baseRevision: before.revision,
+        },
+      });
+      assert.equal(result.isError, true);
+      assert.match(textFrom(result), /INVALID_OPERATION: clip duration must be positive/);
+    }
+
+    assert.equal(applyCalls, 0);
+    assert.deepEqual(await runtime.inspectProject(), before);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
+
 test("composite execute consumes tokens and rejects stale, expired, and unavailable workflows before mutation", async () => {
   let now = 1_000;
   const { adapter, runtime } = createCompositeRuntime({ now: () => now, previewTtlMs: 10 });


### PR DESCRIPTION
- [x] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [x] Github issue: Closes: #134

## Summary

Reject zero and negative rational `durationTime` values for `trim-clip` as
`INVALID_OPERATION` before any adapter write or preview. The guard lives in the
runtime edit service, so direct runtime, composite, and MCP entry points share
the same safety contract.

Closes #134

## Validation

```bash
pnpm exec tsx --test tests/integration/composite-transactions.test.ts
.agents/skills/validate-framekit/scripts/validate.sh
```

Both passed. The full validation run passed build, all 481 deterministic tests,
and package boundary checks. Native Xcode gates were skipped because no native
files changed.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Public MCP behavior or package interfaces are documented if changed.
- [x] Existing adapters and test fixtures remain compatible, or the migration is explained above.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [x] Documentation reflects any changed commands, paths, or environment variables.
