### PR TITLE
fix: invalidate cached media understanding after edits

### DIFF
--- a/packages/runtime/src/context/context-engine.ts
+++ b/packages/runtime/src/context/context-engine.ts
@@ -122,8 +122,7 @@ export class ContextEngine {
     next.media = next.media.map((media) => {
       const understanding = this.mediaUnderstanding.get(media.mediaId);
       if (!understanding) return media;
-      if (!sameMediaSourceIdentity(understanding.sourceIdentity, media)
-        || !sameRevision(understanding.analysisRevision, snapshot.revision)) {
+      if (!isCurrentUnderstanding(understanding, media, snapshot.revision)) {
         this.mediaUnderstanding.delete(media.mediaId);
         return media;
       }
@@ -141,6 +140,15 @@ export class ContextEngine {
     });
     return next;
   }
+}
+
+function isCurrentUnderstanding(
+  understanding: MediaUnderstanding,
+  media: ProjectSnapshot["media"][number],
+  revision: ContextRevision,
+): boolean {
+  return sameMediaSourceIdentity(understanding.sourceIdentity, media)
+    && sameRevision(understanding.analysisRevision, revision);
 }
 
 function isOptionalLiveUnavailable(error: unknown): boolean {

--- a/packages/runtime/src/context/context-engine.ts
+++ b/packages/runtime/src/context/context-engine.ts
@@ -3,6 +3,7 @@ import type { AgentContext, ContextDiff, EditorChange, EditorLiveState } from ".
 import type { AssetSearchQuery, EditorPort } from "../domain/ports.js";
 import type { ContextRevision } from "../domain/primitives.js";
 import { sameMediaSourceIdentity, type MediaUnderstanding } from "../domain/media.js";
+import { sameRevision } from "./revision.js";
 import type { ProjectSnapshot } from "../domain/project.js";
 import type { RuntimeCapabilities } from "../domain/capabilities.js";
 import type { TimelineDiff } from "../domain/diff.js";
@@ -120,7 +121,12 @@ export class ContextEngine {
     const next = structuredClone(snapshot);
     next.media = next.media.map((media) => {
       const understanding = this.mediaUnderstanding.get(media.mediaId);
-      if (!understanding || !sameMediaSourceIdentity(understanding.sourceIdentity, media)) return media;
+      if (!understanding) return media;
+      if (!sameMediaSourceIdentity(understanding.sourceIdentity, media)
+        || !sameRevision(understanding.analysisRevision, snapshot.revision)) {
+        this.mediaUnderstanding.delete(media.mediaId);
+        return media;
+      }
       const attached = structuredClone(understanding);
       return {
         ...media,

--- a/tests/integration/semantic-media.test.ts
+++ b/tests/integration/semantic-media.test.ts
@@ -128,6 +128,32 @@ test("media understanding cache rejects changed source identities", async () => 
   }
 });
 
+test("media understanding cache invalidates after a timeline revision", async () => {
+  const fixture = semanticFixture();
+  const runtime = new AgentVideoRuntime(fixture.adapter, {
+    visualAnalyzer: new FixtureVisualAnalyzer(),
+  });
+
+  const before = await runtime.inspectProject();
+  const understanding = await runtime.understandMedia("media-semantic-1");
+  assert.equal(understanding.analysisRevision.id, before.revision.id);
+
+  const transaction = await runtime.edit({
+    type: "rename-clip",
+    clipId: "clip-semantic-1",
+    name: "Interview - Clean",
+  });
+  assert.equal(transaction.after.revision.id, "rev-1");
+  assert.equal(transaction.after.media[0]?.analysisRevision, transaction.after.revision.id);
+
+  const inspected = await runtime.inspectProject();
+  const media = inspected.media[0];
+  assert.equal(inspected.revision.id, transaction.after.revision.id);
+  assert.equal(media?.analysisRevision, undefined);
+  assert.equal(media?.semantic, undefined);
+  assert.equal(media?.analysis, undefined);
+});
+
 test("attached media understanding is isolated from returned snapshots", async () => {
   const fixture = semanticFixture();
   const runtime = new AgentVideoRuntime(fixture.adapter, {


### PR DESCRIPTION
- [x] Request PR review
- [ ] If you are unable to review, please set it as a PR draft.
- [x] Github issue: Closes: #137

## Summary

Prevent cached media understanding from being attached after its source
identity or analysis revision no longer matches the current project. Stale
entries are removed from the context cache, and a deterministic regression
covers understanding at rev-0, a rename to rev-1, post-write reanalysis, and
the subsequent project inspection.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm run test` — 479 passed
- `pnpm run check:boundaries`
- Native Xcode checks skipped; no native files changed.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Public MCP behavior or package interfaces are documented if changed.
- [x] Existing adapters and test fixtures remain compatible.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [x] Documentation reflects any changed commands, paths, or environment variables.
