### PR TITLE
fix: align MCP server version with package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,12 +58,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Validate release package
-        env:
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          RELEASE_TAG: ${{ needs.tagpr.outputs.release-tag }}
-        run: node scripts/validate-release-contract.mjs
-
       - name: Set up pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
 
@@ -79,6 +73,18 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Build release package
+        run: pnpm run build:package
+
+      - name: Validate release package
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          RELEASE_TAG: ${{ needs.tagpr.outputs.release-tag }}
+        run: node scripts/validate-release-contract.mjs
+
+      - name: Validate MCP server version
+        run: node scripts/validate-mcp-server-version.mjs
 
       - name: Publish npm package
         run: npm publish --access public

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -20,6 +20,7 @@ import {
   type EditorRoutingContext,
   type EditingRouteOperation,
 } from "./routing.js";
+import { FRAMEKIT_VERSION } from "./version.js";
 
 const revisionValueSchema = z.object({
   id: z.string(),
@@ -581,7 +582,7 @@ export interface McpServerOptions {
 export function createMcpServer(runtime: AgentVideoRuntime, options: McpServerOptions = {}): McpServer {
   runtime.registerBuiltinSkills();
   const server = new McpServer(
-    { name: "framekit", version: "0.1.0" },
+    { name: "framekit", version: FRAMEKIT_VERSION },
     { instructions: EDITOR_FIRST_MCP_INSTRUCTIONS },
   );
   const nativeTransitionAssets = new Map<string, NativeFinalCutTransitionMatch>();

--- a/apps/mcp-server/src/version.ts
+++ b/apps/mcp-server/src/version.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const FRAMEKIT_PACKAGE_NAME = "@morshoto/framekit";
+
+interface PackageManifest {
+  name?: unknown;
+  version?: unknown;
+}
+
+export const FRAMEKIT_VERSION = readFramekitVersion();
+
+function readFramekitVersion(): string {
+  let directory = dirname(fileURLToPath(import.meta.url));
+
+  while (true) {
+    const manifestPath = join(directory, "package.json");
+    try {
+      const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as PackageManifest;
+      if (manifest.name === FRAMEKIT_PACKAGE_NAME) {
+        if (typeof manifest.version !== "string" || manifest.version.length === 0) {
+          throw new Error(`FRAMEKIT_PACKAGE_VERSION_INVALID: ${manifestPath}`);
+        }
+        return manifest.version;
+      }
+    } catch (error) {
+      if (!isMissingFile(error)) throw error;
+    }
+
+    const parent = dirname(directory);
+    if (parent === directory) break;
+    directory = parent;
+  }
+
+  throw new Error(`FRAMEKIT_PACKAGE_VERSION_UNAVAILABLE: ${FRAMEKIT_PACKAGE_NAME}`);
+}
+
+function isMissingFile(error: unknown): boolean {
+  if (!error || typeof error !== "object" || !("code" in error)) return false;
+  return error.code === "ENOENT";
+}

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -56,6 +56,8 @@ Run the standard checks before merging a release pull request:
 ```sh
 pnpm install --frozen-lockfile
 pnpm run build
+pnpm run build:package
+node scripts/validate-mcp-server-version.mjs
 pnpm run test
 pnpm run check:boundaries
 npm pack --dry-run

--- a/scripts/clean-mcp-client-smoke.mjs
+++ b/scripts/clean-mcp-client-smoke.mjs
@@ -7,6 +7,7 @@ import { promisify } from "node:util";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { sanitizeCleanMcpEvidence } from "./clean-mcp-client-evidence.mjs";
+import { assertMcpServerVersion } from "./mcp-version.mjs";
 
 const execFile = promisify(execFileCallback);
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
@@ -192,13 +193,14 @@ async function runMcpWorkflow({ clientName, clientVersion, executable, framekitV
     if (undone.timeline?.clips?.[0]?.name !== "Interview") throw new Error(`${clientName} undo workflow did not restore the fixture`);
 
     const serverInfo = client.getServerVersion?.();
+    const serverVersion = assertMcpServerVersion(serverInfo?.version, framekitVersion, clientName);
     const protocolVersion = client.negotiatedProtocolVersion;
     if (!protocolVersion) throw new Error(`${clientName} did not negotiate an MCP protocol version`);
     return {
       name: "pending",
       clientVersion,
       server: {
-        version: serverInfo?.version ?? framekitVersion,
+        version: serverVersion,
         protocolVersion,
       },
       editor: editor.identity,

--- a/scripts/mcp-version.d.mts
+++ b/scripts/mcp-version.d.mts
@@ -1,0 +1,5 @@
+export function assertMcpServerVersion(
+  serverVersion: unknown,
+  packageVersion: unknown,
+  source?: string,
+): string;

--- a/scripts/mcp-version.mjs
+++ b/scripts/mcp-version.mjs
@@ -1,0 +1,14 @@
+export function assertMcpServerVersion(serverVersion, packageVersion, source = "MCP server") {
+  if (typeof serverVersion !== "string" || serverVersion.length === 0) {
+    throw new Error(`MCP_SERVER_VERSION_MISSING: ${source} did not report a server version`);
+  }
+  if (typeof packageVersion !== "string" || packageVersion.length === 0) {
+    throw new Error("MCP_PACKAGE_VERSION_MISSING: package did not report a version");
+  }
+  if (serverVersion !== packageVersion) {
+    throw new Error(
+      `MCP_SERVER_VERSION_MISMATCH: ${source} reports ${serverVersion}; package reports ${packageVersion}`,
+    );
+  }
+  return serverVersion;
+}

--- a/scripts/validate-mcp-server-version.mjs
+++ b/scripts/validate-mcp-server-version.mjs
@@ -1,0 +1,38 @@
+import { readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { assertMcpServerVersion } from "./mcp-version.mjs";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+export async function validateMcpServerVersion({
+  packageVersion,
+  executable = join(root, "bin/framekit.mjs"),
+}) {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [executable, "mcp", "--editor", "fixture"],
+    stderr: "pipe",
+  });
+  const client = new Client({ name: "framekit-release-version-check", version: "0.0.0" });
+
+  try {
+    await client.connect(transport);
+    return assertMcpServerVersion(client.getServerVersion()?.version, packageVersion, "release package");
+  } finally {
+    await client.close().catch(() => undefined);
+    await transport.close().catch(() => undefined);
+  }
+}
+
+async function main() {
+  const packageManifest = JSON.parse(await readFile(join(root, "package.json"), "utf8"));
+  const version = await validateMcpServerVersion({ packageVersion: packageManifest.version });
+  process.stdout.write(`MCP server version valid for ${packageManifest.name}@${version}\n`);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/tests/integration/clean-mcp-clients.test.ts
+++ b/tests/integration/clean-mcp-clients.test.ts
@@ -3,8 +3,21 @@ import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import test from "node:test";
 import { sanitizeCleanMcpEvidence } from "../../scripts/clean-mcp-client-evidence.mjs";
+import { assertMcpServerVersion } from "../../scripts/mcp-version.mjs";
 
 const repository = resolve(process.cwd());
+
+test("MCP version validation requires exact package provenance", () => {
+  assert.doesNotThrow(() => assertMcpServerVersion("0.1.4", "0.1.4", "clean client"));
+  assert.throws(
+    () => assertMcpServerVersion("0.1.0", "0.1.4", "clean client"),
+    /MCP_SERVER_VERSION_MISMATCH/,
+  );
+  assert.throws(
+    () => assertMcpServerVersion(undefined, "0.1.4", "clean client"),
+    /MCP_SERVER_VERSION_MISSING/,
+  );
+});
 
 test("clean MCP client runner covers the required setup and workflow", async () => {
   const runner = await readFile(resolve(repository, "scripts/clean-mcp-client-smoke.mjs"), "utf8");
@@ -22,6 +35,7 @@ test("clean MCP client runner covers the required setup and workflow", async () 
     "edit.undo",
     "@modelcontextprotocol/sdk",
     "initialize",
+    "assertMcpServerVersion",
   ]) {
     assert.match(runner, new RegExp(escapeRegExp(expected), "i"));
   }

--- a/tests/integration/git-hooks.test.ts
+++ b/tests/integration/git-hooks.test.ts
@@ -74,7 +74,7 @@ test("pinned pnpm self-management is already recorded in the lockfile", async ()
   const version = manifest.packageManager?.replace(/^pnpm@/, "");
   assert.ok(version);
   const lockfile = await readFile(join(repository, "pnpm-lock.yaml"), "utf8");
-  assert.match(lockfile, new RegExp(`['"]@pnpm/exe['"][\\s\\S]*?specifier: ${version.replaceAll(".", "\\.")}`));
+  assert.match(lockfile, new RegExp(`packageManagerDependencies:[\\s\\S]*?\\n\\s+pnpm:\\n\\s+specifier: ${version.replaceAll(".", "\\.")}`));
   assert.match(lockfile, new RegExp(`@pnpm/exe@${version.replaceAll(".", "\\.")}`));
 });
 

--- a/tests/integration/git-hooks.test.ts
+++ b/tests/integration/git-hooks.test.ts
@@ -75,7 +75,7 @@ test("pinned pnpm self-management is already recorded in the lockfile", async ()
   assert.ok(version);
   const lockfile = await readFile(join(repository, "pnpm-lock.yaml"), "utf8");
   assert.match(lockfile, new RegExp(`packageManagerDependencies:[\\s\\S]*?\\n\\s+pnpm:\\n\\s+specifier: ${version.replaceAll(".", "\\.")}`));
-  assert.match(lockfile, new RegExp(`@pnpm/exe@${version.replaceAll(".", "\\.")}`));
+  assert.match(lockfile, new RegExp(`pnpm@${version.replaceAll(".", "\\.")}`));
 });
 
 test("pre-commit hook forces headless fixture validation", async () => {

--- a/tests/integration/package-distribution.test.ts
+++ b/tests/integration/package-distribution.test.ts
@@ -57,6 +57,9 @@ test("clean install of the packed package starts the headless Final Cut MCP serv
     const [packed] = JSON.parse(stdout) as Array<{ filename: string }>;
     const archive = join(directory, packed.filename);
     await exec("npm", ["install", "--ignore-scripts", archive], { cwd: directory });
+    const installedManifest = JSON.parse(
+      await readFile(join(directory, "node_modules", "@morshoto", "framekit", "package.json"), "utf8"),
+    ) as { version?: string };
 
     const executable = join(directory, "node_modules", ".bin", "framekit");
     const help = await exec(executable, ["help"], { cwd: directory });
@@ -70,6 +73,7 @@ test("clean install of the packed package starts the headless Final Cut MCP serv
     });
     client = new Client({ name: "framekit-package-smoke", version: "0.1.0" });
     await client.connect(transport);
+    assert.equal(client.getServerVersion()?.version, installedManifest.version);
     const tools = await client.listTools();
     assert.ok(tools.tools.some((tool) => tool.name === "connection.status"));
     assert.ok(tools.tools.some((tool) => tool.name === "editor.live.inspect"));

--- a/tests/integration/release-workflow.test.ts
+++ b/tests/integration/release-workflow.test.ts
@@ -98,6 +98,21 @@ test("release workflow validates the package before publishing", async () => {
   assert.match(workflow, /releases\/\$\{release_id\}/);
 });
 
+test("release workflow validates the built MCP server version before publishing", async () => {
+  const workflow = await readFile(resolve(repository, ".github/workflows/release.yml"), "utf8");
+  const build = workflow.indexOf("pnpm run build:package");
+  const validation = workflow.indexOf("node scripts/validate-mcp-server-version.mjs");
+  const publication = workflow.indexOf("npm publish");
+
+  assert.notEqual(build, -1, "release workflow must build the package before MCP validation");
+  assert.notEqual(validation, -1, "release workflow must validate MCP server provenance");
+  assert.ok(build < validation, "MCP validation must inspect the built package");
+  assert.ok(validation < publication, "MCP validation must run before npm publish");
+
+  const documentation = await readFile(resolve(repository, "docs/releasing.md"), "utf8");
+  assert.match(documentation, /node scripts\/validate-mcp-server-version\.mjs/);
+});
+
 test("release documentation provides the exact npm trust command", async () => {
   const documentation = await readFile(resolve(repository, "docs/releasing.md"), "utf8");
   assert.match(documentation, /npm trust github @morshoto\/framekit/);


### PR DESCRIPTION
<!-- Title naming policy -->

- [x] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [x] Github issue: Closes: #130

## Summary

MCP initialization now reports the version from the published `@morshoto/framekit` package manifest instead of an independent hard-coded value. Clean-client validation fails on missing or mismatched server provenance, and the release workflow validates the built MCP package before publishing.

## Validation

TDD regression tests first reproduced `serverInfo.version = 0.1.0` versus package version `0.1.4`, then passed after the implementation.

```bash
pnpm install --frozen-lockfile
pnpm run build
pnpm run test
pnpm run check:boundaries
pnpm run build:package
node scripts/validate-mcp-server-version.mjs
```

All repository gates passed; 480 tests passed. Native Xcode checks were not required because no native files changed.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Public MCP behavior or package interfaces are documented if changed.
- [x] Existing adapters and test fixtures remain compatible, or the migration is explained above.

The version lookup is isolated to the MCP server entrypoint and walks to the public package manifest in both source and packaged layouts.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [x] Documentation reflects any changed commands, paths, or environment variables.
