### PR TITLE
fix: Expose operation-specific requirements in single-edit MCP schemas

### DIFF
--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import {
   AgentVideoRuntime,
@@ -212,31 +213,78 @@ const verificationPolicySchema = z.object({
   loudnessToleranceDb: z.number().finite().nonnegative().optional(),
   assertions: z.array(verificationAssertionSchema).optional(),
 }).strict();
-const editToolInputSchema = z.object({
-  type: z.enum(["rename-clip", "trim-clip", "set-gain", "reduce-noise", "set-color-correction", "ripple-delete", "add-marker"]),
-  clipId: z.string().min(1).optional(),
-  name: z.string().min(1).optional(),
-  duration: z.number().positive().optional(),
-  durationTime: rationalTimeSchema.optional(),
-  gainDb: z.number().finite().optional(),
-  reductionDb: z.number().finite().positive().optional(),
-  correction: colorCorrectionSchema.shape.correction.optional(),
-  timelineId: z.string().min(1).optional(),
-  range: rangeSchema.optional(),
-  reason: z.string().optional(),
-  marker: markerSchema.optional(),
-  baseRevision: revisionSchema,
-  verification: verificationPolicySchema.optional(),
-}).strict();
-const artifactEditToolInputSchema = editToolInputSchema.extend({
+function mcpDiscriminatedUnion<const Options extends readonly [z.AnyZodObject, ...z.AnyZodObject[]]>(
+  options: Options,
+): z.ZodType<z.output<Options[number]>, z.ZodTypeDef, z.input<Options[number]>> {
+  const schema = z.discriminatedUnion("type", options as unknown as [
+    z.ZodDiscriminatedUnionOption<"type">,
+    ...z.ZodDiscriminatedUnionOption<"type">[],
+  ]);
+  // The MCP SDK only serializes schemas it recognizes as object-shaped.
+  Object.defineProperty(schema, "shape", { value: {}, enumerable: false });
+  return schema;
+}
+
+function createEditToolInputSchema<Target extends z.ZodRawShape = {}>(
+  target: Target = {} as Target,
+  baseRevision: z.ZodTypeAny = revisionSchema,
+) {
+  const options = [
+    renameClipSchema.extend({ ...target, verification: verificationPolicySchema.optional(), baseRevision }),
+    trimClipSchema.extend({ ...target, verification: verificationPolicySchema.optional(), baseRevision }),
+    setGainSchema.extend({ ...target, verification: verificationPolicySchema.optional(), baseRevision }),
+    reduceNoiseSchema.extend({ ...target, verification: verificationPolicySchema.optional(), baseRevision }),
+    colorCorrectionSchema.extend({ ...target, verification: verificationPolicySchema.optional(), baseRevision }),
+    rippleDeleteSchema.extend({ ...target, verification: verificationPolicySchema.optional(), baseRevision }),
+    addMarkerSchema.extend({ ...target, verification: verificationPolicySchema.optional(), baseRevision }),
+  ] as const;
+  return mcpDiscriminatedUnion(options);
+}
+
+const editToolInputSchema = createEditToolInputSchema();
+const artifactEditToolInputSchema = createEditToolInputSchema({
   artifactPath: z.string().trim().min(1),
-  baseRevision: revisionValueSchema,
-}).strict();
-const editorTimelineEditToolInputSchema = editToolInputSchema.extend({
+}, revisionValueSchema);
+const editorTimelineEditToolInputSchema = createEditToolInputSchema({
   projectId: z.string().trim().min(1),
   sequenceId: z.string().trim().min(1),
-  baseRevision: revisionValueSchema,
-}).strict();
+}, revisionValueSchema);
+
+type JsonSchema = {
+  anyOf?: JsonSchema[];
+  properties?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+function exposeObjectRoot(schema: unknown): unknown {
+  if (!isRecord(schema) || !Array.isArray(schema.anyOf)) return schema;
+  const properties: Record<string, unknown> = {};
+  for (const branch of schema.anyOf as JsonSchema[]) {
+    if (branch.properties) Object.assign(properties, branch.properties);
+  }
+  return { ...schema, type: "object", properties };
+}
+
+function installMcpSchemaCompatibility(server: McpServer): void {
+  type RequestHandler = (request: unknown, extra: unknown) => Promise<unknown>;
+  type ToolListResponse = { tools?: Array<Record<string, unknown>>; [key: string]: unknown };
+  const handlers = (server.server as unknown as { _requestHandlers?: Map<string, RequestHandler> })._requestHandlers;
+  const listToolsHandler = handlers?.get("tools/list");
+  if (!listToolsHandler) throw new Error("MCP tools/list handler was not initialized");
+
+  server.server.removeRequestHandler("tools/list");
+  server.server.setRequestHandler(ListToolsRequestSchema, async (request, extra) => {
+    const response = await listToolsHandler(request, extra) as ToolListResponse;
+    return {
+      ...response,
+      tools: response.tools?.map((tool) => ({
+        ...tool,
+        inputSchema: exposeObjectRoot(tool.inputSchema),
+      })) ?? [],
+    };
+  });
+}
+
 const artifactPublishInputSchema = z.object({
   artifactPath: z.string().trim().min(1),
   transactionId: z.string().min(1),
@@ -1351,6 +1399,7 @@ export function createMcpServer(runtime: AgentVideoRuntime, options: McpServerOp
     inputSchema: { transactionId: z.string().min(1) },
   }, async ({ transactionId }) => jsonResult(await runtime.undo(transactionId)));
 
+  installMcpSchemaCompatibility(server);
   return server;
 }
 

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -263,7 +263,9 @@ function exposeObjectRoot(schema: unknown): unknown {
   if (!isRecord(schema) || !Array.isArray(schema.anyOf)) return schema;
   const properties: Record<string, unknown> = {};
   for (const branch of schema.anyOf as JsonSchema[]) {
-    if (branch.properties) Object.assign(properties, branch.properties);
+    for (const [key, value] of Object.entries(branch.properties ?? {})) {
+      if (key !== "type") properties[key] = value;
+    }
   }
   return { ...schema, type: "object", properties };
 }

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -230,13 +230,13 @@ function createEditToolInputSchema<Target extends z.ZodRawShape = {}>(
   baseRevision: z.ZodTypeAny = revisionSchema,
 ) {
   const options = [
-    renameClipSchema.extend({ ...target, verification: verificationPolicySchema.optional(), baseRevision }),
-    trimClipSchema.extend({ ...target, verification: verificationPolicySchema.optional(), baseRevision }),
-    setGainSchema.extend({ ...target, verification: verificationPolicySchema.optional(), baseRevision }),
-    reduceNoiseSchema.extend({ ...target, verification: verificationPolicySchema.optional(), baseRevision }),
-    colorCorrectionSchema.extend({ ...target, verification: verificationPolicySchema.optional(), baseRevision }),
-    rippleDeleteSchema.extend({ ...target, verification: verificationPolicySchema.optional(), baseRevision }),
-    addMarkerSchema.extend({ ...target, verification: verificationPolicySchema.optional(), baseRevision }),
+    renameClipSchema.extend({ ...target, verification: verificationPolicySchema.optional(), baseRevision }).strict(),
+    trimClipSchema.extend({ ...target, verification: verificationPolicySchema.optional(), baseRevision }).strict(),
+    setGainSchema.extend({ ...target, verification: verificationPolicySchema.optional(), baseRevision }).strict(),
+    reduceNoiseSchema.extend({ ...target, verification: verificationPolicySchema.optional(), baseRevision }).strict(),
+    colorCorrectionSchema.extend({ ...target, verification: verificationPolicySchema.optional(), baseRevision }).strict(),
+    rippleDeleteSchema.extend({ ...target, verification: verificationPolicySchema.optional(), baseRevision }).strict(),
+    addMarkerSchema.extend({ ...target, verification: verificationPolicySchema.optional(), baseRevision }).strict(),
   ] as const;
   return mcpDiscriminatedUnion(options);
 }

--- a/tests/integration/edit-tool-schema.test.ts
+++ b/tests/integration/edit-tool-schema.test.ts
@@ -116,3 +116,27 @@ test("editor.timeline.edit validates trim duration before its handler", async ()
     await server.close();
   }
 });
+
+test("single-edit tools reject fields from another operation", async () => {
+  const { client, server } = await connectedClient();
+  try {
+    const project = JSON.parse(textFrom(await client.callTool({ name: "project.inspect", arguments: {} })));
+    const invalid = await client.callTool({
+      name: "editor.timeline.edit",
+      arguments: {
+        projectId: project.projectId,
+        sequenceId: project.timeline.id,
+        type: "rename-clip",
+        clipId: "schema-clip",
+        name: "Interview Clean",
+        duration: 5,
+        baseRevision: project.revision,
+      },
+    });
+    assert.equal(invalid.isError, true);
+    assert.match(textFrom(invalid), /Unrecognized key\(s\).*duration/);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});

--- a/tests/integration/edit-tool-schema.test.ts
+++ b/tests/integration/edit-tool-schema.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { AgentVideoRuntime } from "@framekit/runtime";
+import { InMemoryEditorAdapter } from "@framekit/testkit";
+import { createMcpServer } from "../../apps/mcp-server/src/server.js";
+
+type JsonSchema = {
+  anyOf?: JsonSchema[];
+  properties?: Record<string, { const?: string }>;
+  required?: string[];
+};
+
+const operationRequirements = {
+  "rename-clip": ["clipId", "name", "type"],
+  "trim-clip": ["clipId", "duration", "type"],
+  "set-gain": ["clipId", "gainDb", "type"],
+  "reduce-noise": ["clipId", "range", "reductionDb", "type"],
+  "set-color-correction": ["clipId", "correction", "type"],
+  "ripple-delete": ["range", "timelineId", "type"],
+  "add-marker": ["marker", "timelineId", "type"],
+} as const;
+
+function runtime(): AgentVideoRuntime {
+  return new AgentVideoRuntime(new InMemoryEditorAdapter({
+    projectId: "schema-project",
+    projectName: "Schema Contract",
+    timelineId: "schema-timeline",
+    timelineName: "Main",
+    clips: [{ id: "schema-clip", mediaId: "schema-media", name: "Interview", start: 0, duration: 10, track: 1 }],
+    media: [{ mediaId: "schema-media", source: "interview.mov", mediaKind: "video", duration: 10 }],
+  }));
+}
+
+function branchFor(schema: JsonSchema, type: string): JsonSchema {
+  const branch = schema.anyOf?.find((candidate) => candidate.properties?.type?.const === type);
+  assert.ok(branch, `missing ${type} schema branch`);
+  return branch;
+}
+
+async function connectedClient() {
+  const server = createMcpServer(runtime());
+  const client = new Client({ name: "edit-tool-schema-test", version: "1.0.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  return { client, server };
+}
+
+function textFrom(result: unknown): string {
+  const content = (result as { content?: unknown }).content;
+  assert.ok(Array.isArray(content));
+  const first = content[0] as { text?: unknown } | undefined;
+  assert.equal(typeof first?.text, "string");
+  return first?.text as string;
+}
+
+test("single-edit tools advertise operation-specific required fields", async () => {
+  const { client, server } = await connectedClient();
+  try {
+    const tools = await client.listTools();
+    for (const toolName of ["timeline.edit", "artifact.edit", "editor.timeline.edit"]) {
+      const tool = tools.tools.find((candidate) => candidate.name === toolName);
+      assert.ok(tool);
+      const schema = tool.inputSchema as JsonSchema;
+      for (const [type, required] of Object.entries(operationRequirements)) {
+        const branch = branchFor(schema, type);
+        assert.deepEqual(branch.required?.slice().sort(), [
+          ...required,
+          ...(toolName === "artifact.edit" ? ["artifactPath", "baseRevision"] : []),
+          ...(toolName === "editor.timeline.edit" ? ["baseRevision", "projectId", "sequenceId"] : []),
+        ].sort(), `${toolName} ${type}`);
+      }
+    }
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
+
+test("editor.timeline.edit validates trim duration before its handler", async () => {
+  const { client, server } = await connectedClient();
+  try {
+    const project = JSON.parse(textFrom(await client.callTool({ name: "project.inspect", arguments: {} })));
+    const invalid = await client.callTool({
+      name: "editor.timeline.edit",
+      arguments: {
+        projectId: project.projectId,
+        sequenceId: project.timeline.id,
+        type: "trim-clip",
+        clipId: "schema-clip",
+        durationTime: { value: "1", timescale: "24" },
+        baseRevision: project.revision,
+      },
+    });
+    assert.equal(invalid.isError, true);
+    assert.match(textFrom(invalid), /Input validation error/);
+    assert.match(textFrom(invalid), /duration.*Required/);
+
+    const valid = await client.callTool({
+      name: "editor.timeline.edit",
+      arguments: {
+        projectId: project.projectId,
+        sequenceId: project.timeline.id,
+        type: "trim-clip",
+        clipId: "schema-clip",
+        duration: 5,
+        baseRevision: project.revision,
+      },
+    });
+    assert.equal(valid.isError, undefined);
+    assert.equal(JSON.parse(textFrom(valid)).status, "VERIFIED");
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});

--- a/tests/integration/edit-tool-schema.test.ts
+++ b/tests/integration/edit-tool-schema.test.ts
@@ -8,7 +8,7 @@ import { createMcpServer } from "../../apps/mcp-server/src/server.js";
 
 type JsonSchema = {
   anyOf?: JsonSchema[];
-  properties?: Record<string, { const?: string }>;
+  properties?: Record<string, { const?: unknown }>;
   required?: string[];
 };
 
@@ -37,6 +37,14 @@ function branchFor(schema: JsonSchema, type: string): JsonSchema {
   const branch = schema.anyOf?.find((candidate) => candidate.properties?.type?.const === type);
   assert.ok(branch, `missing ${type} schema branch`);
   return branch;
+}
+
+function matchesPublishedSchema(schema: JsonSchema, value: Record<string, unknown>): boolean {
+  if (schema.required?.some((key) => !(key in value))) return false;
+  for (const [key, property] of Object.entries(schema.properties ?? {})) {
+    if (property.const !== undefined && value[key] !== property.const) return false;
+  }
+  return schema.anyOf?.some((branch) => matchesPublishedSchema(branch, value)) ?? true;
 }
 
 async function connectedClient() {
@@ -72,6 +80,41 @@ test("single-edit tools advertise operation-specific required fields", async () 
           ...(toolName === "editor.timeline.edit" ? ["baseRevision", "projectId", "sequenceId"] : []),
         ].sort(), `${toolName} ${type}`);
       }
+    }
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
+
+test("published root schema validates non-last edit operations", async () => {
+  const { client, server } = await connectedClient();
+  try {
+    const tools = await client.listTools();
+    const tool = tools.tools.find((candidate) => candidate.name === "editor.timeline.edit");
+    assert.ok(tool);
+    const schema = tool.inputSchema as JsonSchema;
+    assert.equal(schema.properties?.type, undefined);
+
+    for (const request of [
+      {
+        type: "rename-clip",
+        clipId: "schema-clip",
+        name: "Interview Clean",
+        baseRevision: "1",
+        projectId: "schema-project",
+        sequenceId: "schema-timeline",
+      },
+      {
+        type: "trim-clip",
+        clipId: "schema-clip",
+        duration: 5,
+        baseRevision: "1",
+        projectId: "schema-project",
+        sequenceId: "schema-timeline",
+      },
+    ]) {
+      assert.equal(matchesPublishedSchema(schema, request), true, request.type);
     }
   } finally {
     await client.close();

--- a/tests/integration/edit-tool-schema.test.ts
+++ b/tests/integration/edit-tool-schema.test.ts
@@ -96,7 +96,7 @@ test("editor.timeline.edit validates trim duration before its handler", async ()
     });
     assert.equal(invalid.isError, true);
     assert.match(textFrom(invalid), /Input validation error/);
-    assert.match(textFrom(invalid), /duration.*Required/);
+    assert.match(textFrom(invalid), /Required at duration/);
 
     const valid = await client.callTool({
       name: "editor.timeline.edit",

--- a/tests/integration/mcp.test.ts
+++ b/tests/integration/mcp.test.ts
@@ -123,9 +123,15 @@ test("Phase 0 exposes read/write/diff through MCP stdio", async () => {
     assert.deepEqual(Object.keys(timelineEditTool?.inputSchema.properties ?? {}).sort(), [
       "baseRevision", "clipId", "correction", "duration", "durationTime", "gainDb", "marker", "name", "projectId", "range", "reason", "reductionDb", "sequenceId", "timelineId", "type", "verification",
     ]);
-    assert.deepEqual(timelineEditTool?.inputSchema.required?.slice().sort(), ["baseRevision", "projectId", "sequenceId", "type"]);
+    const timelineEditTrim = (timelineEditTool?.inputSchema as { anyOf?: Array<{ properties?: Record<string, { const?: string }>; required?: string[] }> }).anyOf?.find(
+      (branch) => branch.properties?.type?.const === "trim-clip",
+    );
+    assert.deepEqual(timelineEditTrim?.required?.slice().sort(), ["baseRevision", "clipId", "duration", "projectId", "sequenceId", "type"]);
     const artifactEditTool = tools.tools.find((tool) => tool.name === "artifact.edit");
-    assert.deepEqual(artifactEditTool?.inputSchema.required?.slice().sort(), ["artifactPath", "baseRevision", "type"]);
+    const artifactEditRename = (artifactEditTool?.inputSchema as { anyOf?: Array<{ properties?: Record<string, { const?: string }>; required?: string[] }> }).anyOf?.find(
+      (branch) => branch.properties?.type?.const === "rename-clip",
+    );
+    assert.deepEqual(artifactEditRename?.required?.slice().sort(), ["artifactPath", "baseRevision", "clipId", "name", "type"]);
     const artifactPublishTool = tools.tools.find((tool) => tool.name === "artifact.publish");
     assert.deepEqual(artifactPublishTool?.inputSchema.required?.slice().sort(), ["artifactPath", "confirm", "transactionId"]);
     const nativeEditTool = tools.tools.find((tool) => tool.name === "editor.native.edit");

--- a/tests/integration/mcp.test.ts
+++ b/tests/integration/mcp.test.ts
@@ -121,7 +121,7 @@ test("Phase 0 exposes read/write/diff through MCP stdio", async () => {
     );
     const timelineEditTool = tools.tools.find((tool) => tool.name === "editor.timeline.edit");
     assert.deepEqual(Object.keys(timelineEditTool?.inputSchema.properties ?? {}).sort(), [
-      "baseRevision", "clipId", "correction", "duration", "durationTime", "gainDb", "marker", "name", "projectId", "range", "reason", "reductionDb", "sequenceId", "timelineId", "type", "verification",
+      "baseRevision", "clipId", "correction", "duration", "durationTime", "gainDb", "marker", "name", "projectId", "range", "reason", "reductionDb", "sequenceId", "timelineId", "verification",
     ]);
     const timelineEditTrim = (timelineEditTool?.inputSchema as { anyOf?: Array<{ properties?: Record<string, { const?: string }>; required?: string[] }> }).anyOf?.find(
       (branch) => branch.properties?.type?.const === "trim-clip",


### PR DESCRIPTION
Closes #133

## Summary

- Expose operation-specific required fields for all single-edit MCP tools.
- Preserve the MCP object-root schema contract while publishing discriminated branches.
- Reject missing operation fields and unrelated operation fields during MCP validation.
- Add deterministic integration coverage for schema advertisement and validation behavior.

## TDD

- Red: added failing schema advertisement and validation tests.
- Green: implemented strict operation-specific schemas and MCP schema compatibility.
- Red: added a failing cross-operation field rejection test.
- Green: made each operation branch strict.

## Validation

```text
pnpm install --frozen-lockfile
pnpm run build
pnpm run test       # 481 passed
pnpm run check:boundaries
```

Native Xcode checks were not required because no native files changed.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] MCP contract behavior is covered by integration tests.
- [x] Existing edit handlers and deterministic fixtures remain compatible.

## Safety

- [x] No credentials, private media, raw crash dumps, or local paths added.
- [x] No generated files or build artifacts added.
