### PR TITLE
feat: add revision-bound speech and VAD analysis

### DIFF
--- a/adapters/final-cut/typescript/src/analyzers.ts
+++ b/adapters/final-cut/typescript/src/analyzers.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { access } from "node:fs/promises";
+import { bindSpeechAnalysis } from "@framekit/runtime";
 import type {
   AnalysisInput,
   AudioAnalysis,
@@ -8,6 +9,7 @@ import type {
   MetadataAnalyzer,
   SpeechAnalysis,
   SpeechAnalyzer,
+  MediaSourceIdentity,
   TimeRange,
   VisualAnalysis,
   VisualAnalyzer,
@@ -48,7 +50,12 @@ export class CommandSpeechAnalyzer implements SpeechAnalyzer {
   public constructor(private readonly options: CommandAnalyzerOptions) {}
 
   public async analyze(input: AnalysisInput, range?: TimeRange): Promise<SpeechAnalysis> {
-    return runCommand<SpeechAnalysis>(this.options, { ...input, range }, "speech");
+    const result = await runCommand<unknown>(this.options, { ...input, range }, "speech");
+    try {
+      return bindSpeechAnalysis(result, { input, range, provider: this.descriptor });
+    } catch (error) {
+      throw new Error(`ANALYZER_INVALID_OUTPUT: speech analyzer returned invalid JSON or schema: ${String(error)}`);
+    }
   }
 }
 
@@ -130,8 +137,28 @@ async function runCommand<T>(options: CommandAnalyzerOptions, request: AnalyzerR
       }
     });
 
-    child.stdin.end(JSON.stringify(request));
+    child.stdin.end(JSON.stringify(commandRequest(request, kind)));
   });
+}
+
+function commandRequest(request: AnalyzerRequest, kind: string): unknown {
+  if (kind !== "speech") return request;
+  return {
+    schemaVersion: 1,
+    media: sourceIdentityOf(request.media),
+    revision: request.project.revision,
+    ...(request.range ? { range: structuredClone(request.range) } : {}),
+  };
+}
+
+function sourceIdentityOf(media: AnalysisInput["media"]): MediaSourceIdentity {
+  return {
+    mediaId: media.mediaId,
+    source: media.source,
+    ...(media.sourceDigest ? { sourceDigest: media.sourceDigest } : {}),
+    ...(media.mediaKind ? { mediaKind: media.mediaKind } : {}),
+    ...(media.duration !== undefined ? { duration: media.duration } : {}),
+  };
 }
 
 function validateResult(value: unknown, kind: string): void {

--- a/adapters/final-cut/typescript/src/analyzers.ts
+++ b/adapters/final-cut/typescript/src/analyzers.ts
@@ -46,7 +46,7 @@ export function createCommandAnalyzers(options: {
 
 export class CommandSpeechAnalyzer implements SpeechAnalyzer {
   public readonly descriptor = { id: "command.speech", provider: "command" };
-  public readonly capabilities = { transcription: true, vad: true };
+  public readonly capabilities = { transcription: true, vad: false };
 
   public constructor(private readonly options: CommandAnalyzerOptions) {}
 

--- a/adapters/final-cut/typescript/src/analyzers.ts
+++ b/adapters/final-cut/typescript/src/analyzers.ts
@@ -46,6 +46,7 @@ export function createCommandAnalyzers(options: {
 
 export class CommandSpeechAnalyzer implements SpeechAnalyzer {
   public readonly descriptor = { id: "command.speech", provider: "command" };
+  public readonly capabilities = { transcription: true, vad: true };
 
   public constructor(private readonly options: CommandAnalyzerOptions) {}
 

--- a/adapters/final-cut/typescript/src/fcpxml.ts
+++ b/adapters/final-cut/typescript/src/fcpxml.ts
@@ -418,13 +418,17 @@ export class FcpxmlDocumentAdapter implements EditorPort {
     const resources = findElement(this.xml ?? [], "resources");
     return storyEntries(resources ?? {})
       .filter(({ kind }) => kind === "asset" || kind === "media" || kind === "effect")
-      .map(({ node }) => ({
-        mediaId: String(attribute(node, "id") ?? ""),
-        source: resolveMediaSource(
-          String(attribute(node, "src") ?? attribute(node, "name") ?? attribute(node, "id") ?? ""),
-          this.filePath,
-        ),
-      }))
+      .map(({ node }) => {
+        const durationValue = attribute(node, "duration");
+        return {
+          mediaId: String(attribute(node, "id") ?? ""),
+          source: resolveMediaSource(
+            String(attribute(node, "src") ?? attribute(node, "name") ?? attribute(node, "id") ?? ""),
+            this.filePath,
+          ),
+          ...(durationValue !== undefined ? { duration: parseSeconds(durationValue) } : {}),
+        };
+      })
       .filter((media) => media.mediaId.length > 0);
   }
 

--- a/adapters/final-cut/typescript/src/fcpxml.ts
+++ b/adapters/final-cut/typescript/src/fcpxml.ts
@@ -338,12 +338,17 @@ export class FcpxmlDocumentAdapter implements EditorPort {
   private clipFromXml(entry: TimelineEntry, timelineId: string): Clip {
     const { node, kind, path, startTime, durationTime } = entry;
     const gain = firstChild(node, "adjust-volume");
+    const sourceStartValue = attribute(node, "start");
+    const sourceStartTime = sourceStartValue === undefined ? undefined : parseRational(sourceStartValue);
+    const sourceStart = sourceStartTime === undefined ? undefined : rationalSeconds(sourceStartTime);
+    if (sourceStart !== undefined && sourceStart < 0) throw new Error("FCPXML_INVALID_TIME: source clip start cannot be negative");
     return {
       id: this.instanceId(node, kind, path, timelineId),
       mediaId: attribute(node, "ref") === undefined ? undefined : String(attribute(node, "ref")),
       name: String(attribute(node, "name") ?? attribute(node, "ref") ?? `Clip ${path.includes(".") ? path : path + 1}`),
       start: rationalSeconds(startTime),
       duration: rationalSeconds(durationTime),
+      ...(sourceStart !== undefined ? { sourceStart, sourceStartTime } : {}),
       track: Number(attribute(node, "lane") ?? 0),
       startTime,
       durationTime,

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -1278,9 +1278,9 @@ export function createMcpServer(runtime: AgentVideoRuntime, options: McpServerOp
   });
 
   server.registerTool("speech.analyze", {
-    description: "Analyze speech words and filler markers for one media item.",
-    inputSchema: { mediaId: z.string().min(1) },
-  }, async ({ mediaId }) => jsonResult(await runtime.analyzeSpeech(mediaId)));
+    description: "Analyze speech words, filler markers, and optional VAD for one media item or source range.",
+    inputSchema: { mediaId: z.string().min(1), range: rangeSchema.optional() },
+  }, async ({ mediaId, range }) => jsonResult(await runtime.analyzeSpeech(mediaId, range)));
 
   server.registerTool("speech.filler.remove.preview", {
     description: "Analyze a selected canonical timeline range and preview removal of high-confidence filler words with safe rational delete ranges.",

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,8 @@ Repository-local GitHub agent playbooks are documented in
 - [SDD](./SDD.md): architecture and design contracts.
 - [Compatibility](./COMPATIBILITY.md): verified editor and toolchain support.
 - [MCP](./mcp/README.md): agent-facing protocol and tools.
+- [Local speech analysis](./speech-analysis.md): the executable wrapper,
+  JSON contract, provenance, and capability boundaries.
 - [Rough-cut duration policy](./rough-cut/duration-policy.md): explicit duration tradeoffs and safety defaults.
 - [Tests](./tests/README.md): reproducible checks and evidence, including the [golden workflow corpus](./tests/golden-corpus.md), [deterministic MCP evaluation](./tests/mcp-evaluation.md), and [v0.0.3 release gate](./tests/release-gate.md).
 - [Generic MCP Skills](./mcp/skills.md): versioned Skill discovery and execution.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -87,8 +87,9 @@ time of day, mood, and usable source ranges. Analyzer availability is exposed
 through `editor.inspect`; missing providers produce explicit unavailable
 statuses instead of fabricated descriptions. Motion templates are discovered
 from standard locations; restrict those locations with the colon-separated
-`FRAMEKIT_FINAL_CUT_ASSET_ROOTS` variable. The complete provider setup is
-documented in the [Final Cut installation guide](./final-cut/installation.md).
+`FRAMEKIT_FINAL_CUT_ASSET_ROOTS` variable. Speech wrapper setup and its
+revision-bound schema are documented in the [local speech analysis guide](./speech-analysis.md).
+The complete Final Cut provider setup is documented in the [Final Cut installation guide](./final-cut/installation.md).
 
 ## Connect Codex to Final Cut
 

--- a/docs/mcp/README.md
+++ b/docs/mcp/README.md
@@ -25,6 +25,8 @@ invoke the external renderer.
 - [Rough-cut duration policy](../rough-cut/duration-policy.md): explicit duration tradeoffs for planning workflows.
 - [Capabilities and errors](./capabilities-and-errors.md): fail-closed rules.
 - [Final Cut live backend](./final-cut-live.md): selecting and probing it.
+- [Local speech analysis](../speech-analysis.md): configuring a local
+  Whisper/VAD-compatible wrapper and its revision-bound JSON contract.
 
 The default `pnpm run mcp` configuration uses the deterministic in-memory
 fixture. Set `FRAMEKIT_EDITOR=final-cut-live` to select the live Final Cut

--- a/docs/speech-analysis.md
+++ b/docs/speech-analysis.md
@@ -1,0 +1,109 @@
+# Local Speech Analysis
+
+Framekit speech analysis is editor-independent. A configured local executable
+can provide transcription and optional voice-activity detection (VAD) without
+turning speech into a Final Cut capability.
+
+## Setup
+
+The repository includes an executable protocol wrapper at
+[`scripts/speech-analyzer-wrapper.mjs`](../scripts/speech-analyzer-wrapper.mjs).
+It delegates to one locally installed Whisper/VAD-compatible executable named by
+`FRAMEKIT_SPEECH_BACKEND`; it does not bundle a model, credentials, or hosted
+service. Both values are executable paths, not shell command strings with
+embedded arguments:
+
+```sh
+export FRAMEKIT_EDITOR=final-cut-live
+export FRAMEKIT_FCPXML_PATH=/absolute/path/to/project.fcpxml
+export FRAMEKIT_SPEECH_ANALYZER=/absolute/path/to/framekit/scripts/speech-analyzer-wrapper.mjs
+export FRAMEKIT_SPEECH_BACKEND=/absolute/path/to/whisper-vad-backend
+pnpm run mcp
+```
+
+The wrapper exits with `SPEECH_ANALYZER_SETUP_REQUIRED` when the backend is
+missing or not executable. Framekit reports that as an analyzer setup failure;
+it is not reported as a Final Cut editor limitation. Confirm the setup before
+starting MCP:
+
+```sh
+test -x "$FRAMEKIT_SPEECH_ANALYZER"
+test -x "$FRAMEKIT_SPEECH_BACKEND"
+```
+
+## JSON protocol
+
+Framekit writes one request to wrapper stdin and reads one JSON object from
+stdout. The request contains only the source identity needed by the analyzer,
+the inspected editor revision, and an optional source-media range:
+
+```json
+{
+  "schemaVersion": 1,
+  "media": {
+    "mediaId": "media-1",
+    "source": "/absolute/path/to/interview.wav",
+    "sourceDigest": "sha256:...",
+    "mediaKind": "audio",
+    "duration": 120
+  },
+  "revision": {
+    "id": "rev-4",
+    "sequence": 4,
+    "timestamp": "2026-09-10T00:00:00.000Z"
+  },
+  "range": { "start": 10, "end": 20 }
+}
+```
+
+The backend returns a speech object. `words` is required; all other evidence
+is optional:
+
+```json
+{
+  "words": [
+    { "text": "hello", "start": 10.2, "end": 10.8, "confidence": 0.98 }
+  ],
+  "vadSegments": [
+    { "start": 10, "end": 11, "kind": "speech" },
+    { "start": 11, "end": 12, "kind": "silence" }
+  ],
+  "silenceSegments": [
+    { "start": 11, "end": 12, "kind": "silence" }
+  ],
+  "protectedSegments": [
+    { "start": 12, "end": 12.2, "kind": "breath" }
+  ],
+  "sourceTimebase": { "value": "1", "timescale": "1000" }
+}
+```
+
+Timestamps are source-media seconds. Words and each segment list must be
+finite, ordered, positive, non-overlapping, and within the observed media
+range. Word confidence and optional segment confidence are between `0` and
+`1`. Validated runtime results are bound to the requested media identity,
+revision, requested/observed range, provider descriptor, and source timebase.
+Conflicting provider metadata fails closed rather than authorizing an edit.
+
+## Capability truthfulness
+
+`editor.inspect` retains the legacy `speechTranscribe` and `speechVad` flags
+and adds `speechCapability`:
+
+- `unavailable`: no speech analyzer is configured;
+- `transcription-only`: words are available without VAD;
+- `transcription-plus-vad`: words and VAD segments are available.
+
+The normalized `speech.analyze` result carries the same distinction. Missing
+VAD is never silently converted into silence or protected speech evidence.
+Fixture analyzers remain deterministic test providers and are never evidence
+that live Final Cut performed speech analysis.
+
+## Safety boundary
+
+Speech evidence can be mapped to a specific trimmed or offset timeline
+occurrence only when its media identity and revision match, its source and
+sequence durations agree, and the sequence occurrence has exact rational
+timing. The runtime rejects stale, ambiguous, partial, unordered, overlapping,
+out-of-range, and non-frame-safe mappings before a filler-removal operation is
+planned.

--- a/docs/speech-analysis.md
+++ b/docs/speech-analysis.md
@@ -78,6 +78,12 @@ is optional:
 }
 ```
 
+The normalized runtime and MCP response adds `schemaVersion: 1`, `mediaId`,
+`sourceIdentity`, `requestedRange`, `observedRange`, `revision`, `provider`,
+`sourceTimebase`, and `capability` to that evidence. A provider may omit these
+fields because Framekit fills them from the trusted request; conflicting values
+are rejected.
+
 Timestamps are source-media seconds. Words and each segment list must be
 finite, ordered, positive, non-overlapping, and within the observed media
 range. Word confidence and optional segment confidence are between `0` and

--- a/packages/runtime/src/application/media-analysis-service.ts
+++ b/packages/runtime/src/application/media-analysis-service.ts
@@ -16,6 +16,7 @@ import type {
   NoiseAnalysis,
   NoiseMeasurement,
   SpeechAnalysis,
+  RevisionBoundSpeechAnalysis,
   VisualAnalysis,
 } from "../domain/media.js";
 import type { EditTransaction } from "../domain/editing.js";
@@ -25,6 +26,7 @@ import { ContextEngine } from "../context/context-engine.js";
 import { ProjectService } from "./project-service.js";
 import type { RuntimeOptions } from "./runtime-options.js";
 import { planRoughCut } from "../planning/rough-cut.js";
+import { bindSpeechAnalysis } from "../speech/analysis.js";
 
 export class MediaAnalysisService {
   public constructor(
@@ -33,11 +35,11 @@ export class MediaAnalysisService {
     private readonly options: RuntimeOptions,
   ) {}
 
-  public async analyzeSpeech(mediaId: string, range?: TimeRange): Promise<SpeechAnalysis> {
+  public async analyzeSpeech(mediaId: string, range?: TimeRange): Promise<RevisionBoundSpeechAnalysis> {
     if (!this.options.speechAnalyzer) throw new Error("CAPABILITY_UNAVAILABLE: speech analysis");
     const project = await this.project.inspectProject();
     const media = findMedia(project, mediaId);
-    return this.options.speechAnalyzer.analyze({ project, media }, range);
+    return this.analyzeSpeechForProject(project, media, range);
   }
 
   public async analyzeAudio(mediaId: string): Promise<AudioAnalysis> {
@@ -142,7 +144,7 @@ export class MediaAnalysisService {
     const media = findMedia(project, mediaId);
     const input = { project, media };
     const [speechResult, audioResult, noiseResult, visualResult, metadataResult] = await Promise.all([
-      settle(() => this.options.speechAnalyzer?.analyze(input)),
+      settle(() => this.options.speechAnalyzer ? this.analyzeSpeechForProject(project, media) : undefined),
       settle(() => this.options.audioAnalyzer?.analyze(input)),
       settle(() => this.options.noiseAnalyzer?.analyze(input)),
       settle(() => this.options.visualAnalyzer?.analyze(input)),
@@ -271,6 +273,22 @@ export class MediaAnalysisService {
       }
     }
     return next;
+  }
+
+  private async analyzeSpeechForProject(
+    project: ProjectSnapshot,
+    media: MediaContext,
+    range?: TimeRange,
+  ): Promise<RevisionBoundSpeechAnalysis> {
+    const analyzer = this.options.speechAnalyzer;
+    if (!analyzer) throw new Error("CAPABILITY_UNAVAILABLE: speech analysis");
+    const input = { project, media };
+    const analysis = await analyzer.analyze(input, range);
+    return bindSpeechAnalysis(analysis, {
+      input,
+      range,
+      provider: analyzer.descriptor,
+    });
   }
 }
 

--- a/packages/runtime/src/application/media-analysis-service.ts
+++ b/packages/runtime/src/application/media-analysis-service.ts
@@ -226,11 +226,12 @@ export class MediaAnalysisService {
         const intersectionStart = Math.max(range.start, clip.start);
         const intersectionEnd = Math.min(range.end, clip.start + clip.duration);
         if (!clip.mediaId || intersectionStart >= intersectionEnd) return [];
+        const sourceStart = clip.sourceStart ?? 0;
         return [{
           mediaId: clip.mediaId,
           range: {
-            start: intersectionStart - clip.start,
-            end: intersectionEnd - clip.start,
+            start: sourceStart + intersectionStart - clip.start,
+            end: sourceStart + intersectionEnd - clip.start,
           },
         }];
       }),
@@ -246,8 +247,26 @@ export class MediaAnalysisService {
         .map((affected) => affected.range);
       const input = { project: next, media };
       if (this.options.speechAnalyzer) {
-        const analyses = await Promise.all(ranges.map((range) => this.options.speechAnalyzer!.analyze(input, range)));
-        media.speech = { words: analyses.flatMap((analysis) => analysis.words) };
+        const analyses = await Promise.all(ranges.map(async (range) => bindSpeechAnalysis(
+          await this.options.speechAnalyzer!.analyze(input, range),
+          { input, range, provider: this.options.speechAnalyzer!.descriptor },
+        )));
+        const latest = analyses[analyses.length - 1];
+        if (latest) {
+          media.speech = {
+            ...latest,
+            words: analyses.flatMap((analysis) => analysis.words),
+            ...(analyses.some((analysis) => analysis.vadSegments)
+              ? { vadSegments: analyses.flatMap((analysis) => analysis.vadSegments ?? []) }
+              : {}),
+            ...(analyses.some((analysis) => analysis.silenceSegments)
+              ? { silenceSegments: analyses.flatMap((analysis) => analysis.silenceSegments ?? []) }
+              : {}),
+            ...(analyses.some((analysis) => analysis.protectedSegments)
+              ? { protectedSegments: analyses.flatMap((analysis) => analysis.protectedSegments ?? []) }
+              : {}),
+          };
+        }
       }
       if (this.options.audioAnalyzer) {
         const analyses = await Promise.all(ranges.map((range) => this.options.audioAnalyzer!.analyze(input, range)));

--- a/packages/runtime/src/application/media-analysis-service.ts
+++ b/packages/runtime/src/application/media-analysis-service.ts
@@ -27,6 +27,7 @@ import { ProjectService } from "./project-service.js";
 import type { RuntimeOptions } from "./runtime-options.js";
 import { planRoughCut } from "../planning/rough-cut.js";
 import { bindSpeechAnalysis } from "../speech/analysis.js";
+import { parseRational } from "../timeline/rational-time.js";
 
 export class MediaAnalysisService {
   public constructor(
@@ -253,19 +254,10 @@ export class MediaAnalysisService {
         )));
         const latest = analyses[analyses.length - 1];
         if (latest) {
-          media.speech = {
-            ...latest,
-            words: analyses.flatMap((analysis) => analysis.words),
-            ...(analyses.some((analysis) => analysis.vadSegments)
-              ? { vadSegments: analyses.flatMap((analysis) => analysis.vadSegments ?? []) }
-              : {}),
-            ...(analyses.some((analysis) => analysis.silenceSegments)
-              ? { silenceSegments: analyses.flatMap((analysis) => analysis.silenceSegments ?? []) }
-              : {}),
-            ...(analyses.some((analysis) => analysis.protectedSegments)
-              ? { protectedSegments: analyses.flatMap((analysis) => analysis.protectedSegments ?? []) }
-              : {}),
-          };
+          media.speech = mergeSpeechAnalyses(media.speech, analyses, ranges, {
+            input,
+            provider: this.options.speechAnalyzer!.descriptor,
+          });
         }
       }
       if (this.options.audioAnalyzer) {
@@ -319,6 +311,92 @@ function sourceIdentityOf(media: MediaContext): MediaSourceIdentity {
     ...(media.mediaKind ? { mediaKind: media.mediaKind } : {}),
     ...(media.duration !== undefined ? { duration: media.duration } : {}),
   };
+}
+
+function mergeSpeechAnalyses(
+  previous: SpeechAnalysis | undefined,
+  analyses: RevisionBoundSpeechAnalysis[],
+  updatedRanges: TimeRange[],
+  context: Parameters<typeof bindSpeechAnalysis>[1],
+): RevisionBoundSpeechAnalysis {
+  const latest = analyses[analyses.length - 1];
+  if (!latest) throw new Error("ANALYSIS_INVALID: speech reanalysis returned no results");
+  if (previous?.provider && !sameDescriptor(previous.provider, latest.provider)) {
+    throw new Error("ANALYSIS_INVALID: speech evidence providers cannot be combined");
+  }
+  if (previous?.sourceTimebase && !sameRational(previous.sourceTimebase, latest.sourceTimebase)) {
+    throw new Error("ANALYSIS_INVALID: speech evidence timebases cannot be combined");
+  }
+
+  const requestedRange = encompassingRange([
+    ...(previous?.requestedRange ? [previous.requestedRange] : []),
+    ...analyses.map((analysis) => analysis.requestedRange),
+  ]);
+  const observedRange = encompassingRange([
+    ...(previous?.observedRange ? [previous.observedRange] : []),
+    ...analyses.map((analysis) => analysis.observedRange),
+  ]);
+  const words = mergeSpeechEvidence(
+    previous?.words,
+    analyses.map((analysis) => analysis.words),
+    updatedRanges,
+  );
+  const hasVad = previous?.vadSegments !== undefined || analyses.some((analysis) => analysis.vadSegments !== undefined);
+  const vadSegments = hasVad
+    ? mergeSpeechEvidence(previous?.vadSegments, analyses.map((analysis) => analysis.vadSegments ?? []), updatedRanges)
+    : undefined;
+  const hasSilence = previous?.silenceSegments !== undefined || analyses.some((analysis) => analysis.silenceSegments !== undefined);
+  const silenceSegments = hasSilence
+    ? mergeSpeechEvidence(previous?.silenceSegments, analyses.map((analysis) => analysis.silenceSegments ?? []), updatedRanges)
+    : undefined;
+  const hasProtected = previous?.protectedSegments !== undefined || analyses.some((analysis) => analysis.protectedSegments !== undefined);
+  const protectedSegments = hasProtected
+    ? mergeSpeechEvidence(previous?.protectedSegments, analyses.map((analysis) => analysis.protectedSegments ?? []), updatedRanges)
+    : undefined;
+
+  return bindSpeechAnalysis({
+    ...latest,
+    requestedRange,
+    observedRange,
+    capability: vadSegments ? "transcription-plus-vad" : latest.capability,
+    words,
+    ...(vadSegments ? { vadSegments } : {}),
+    ...(silenceSegments ? { silenceSegments } : {}),
+    ...(protectedSegments ? { protectedSegments } : {}),
+  }, context);
+}
+
+function mergeSpeechEvidence<T extends { start: number; end: number }>(
+  previous: T[] | undefined,
+  fresh: T[][],
+  updatedRanges: TimeRange[],
+): T[] {
+  return [
+    ...(previous ?? []).filter((evidence) => !updatedRanges.some((range) => rangesOverlap(evidence, range))),
+    ...fresh.flat(),
+  ].sort((left, right) => left.start - right.start || left.end - right.end);
+}
+
+function rangesOverlap(left: { start: number; end: number }, right: TimeRange): boolean {
+  return left.end > right.start && left.start < right.end;
+}
+
+function encompassingRange(ranges: TimeRange[]): TimeRange {
+  if (ranges.length === 0) throw new Error("ANALYSIS_INVALID: speech evidence needs a range");
+  return {
+    start: Math.min(...ranges.map((range) => range.start)),
+    end: Math.max(...ranges.map((range) => range.end)),
+  };
+}
+
+function sameDescriptor(left: AnalyzerDescriptor, right: AnalyzerDescriptor): boolean {
+  return left.id === right.id && left.provider === right.provider && left.version === right.version;
+}
+
+function sameRational(left: { value: string; timescale: string }, right: { value: string; timescale: string }): boolean {
+  const leftParts = parseRational(left, "ANALYSIS_INVALID");
+  const rightParts = parseRational(right, "ANALYSIS_INVALID");
+  return leftParts.value * rightParts.timescale === rightParts.value * leftParts.timescale;
 }
 
 function semanticFromAnalyses(

--- a/packages/runtime/src/application/media-analysis-service.ts
+++ b/packages/runtime/src/application/media-analysis-service.ts
@@ -243,9 +243,9 @@ export class MediaAnalysisService {
     for (const mediaId of mediaIds) {
       const media = next.media.find((candidate) => candidate.mediaId === mediaId);
       if (!media) continue;
-      const ranges = affectedMediaRanges
+      const ranges = mergeRanges(affectedMediaRanges
         .filter((affected) => affected.mediaId === mediaId)
-        .map((affected) => affected.range);
+        .map((affected) => affected.range));
       const input = { project: next, media };
       if (this.options.speechAnalyzer) {
         const analyses = await Promise.all(ranges.map(async (range) => bindSpeechAnalysis(
@@ -387,6 +387,19 @@ function encompassingRange(ranges: TimeRange[]): TimeRange {
     start: Math.min(...ranges.map((range) => range.start)),
     end: Math.max(...ranges.map((range) => range.end)),
   };
+}
+
+function mergeRanges(ranges: TimeRange[]): TimeRange[] {
+  const merged: TimeRange[] = [];
+  for (const range of [...ranges].sort((left, right) => left.start - right.start || left.end - right.end)) {
+    const previous = merged[merged.length - 1];
+    if (!previous || range.start > previous.end) {
+      merged.push({ start: range.start, end: range.end });
+      continue;
+    }
+    previous.end = Math.max(previous.end, range.end);
+  }
+  return merged;
 }
 
 function sameDescriptor(left: AnalyzerDescriptor, right: AnalyzerDescriptor): boolean {

--- a/packages/runtime/src/application/project-service.ts
+++ b/packages/runtime/src/application/project-service.ts
@@ -108,8 +108,11 @@ export class ProjectService {
   public async inspectEditor() {
     const identity = await this.adapter.getIdentity();
     const capabilities = withCapabilityFamilies(await this.adapter.getCapabilities(), { backend: identity.backend });
-    const speechTranscribe = capabilities.analyzers.speechTranscribe || Boolean(this.options.speechAnalyzer?.capabilities?.transcription) || Boolean(this.options.speechAnalyzer);
-    const speechVad = capabilities.analyzers.speechVad || Boolean(this.options.speechAnalyzer?.capabilities?.vad);
+    const speechAnalyzer = this.options.speechAnalyzer;
+    const speechTranscribe = capabilities.analyzers.speechTranscribe
+      || (speechAnalyzer ? speechAnalyzer.capabilities?.transcription ?? true : false);
+    const speechVad = capabilities.analyzers.speechVad
+      || (speechAnalyzer?.capabilities?.vad ?? false);
     const analyzers = {
       ...capabilities.analyzers,
       speechTranscribe,

--- a/packages/runtime/src/application/project-service.ts
+++ b/packages/runtime/src/application/project-service.ts
@@ -108,9 +108,15 @@ export class ProjectService {
   public async inspectEditor() {
     const identity = await this.adapter.getIdentity();
     const capabilities = withCapabilityFamilies(await this.adapter.getCapabilities(), { backend: identity.backend });
+    const speechTranscribe = capabilities.analyzers.speechTranscribe || Boolean(this.options.speechAnalyzer?.capabilities?.transcription) || Boolean(this.options.speechAnalyzer);
+    const speechVad = capabilities.analyzers.speechVad || Boolean(this.options.speechAnalyzer?.capabilities?.vad);
     const analyzers = {
       ...capabilities.analyzers,
-      speechTranscribe: capabilities.analyzers.speechTranscribe || Boolean(this.options.speechAnalyzer),
+      speechTranscribe,
+      speechVad,
+      speechCapability: speechTranscribe
+        ? speechVad ? "transcription-plus-vad" as const : "transcription-only" as const
+        : "unavailable" as const,
       audioLoudness: capabilities.analyzers.audioLoudness || Boolean(this.options.audioAnalyzer),
       audioNoise: capabilities.analyzers.audioNoise || Boolean(this.options.noiseAnalyzer),
       visualTrack: capabilities.analyzers.visualTrack || Boolean(this.options.visualAnalyzer),

--- a/packages/runtime/src/domain/capabilities.ts
+++ b/packages/runtime/src/domain/capabilities.ts
@@ -52,6 +52,7 @@ export interface EditorCapabilities {
 export interface AnalyzerCapabilities {
   speechTranscribe: boolean;
   speechVad: boolean;
+  speechCapability?: "unavailable" | "transcription-only" | "transcription-plus-vad";
   audioLoudness: boolean;
   audioNoise?: boolean;
   visualTrack: boolean;

--- a/packages/runtime/src/domain/media.ts
+++ b/packages/runtime/src/domain/media.ts
@@ -21,6 +21,10 @@ export interface SpeechSegment {
   confidence?: number;
 }
 
+export const SPEECH_ANALYSIS_SCHEMA_VERSION = 1 as const;
+
+export type SpeechAnalysisCapability = "transcription-only" | "transcription-plus-vad";
+
 export type MediaAnalysisCapability = "metadata" | "speech" | "audio" | "noise" | "visual";
 
 export interface SemanticTag {
@@ -134,10 +138,31 @@ export interface RoughCutPlan {
 }
 
 export interface SpeechAnalysis {
+  /** Provenance fields are optional for backwards-compatible provider ports. */
+  mediaId?: string;
+  sourceIdentity?: MediaSourceIdentity;
+  requestedRange?: TimeRange;
+  observedRange?: TimeRange;
+  revision?: ContextRevision;
+  provider?: AnalyzerDescriptor;
+  sourceTimebase?: RationalTime;
+  capability?: SpeechAnalysisCapability;
   words: SpeechWord[];
   vadSegments?: SpeechSegment[];
   silenceSegments?: SpeechSegment[];
   protectedSegments?: SpeechSegment[];
+}
+
+/** Speech evidence that is safe to use for a specific editor revision. */
+export interface RevisionBoundSpeechAnalysis extends SpeechAnalysis {
+  mediaId: string;
+  sourceIdentity: MediaSourceIdentity;
+  requestedRange: TimeRange;
+  observedRange: TimeRange;
+  revision: ContextRevision;
+  provider: AnalyzerDescriptor;
+  sourceTimebase: RationalTime;
+  capability: SpeechAnalysisCapability;
 }
 
 export interface AudioAnalysis {

--- a/packages/runtime/src/domain/media.ts
+++ b/packages/runtime/src/domain/media.ts
@@ -144,6 +144,7 @@ export interface RoughCutPlan {
 
 export interface SpeechAnalysis {
   /** Provenance fields are optional for backwards-compatible provider ports. */
+  schemaVersion?: typeof SPEECH_ANALYSIS_SCHEMA_VERSION;
   mediaId?: string;
   sourceIdentity?: MediaSourceIdentity;
   requestedRange?: TimeRange;
@@ -160,6 +161,7 @@ export interface SpeechAnalysis {
 
 /** Speech evidence that is safe to use for a specific editor revision. */
 export interface RevisionBoundSpeechAnalysis extends SpeechAnalysis {
+  schemaVersion: typeof SPEECH_ANALYSIS_SCHEMA_VERSION;
   mediaId: string;
   sourceIdentity: MediaSourceIdentity;
   requestedRange: TimeRange;

--- a/packages/runtime/src/domain/media.ts
+++ b/packages/runtime/src/domain/media.ts
@@ -25,6 +25,11 @@ export const SPEECH_ANALYSIS_SCHEMA_VERSION = 1 as const;
 
 export type SpeechAnalysisCapability = "transcription-only" | "transcription-plus-vad";
 
+export interface SpeechAnalyzerCapabilities {
+  transcription: boolean;
+  vad: boolean;
+}
+
 export type MediaAnalysisCapability = "metadata" | "speech" | "audio" | "noise" | "visual";
 
 export interface SemanticTag {
@@ -311,6 +316,7 @@ export interface AnalysisInput {
 export interface SpeechAnalyzer {
   analyze(input: AnalysisInput, range?: TimeRange): Promise<SpeechAnalysis>;
   readonly descriptor?: AnalyzerDescriptor;
+  readonly capabilities?: SpeechAnalyzerCapabilities;
 }
 
 export interface AudioAnalyzer {

--- a/packages/runtime/src/domain/project.ts
+++ b/packages/runtime/src/domain/project.ts
@@ -20,6 +20,9 @@ export interface Clip {
   name: string;
   start: number;
   duration: number;
+  /** Source-media start for trimmed occurrences; absent means zero. */
+  sourceStart?: number;
+  sourceStartTime?: RationalTime;
   track: number;
   gainDb?: number;
   noiseReductionDb?: number;

--- a/packages/runtime/src/editing/filler-removal-service.ts
+++ b/packages/runtime/src/editing/filler-removal-service.ts
@@ -12,7 +12,7 @@ import type {
   FillerRemovalTarget,
 } from "../speech/filler-removal.js";
 import { sameRevision } from "../context/revision.js";
-import { translateRationalRange } from "../timeline/rational-time.js";
+import { subtractRationalTimes, translateRationalRange } from "../timeline/rational-time.js";
 import { canonicalSnapshotDigest } from "../timeline/snapshot-digest.js";
 import { planFillerRemoval } from "../speech/filler-removal.js";
 import { bindSpeechAnalysis } from "../speech/analysis.js";
@@ -59,18 +59,23 @@ export class FillerRemovalService {
         end: Math.min(clip.duration, selectedRange.end - clip.start),
       };
       if (localRange.end <= localRange.start) continue;
+      const sourceStart = clip.sourceStart ?? 0;
+      const sourceRange = {
+        start: sourceStart + localRange.start,
+        end: sourceStart + localRange.end,
+      };
       const speech = bindSpeechAnalysis(
-        await this.options.speechAnalyzer!.analyze({ project: before, media }, localRange),
-        { input: { project: before, media }, range: localRange, provider: this.options.speechAnalyzer!.descriptor },
+        await this.options.speechAnalyzer!.analyze({ project: before, media }, sourceRange),
+        { input: { project: before, media }, range: sourceRange, provider: this.options.speechAnalyzer!.descriptor },
       );
-      analysisRangesByClip.set(clip.id, structuredClone(localRange));
-      for (const candidate of planFillerRemoval(speech.words, localRange, request)) {
+      analysisRangesByClip.set(clip.id, structuredClone(sourceRange));
+      for (const candidate of planFillerRemoval(speech.words, sourceRange, request)) {
         candidates.push({
           ...candidate,
           clipId: clip.id,
           mediaId: clip.mediaId,
           sourceRange: structuredClone(candidate.range),
-          range: translateRationalRange(clip.startTime, clip.start, candidate.range),
+          range: translateSourceRangeToSequence(clip, candidate.range),
         });
       }
     }
@@ -355,7 +360,7 @@ function verifyFillerSpeechContinuity(
       if (expected.text.trim().toLowerCase() !== actual.text.trim().toLowerCase()
         || Math.abs(expected.start - actual.start) > 0.02
         || Math.abs(expected.end - actual.end) > 0.02
-        || actual.end > afterClip.duration + 0.02) {
+        || actual.end > (afterClip.sourceStart ?? 0) + afterClip.duration + 0.02) {
         return {
           name: "filler-speech-continuity",
           passed: false,
@@ -373,4 +378,39 @@ function verifyFillerSpeechContinuity(
 
 function sameSpeechWord(left: SpeechWord, right: SpeechWord): boolean {
   return left.text === right.text && left.start === right.start && left.end === right.end;
+}
+
+function translateSourceRangeToSequence(clip: ProjectSnapshot["timeline"]["clips"][number], sourceRange: TimeRange): TimeRange {
+  if (!sourceRange.startTime || !sourceRange.durationTime) {
+    throw new Error("ANALYSIS_INVALID: filler range is missing rational timing");
+  }
+  const sourceStart = clip.sourceStart ?? 0;
+  const sourceStartTime = clip.sourceStartTime ?? secondsToRational(sourceStart);
+  return translateRationalRange(clip.startTime, clip.start, {
+    start: sourceRange.start - sourceStart,
+    end: sourceRange.end - sourceStart,
+    startTime: subtractRationalTimes(sourceRange.startTime, sourceStartTime),
+    durationTime: { ...sourceRange.durationTime },
+  });
+}
+
+function secondsToRational(seconds: number): { value: string; timescale: string } {
+  const text = seconds.toFixed(6).replace(/0+$/, "").replace(/\.$/, "");
+  if (!text.includes(".")) return { value: text || "0", timescale: "1" };
+  const [whole, fraction = ""] = text.split(".");
+  let numerator = BigInt(`${whole}${fraction}`);
+  let denominator = 10n ** BigInt(fraction.length);
+  const divisor = greatestCommonDivisor(numerator < 0n ? -numerator : numerator, denominator);
+  numerator /= divisor;
+  denominator /= divisor;
+  return { value: String(numerator), timescale: String(denominator) };
+}
+
+function greatestCommonDivisor(left: bigint, right: bigint): bigint {
+  while (right !== 0n) {
+    const remainder = left % right;
+    left = right;
+    right = remainder;
+  }
+  return left || 1n;
 }

--- a/packages/runtime/src/editing/filler-removal-service.ts
+++ b/packages/runtime/src/editing/filler-removal-service.ts
@@ -15,6 +15,7 @@ import { sameRevision } from "../context/revision.js";
 import { translateRationalRange } from "../timeline/rational-time.js";
 import { canonicalSnapshotDigest } from "../timeline/snapshot-digest.js";
 import { planFillerRemoval } from "../speech/filler-removal.js";
+import { bindSpeechAnalysis } from "../speech/analysis.js";
 import { ProjectService } from "../application/project-service.js";
 import type { RuntimeOptions } from "../application/runtime-options.js";
 import { TransactionStore } from "../application/transaction-store.js";
@@ -58,7 +59,10 @@ export class FillerRemovalService {
         end: Math.min(clip.duration, selectedRange.end - clip.start),
       };
       if (localRange.end <= localRange.start) continue;
-      const speech = await this.options.speechAnalyzer!.analyze({ project: before, media }, localRange);
+      const speech = bindSpeechAnalysis(
+        await this.options.speechAnalyzer!.analyze({ project: before, media }, localRange),
+        { input: { project: before, media }, range: localRange, provider: this.options.speechAnalyzer!.descriptor },
+      );
       analysisRangesByClip.set(clip.id, structuredClone(localRange));
       for (const candidate of planFillerRemoval(speech.words, localRange, request)) {
         candidates.push({
@@ -216,9 +220,9 @@ export class FillerRemovalService {
         analysisRange,
         deletes,
       );
-      const speech = await this.options.speechAnalyzer!.analyze(
-        { project: next, media },
-        postEditRange,
+      const speech = bindSpeechAnalysis(
+        await this.options.speechAnalyzer!.analyze({ project: next, media }, postEditRange),
+        { input: { project: next, media }, range: postEditRange, provider: this.options.speechAnalyzer!.descriptor },
       );
       const retainedWords = transaction.before.media
         .find((candidate) => candidate.mediaId === beforeClip.mediaId)
@@ -227,6 +231,7 @@ export class FillerRemovalService {
         .filter((word) => !fillerCandidates.some((candidate) => sameSpeechWord(word, candidate.word)))
         .map((word) => translateSpeechWordAfterDeletes(word, deletes));
       media.speech = {
+        ...speech,
         words: [
           ...translatedRetainedWords.filter((word) => !rangesOverlap(
             word.start,

--- a/packages/runtime/src/editing/filler-removal-service.ts
+++ b/packages/runtime/src/editing/filler-removal-service.ts
@@ -12,10 +12,10 @@ import type {
   FillerRemovalTarget,
 } from "../speech/filler-removal.js";
 import { sameRevision } from "../context/revision.js";
-import { subtractRationalTimes, translateRationalRange } from "../timeline/rational-time.js";
 import { canonicalSnapshotDigest } from "../timeline/snapshot-digest.js";
 import { planFillerRemoval } from "../speech/filler-removal.js";
 import { bindSpeechAnalysis } from "../speech/analysis.js";
+import { mapSourceRangeToSequenceRange } from "../speech/mapping.js";
 import { ProjectService } from "../application/project-service.js";
 import type { RuntimeOptions } from "../application/runtime-options.js";
 import { TransactionStore } from "../application/transaction-store.js";
@@ -381,36 +381,19 @@ function sameSpeechWord(left: SpeechWord, right: SpeechWord): boolean {
 }
 
 function translateSourceRangeToSequence(clip: ProjectSnapshot["timeline"]["clips"][number], sourceRange: TimeRange): TimeRange {
-  if (!sourceRange.startTime || !sourceRange.durationTime) {
-    throw new Error("ANALYSIS_INVALID: filler range is missing rational timing");
-  }
   const sourceStart = clip.sourceStart ?? 0;
-  const sourceStartTime = clip.sourceStartTime ?? secondsToRational(sourceStart);
-  return translateRationalRange(clip.startTime, clip.start, {
-    start: sourceRange.start - sourceStart,
-    end: sourceRange.end - sourceStart,
-    startTime: subtractRationalTimes(sourceRange.startTime, sourceStartTime),
-    durationTime: { ...sourceRange.durationTime },
+  return mapSourceRangeToSequenceRange(sourceRange, {
+    sourceRange: {
+      start: sourceStart,
+      end: sourceStart + clip.duration,
+      startTime: clip.sourceStartTime,
+      durationTime: clip.durationTime,
+    },
+    sequenceRange: {
+      start: clip.start,
+      end: clip.start + clip.duration,
+      startTime: clip.startTime,
+      durationTime: clip.durationTime,
+    },
   });
-}
-
-function secondsToRational(seconds: number): { value: string; timescale: string } {
-  const text = seconds.toFixed(6).replace(/0+$/, "").replace(/\.$/, "");
-  if (!text.includes(".")) return { value: text || "0", timescale: "1" };
-  const [whole, fraction = ""] = text.split(".");
-  let numerator = BigInt(`${whole}${fraction}`);
-  let denominator = 10n ** BigInt(fraction.length);
-  const divisor = greatestCommonDivisor(numerator < 0n ? -numerator : numerator, denominator);
-  numerator /= divisor;
-  denominator /= divisor;
-  return { value: String(numerator), timescale: String(denominator) };
-}
-
-function greatestCommonDivisor(left: bigint, right: bigint): bigint {
-  while (right !== 0n) {
-    const remainder = left % right;
-    left = right;
-    right = remainder;
-  }
-  return left || 1n;
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -16,3 +16,4 @@ export * from "./skills/index.js";
 export type { RuntimeOptions } from "./application/runtime-options.js";
 export * from "./speech/filler-detector.js";
 export * from "./speech/safe-cut-resolver.js";
+export * from "./speech/analysis.js";

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -17,3 +17,4 @@ export type { RuntimeOptions } from "./application/runtime-options.js";
 export * from "./speech/filler-detector.js";
 export * from "./speech/safe-cut-resolver.js";
 export * from "./speech/analysis.js";
+export * from "./speech/mapping.js";

--- a/packages/runtime/src/runtime.ts
+++ b/packages/runtime/src/runtime.ts
@@ -256,8 +256,8 @@ export class AgentVideoRuntime {
     return this.contexts.contextChangesSince(revision, waitMs);
   }
 
-  public async analyzeSpeech(mediaId: string): Promise<SpeechAnalysis> {
-    return this.media.analyzeSpeech(mediaId);
+  public async analyzeSpeech(mediaId: string, range?: TimeRange): Promise<SpeechAnalysis> {
+    return this.media.analyzeSpeech(mediaId, range);
   }
 
   public async analyzeAudio(mediaId: string): Promise<AudioAnalysis> {

--- a/packages/runtime/src/speech/analysis.ts
+++ b/packages/runtime/src/speech/analysis.ts
@@ -1,3 +1,4 @@
+import { SPEECH_ANALYSIS_SCHEMA_VERSION } from "../domain/media.js";
 import type {
   AnalysisInput,
   AnalyzerDescriptor,
@@ -33,6 +34,9 @@ export function bindSpeechAnalysis(
   context: SpeechBindingContext,
 ): RevisionBoundSpeechAnalysis {
   const record = asRecord(value, "speech result must be an object");
+  if (record.schemaVersion !== undefined && record.schemaVersion !== SPEECH_ANALYSIS_SCHEMA_VERSION) {
+    throw new Error("ANALYSIS_INVALID: unsupported speech analysis schema version");
+  }
   const inputIdentity = sourceIdentityOf(context.input.media);
   const mediaId = optionalString(record.mediaId, "speech media ID");
   if (mediaId !== undefined && mediaId !== inputIdentity.mediaId) {
@@ -65,6 +69,7 @@ export function bindSpeechAnalysis(
     : validateSourceTimebase(record.sourceTimebase);
 
   return {
+    schemaVersion: SPEECH_ANALYSIS_SCHEMA_VERSION,
     mediaId: inputIdentity.mediaId,
     sourceIdentity: structuredClone(sourceIdentity),
     requestedRange: structuredClone(requestedRange),

--- a/packages/runtime/src/speech/analysis.ts
+++ b/packages/runtime/src/speech/analysis.ts
@@ -255,9 +255,15 @@ function validateSourceIdentity(value: unknown, expected: MediaSourceIdentity): 
   const candidate: MediaSourceIdentity = {
     mediaId: identity.mediaId,
     source: identity.source,
-    ...(identity.sourceDigest !== undefined ? { sourceDigest: optionalString(identity.sourceDigest, "speech source digest") } : {}),
-    ...(identity.mediaKind !== undefined ? { mediaKind: identity.mediaKind as MediaSourceIdentity["mediaKind"] } : {}),
-    ...(identity.duration !== undefined ? { duration: numberValue(identity.duration, "speech source duration") } : {}),
+    ...(identity.sourceDigest !== undefined
+      ? { sourceDigest: optionalString(identity.sourceDigest, "speech source digest") }
+      : expected.sourceDigest !== undefined ? { sourceDigest: expected.sourceDigest } : {}),
+    ...(identity.mediaKind !== undefined
+      ? { mediaKind: identity.mediaKind as MediaSourceIdentity["mediaKind"] }
+      : expected.mediaKind !== undefined ? { mediaKind: expected.mediaKind } : {}),
+    ...(identity.duration !== undefined
+      ? { duration: numberValue(identity.duration, "speech source duration") }
+      : expected.duration !== undefined ? { duration: expected.duration } : {}),
   };
   if (!sameMediaSourceIdentity(candidate, expected)) {
     throw new Error("TARGET_MISMATCH: speech analysis source identity does not match the requested media");

--- a/packages/runtime/src/speech/analysis.ts
+++ b/packages/runtime/src/speech/analysis.ts
@@ -56,9 +56,9 @@ export function bindSpeechAnalysis(
   validateObservedRange(observedRange, requestedRange, context.input.media.duration);
 
   const words = validateWords(record.words, observedRange, context.input.media.duration);
-  const vadSegments = validateOptionalSegments(record.vadSegments, "VAD");
-  const silenceSegments = validateOptionalSegments(record.silenceSegments, "silence");
-  const protectedSegments = validateOptionalSegments(record.protectedSegments, "protected");
+  const vadSegments = validateOptionalSegments(record.vadSegments, "VAD", observedRange, context.input.media.duration);
+  const silenceSegments = validateOptionalSegments(record.silenceSegments, "silence", observedRange, context.input.media.duration);
+  const protectedSegments = validateOptionalSegments(record.protectedSegments, "protected", observedRange, context.input.media.duration);
   const capability = validateCapability(record.capability, vadSegments);
   const sourceTimebase = record.sourceTimebase === undefined
     ? structuredClone(DEFAULT_SPEECH_SOURCE_TIMEBASE)
@@ -164,11 +164,17 @@ function validateWord(value: unknown, index: number): SpeechWord {
   };
 }
 
-function validateOptionalSegments(value: unknown, label: string): SpeechSegment[] | undefined {
+function validateOptionalSegments(
+  value: unknown,
+  label: string,
+  observed: TimeRange,
+  duration: number | undefined,
+): SpeechSegment[] | undefined {
   if (value === undefined) return undefined;
   if (!Array.isArray(value)) throw new Error(`ANALYSIS_INVALID: ${label} segments must be an array`);
   const segments = value.map((entry, index) => validateSegment(entry, index, label));
   validateOrderedRanges(segments, `${label} segments`);
+  validateEvidenceBounds(segments, observed, duration, `${label} segment`);
   return segments;
 }
 

--- a/packages/runtime/src/speech/analysis.ts
+++ b/packages/runtime/src/speech/analysis.ts
@@ -96,7 +96,13 @@ function resolveRequestedRange(
   media: AnalysisInput["media"],
   record: Record<string, unknown>,
 ): TimeRange {
-  if (result !== undefined) return validateRange(result, "requested speech range");
+  if (result !== undefined) {
+    const resultRange = validateRange(result, "requested speech range");
+    if (requested && (resultRange.start !== requested.start || resultRange.end !== requested.end)) {
+      throw new Error("ANALYSIS_INVALID: speech requested range does not match the runtime request");
+    }
+    return resultRange;
+  }
   if (requested) return structuredClone(requested);
   if (media.duration !== undefined) return { start: 0, end: media.duration };
   const evidenceEnd = evidenceMaximumEnd(record);
@@ -119,8 +125,8 @@ function evidenceMaximumEnd(record: Record<string, unknown>): number {
 }
 
 function validateObservedRange(observed: TimeRange, requested: TimeRange, duration: number | undefined): void {
-  if (observed.start > requested.start || observed.end < requested.end) {
-    throw new Error("ANALYSIS_INVALID: observed speech range does not cover the requested range");
+  if (observed.end <= requested.start || observed.start >= requested.end) {
+    throw new Error("ANALYSIS_INVALID: observed speech range does not overlap the requested range");
   }
   if (duration !== undefined && observed.end > duration) {
     throw new Error("ANALYSIS_INVALID: observed speech range exceeds media duration");

--- a/packages/runtime/src/speech/analysis.ts
+++ b/packages/runtime/src/speech/analysis.ts
@@ -1,0 +1,327 @@
+import type {
+  AnalysisInput,
+  AnalyzerDescriptor,
+  MediaSourceIdentity,
+  RevisionBoundSpeechAnalysis,
+  SpeechAnalysis,
+  SpeechAnalysisCapability,
+  SpeechSegment,
+  SpeechWord,
+} from "../domain/media.js";
+import { sameMediaSourceIdentity } from "../domain/media.js";
+import type { RationalTime, TimeRange } from "../domain/primitives.js";
+import { parseRational } from "../timeline/rational-time.js";
+
+export const DEFAULT_SPEECH_SOURCE_TIMEBASE: RationalTime = {
+  value: "1",
+  timescale: "1000",
+};
+
+export interface SpeechBindingContext {
+  input: AnalysisInput;
+  provider?: AnalyzerDescriptor;
+  range?: TimeRange;
+}
+
+/**
+ * Validate provider evidence and bind it to the current source and revision.
+ * Missing provenance is filled from the trusted runtime request; conflicting
+ * provenance is rejected before the evidence can authorize an edit.
+ */
+export function bindSpeechAnalysis(
+  value: unknown,
+  context: SpeechBindingContext,
+): RevisionBoundSpeechAnalysis {
+  const record = asRecord(value, "speech result must be an object");
+  const inputIdentity = sourceIdentityOf(context.input.media);
+  const mediaId = optionalString(record.mediaId, "speech media ID");
+  if (mediaId !== undefined && mediaId !== inputIdentity.mediaId) {
+    throw new Error("TARGET_MISMATCH: speech analysis media identity does not match the requested media");
+  }
+
+  const sourceIdentity = record.sourceIdentity === undefined
+    ? inputIdentity
+    : validateSourceIdentity(record.sourceIdentity, inputIdentity);
+  const revision = record.revision === undefined
+    ? structuredClone(context.input.project.revision)
+    : validateRevision(record.revision, context.input.project.revision);
+  const provider = record.provider === undefined
+    ? context.provider ?? { id: "framekit.speech", provider: "unknown" }
+    : validateDescriptor(record.provider);
+  const requestedRange = resolveRequestedRange(record.requestedRange, context.range, context.input.media, record);
+  const observedRange = record.observedRange === undefined
+    ? structuredClone(requestedRange)
+    : validateRange(record.observedRange, "observed speech range");
+  validateRange(requestedRange, "requested speech range");
+  validateObservedRange(observedRange, requestedRange, context.input.media.duration);
+
+  const words = validateWords(record.words, observedRange, context.input.media.duration);
+  const vadSegments = validateOptionalSegments(record.vadSegments, "VAD");
+  const silenceSegments = validateOptionalSegments(record.silenceSegments, "silence");
+  const protectedSegments = validateOptionalSegments(record.protectedSegments, "protected");
+  const capability = validateCapability(record.capability, vadSegments);
+  const sourceTimebase = record.sourceTimebase === undefined
+    ? structuredClone(DEFAULT_SPEECH_SOURCE_TIMEBASE)
+    : validateSourceTimebase(record.sourceTimebase);
+
+  return {
+    mediaId: inputIdentity.mediaId,
+    sourceIdentity: structuredClone(sourceIdentity),
+    requestedRange: structuredClone(requestedRange),
+    observedRange: structuredClone(observedRange),
+    revision: structuredClone(revision),
+    provider: structuredClone(provider),
+    sourceTimebase,
+    capability,
+    words,
+    ...(vadSegments ? { vadSegments } : {}),
+    ...(silenceSegments ? { silenceSegments } : {}),
+    ...(protectedSegments ? { protectedSegments } : {}),
+  };
+}
+
+function sourceIdentityOf(media: AnalysisInput["media"]): MediaSourceIdentity {
+  return {
+    mediaId: media.mediaId,
+    source: media.source,
+    ...(media.sourceDigest ? { sourceDigest: media.sourceDigest } : {}),
+    ...(media.mediaKind ? { mediaKind: media.mediaKind } : {}),
+    ...(media.duration !== undefined ? { duration: media.duration } : {}),
+  };
+}
+
+function resolveRequestedRange(
+  result: unknown,
+  requested: TimeRange | undefined,
+  media: AnalysisInput["media"],
+  record: Record<string, unknown>,
+): TimeRange {
+  if (result !== undefined) return validateRange(result, "requested speech range");
+  if (requested) return structuredClone(requested);
+  if (media.duration !== undefined) return { start: 0, end: media.duration };
+  const evidenceEnd = evidenceMaximumEnd(record);
+  if (evidenceEnd <= 0) throw new Error("ANALYSIS_INVALID: speech result needs a range or media duration");
+  return { start: 0, end: evidenceEnd };
+}
+
+function evidenceMaximumEnd(record: Record<string, unknown>): number {
+  const values: number[] = [];
+  for (const key of ["words", "vadSegments", "silenceSegments", "protectedSegments"] as const) {
+    const entries = record[key];
+    if (!Array.isArray(entries)) continue;
+    for (const entry of entries) {
+      if (entry && typeof entry === "object" && typeof (entry as Record<string, unknown>).end === "number") {
+        values.push((entry as Record<string, unknown>).end as number);
+      }
+    }
+  }
+  return values.length > 0 ? Math.max(...values) : 0;
+}
+
+function validateObservedRange(observed: TimeRange, requested: TimeRange, duration: number | undefined): void {
+  if (observed.start > requested.start || observed.end < requested.end) {
+    throw new Error("ANALYSIS_INVALID: observed speech range does not cover the requested range");
+  }
+  if (duration !== undefined && observed.end > duration) {
+    throw new Error("ANALYSIS_INVALID: observed speech range exceeds media duration");
+  }
+}
+
+function validateWords(value: unknown, observed: TimeRange, duration: number | undefined): SpeechWord[] {
+  if (!Array.isArray(value)) throw new Error("ANALYSIS_INVALID: speech result requires typed words");
+  const words = value.map((entry, index) => validateWord(entry, index));
+  validateOrderedRanges(words, "speech words");
+  validateEvidenceBounds(words, observed, duration, "speech word");
+  return words;
+}
+
+function validateWord(value: unknown, index: number): SpeechWord {
+  const word = asRecord(value, `speech word ${index + 1} must be an object`);
+  if (typeof word.text !== "string" || !word.text.trim()) {
+    throw new Error("ANALYSIS_INVALID: speech word text is required");
+  }
+  if (!isFiniteNumber(word.start) || !isFiniteNumber(word.end) || word.start < 0 || word.end <= word.start) {
+    throw new Error("ANALYSIS_INVALID: speech word boundaries are invalid");
+  }
+  if (!isFiniteNumber(word.confidence) || word.confidence < 0 || word.confidence > 1) {
+    throw new Error("ANALYSIS_INVALID: speech word confidence is invalid");
+  }
+  if (word.filler !== undefined && typeof word.filler !== "boolean") {
+    throw new Error("ANALYSIS_INVALID: speech word filler flag is invalid");
+  }
+  return {
+    text: word.text,
+    start: word.start,
+    end: word.end,
+    confidence: word.confidence,
+    ...(word.filler !== undefined ? { filler: word.filler } : {}),
+  };
+}
+
+function validateOptionalSegments(value: unknown, label: string): SpeechSegment[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) throw new Error(`ANALYSIS_INVALID: ${label} segments must be an array`);
+  const segments = value.map((entry, index) => validateSegment(entry, index, label));
+  validateOrderedRanges(segments, `${label} segments`);
+  return segments;
+}
+
+function validateSegment(value: unknown, index: number, label: string): SpeechSegment {
+  const segment = asRecord(value, `${label} segment ${index + 1} must be an object`);
+  if (!isFiniteNumber(segment.start) || !isFiniteNumber(segment.end)
+    || segment.start < 0 || segment.end <= segment.start) {
+    throw new Error(`ANALYSIS_INVALID: ${label} segment boundaries are invalid`);
+  }
+  if (!["speech", "silence", "breath", "laughter", "noise"].includes(String(segment.kind))) {
+    throw new Error(`ANALYSIS_INVALID: ${label} segment kind is invalid`);
+  }
+  if (segment.confidence !== undefined
+    && (!isFiniteNumber(segment.confidence) || segment.confidence < 0 || segment.confidence > 1)) {
+    throw new Error(`ANALYSIS_INVALID: ${label} segment confidence is invalid`);
+  }
+  return {
+    start: segment.start,
+    end: segment.end,
+    kind: segment.kind as SpeechSegment["kind"],
+    ...(segment.confidence !== undefined ? { confidence: segment.confidence } : {}),
+  };
+}
+
+function validateEvidenceBounds(
+  evidence: Array<{ start: number; end: number }>,
+  observed: TimeRange,
+  duration: number | undefined,
+  label: string,
+): void {
+  for (const entry of evidence) {
+    if (entry.start < observed.start || entry.end > observed.end) {
+      throw new Error(`ANALYSIS_INVALID: ${label} is outside observed speech range`);
+    }
+    if (duration !== undefined && entry.end > duration) {
+      throw new Error(`ANALYSIS_INVALID: ${label} exceeds media duration`);
+    }
+  }
+}
+
+function validateOrderedRanges(evidence: Array<{ start: number; end: number }>, label: string): void {
+  for (let index = 1; index < evidence.length; index += 1) {
+    const previous = evidence[index - 1]!;
+    const current = evidence[index]!;
+    if (current.start < previous.start || (current.start === previous.start && current.end < previous.end)) {
+      throw new Error(`ANALYSIS_INVALID: ${label} must be ordered`);
+    }
+    if (current.start < previous.end) {
+      throw new Error(`ANALYSIS_INVALID: ${label} overlap`);
+    }
+  }
+}
+
+function validateCapability(value: unknown, vadSegments: SpeechSegment[] | undefined): SpeechAnalysisCapability {
+  const capability = value ?? (vadSegments ? "transcription-plus-vad" : "transcription-only");
+  if (capability !== "transcription-only" && capability !== "transcription-plus-vad") {
+    throw new Error("ANALYSIS_INVALID: speech capability is unsupported");
+  }
+  if (capability === "transcription-plus-vad" && !vadSegments) {
+    throw new Error("ANALYSIS_INVALID: transcription-plus-vad requires VAD segments");
+  }
+  if (capability === "transcription-only" && vadSegments) {
+    throw new Error("ANALYSIS_INVALID: VAD evidence requires transcription-plus-vad capability");
+  }
+  return capability;
+}
+
+function validateSourceIdentity(value: unknown, expected: MediaSourceIdentity): MediaSourceIdentity {
+  const identity = asRecord(value, "speech source identity must be an object");
+  if (typeof identity.mediaId !== "string" || typeof identity.source !== "string") {
+    throw new Error("ANALYSIS_INVALID: speech source identity is incomplete");
+  }
+  const candidate: MediaSourceIdentity = {
+    mediaId: identity.mediaId,
+    source: identity.source,
+    ...(identity.sourceDigest !== undefined ? { sourceDigest: optionalString(identity.sourceDigest, "speech source digest") } : {}),
+    ...(identity.mediaKind !== undefined ? { mediaKind: identity.mediaKind as MediaSourceIdentity["mediaKind"] } : {}),
+    ...(identity.duration !== undefined ? { duration: numberValue(identity.duration, "speech source duration") } : {}),
+  };
+  if (!sameMediaSourceIdentity(candidate, expected)) {
+    throw new Error("TARGET_MISMATCH: speech analysis source identity does not match the requested media");
+  }
+  return candidate;
+}
+
+function validateRevision(value: unknown, expected: AnalysisInput["project"]["revision"]): AnalysisInput["project"]["revision"] {
+  const revision = asRecord(value, "speech revision must be an object");
+  if (typeof revision.id !== "string" || !Number.isInteger(revision.sequence) || typeof revision.timestamp !== "string") {
+    throw new Error("ANALYSIS_INVALID: speech revision is incomplete");
+  }
+  if (revision.id !== expected.id || revision.sequence !== expected.sequence || revision.timestamp !== expected.timestamp) {
+    throw new Error("STALE_CONTEXT: speech analysis revision does not match the current editor state");
+  }
+  return { id: revision.id, sequence: revision.sequence, timestamp: revision.timestamp };
+}
+
+function validateDescriptor(value: unknown): AnalyzerDescriptor {
+  const descriptor = asRecord(value, "speech provider must be an object");
+  if (typeof descriptor.id !== "string" || !descriptor.id.trim() || typeof descriptor.provider !== "string" || !descriptor.provider.trim()) {
+    throw new Error("ANALYSIS_INVALID: speech provider descriptor is incomplete");
+  }
+  if (descriptor.version !== undefined && typeof descriptor.version !== "string") {
+    throw new Error("ANALYSIS_INVALID: speech provider version is invalid");
+  }
+  return {
+    id: descriptor.id,
+    provider: descriptor.provider,
+    ...(descriptor.version !== undefined ? { version: descriptor.version } : {}),
+  };
+}
+
+function validateSourceTimebase(value: unknown): RationalTime {
+  const timebase = asRecord(value, "speech source timebase must be an object") as Partial<RationalTime>;
+  if (typeof timebase.value !== "string" || typeof timebase.timescale !== "string") {
+    throw new Error("ANALYSIS_INVALID: speech source timebase is incomplete");
+  }
+  const parsed = parseRational({ value: timebase.value, timescale: timebase.timescale }, "ANALYSIS_INVALID");
+  if (parsed.value <= 0n) throw new Error("ANALYSIS_INVALID: speech source timebase must be positive");
+  return { value: timebase.value, timescale: timebase.timescale };
+}
+
+function validateRange(value: unknown, label: string): TimeRange {
+  const range = asRecord(value, `${label} must be an object`);
+  if (!isFiniteNumber(range.start) || !isFiniteNumber(range.end) || range.start < 0 || range.end <= range.start) {
+    throw new Error(`ANALYSIS_INVALID: ${label} is invalid`);
+  }
+  return {
+    start: range.start,
+    end: range.end,
+    ...(range.startTime !== undefined ? { startTime: validateRational(range.startTime, `${label} start time`) } : {}),
+    ...(range.durationTime !== undefined ? { durationTime: validateRational(range.durationTime, `${label} duration time`) } : {}),
+  };
+}
+
+function validateRational(value: unknown, label: string): RationalTime {
+  const rational = asRecord(value, `${label} must be an object`);
+  if (typeof rational.value !== "string" || typeof rational.timescale !== "string") {
+    throw new Error(`ANALYSIS_INVALID: ${label} is incomplete`);
+  }
+  parseRational({ value: rational.value, timescale: rational.timescale }, "ANALYSIS_INVALID");
+  return { value: rational.value, timescale: rational.timescale };
+}
+
+function optionalString(value: unknown, label: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || !value.trim()) throw new Error(`ANALYSIS_INVALID: ${label} is invalid`);
+  return value;
+}
+
+function numberValue(value: unknown, label: string): number {
+  if (!isFiniteNumber(value)) throw new Error(`ANALYSIS_INVALID: ${label} is invalid`);
+  return value;
+}
+
+function asRecord(value: unknown, message: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`ANALYSIS_INVALID: ${message}`);
+  return value as Record<string, unknown>;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}

--- a/packages/runtime/src/speech/mapping.ts
+++ b/packages/runtime/src/speech/mapping.ts
@@ -4,7 +4,7 @@ import type {
   SpeechWord,
 } from "../domain/media.js";
 import type { ContextRevision, RationalTime, TimeRange } from "../domain/primitives.js";
-import { addRationalTimes, parseRational } from "../timeline/rational-time.js";
+import { addRationalTimes, parseRational, subtractRationalTimes } from "../timeline/rational-time.js";
 
 export interface SpeechOccurrence {
   occurrenceId: string;
@@ -78,7 +78,7 @@ export function mapSpeechAnalysisToOccurrence(
   if (Math.abs(sourceDuration - sequenceDuration) > 0.000000001) {
     throw new Error("AMBIGUOUS_MAPPING: source and sequence occurrence durations differ");
   }
-  const sequenceStartTime = validateSequenceRationalRange(occurrence.sequenceRange);
+  validateSequenceRationalRange(occurrence.sequenceRange);
 
   return {
     occurrenceId: occurrence.occurrenceId,
@@ -89,23 +89,41 @@ export function mapSpeechAnalysisToOccurrence(
     sourceTimebase,
     sequenceFrameDuration: frame,
     capability: analysis.capability,
-    words: mapEvidence(analysis.words, occurrence, sequenceStartTime, frame, "speech word", (word) => word),
+    words: mapEvidence(analysis.words, occurrence, frame, "speech word", (word) => word),
     ...(analysis.vadSegments
-      ? { vadSegments: mapEvidence(analysis.vadSegments, occurrence, sequenceStartTime, frame, "VAD segment", (segment) => segment) }
+      ? { vadSegments: mapEvidence(analysis.vadSegments, occurrence, frame, "VAD segment", (segment) => segment) }
       : {}),
     ...(analysis.silenceSegments
-      ? { silenceSegments: mapEvidence(analysis.silenceSegments, occurrence, sequenceStartTime, frame, "silence segment", (segment) => segment) }
+      ? { silenceSegments: mapEvidence(analysis.silenceSegments, occurrence, frame, "silence segment", (segment) => segment) }
       : {}),
     ...(analysis.protectedSegments
-      ? { protectedSegments: mapEvidence(analysis.protectedSegments, occurrence, sequenceStartTime, frame, "protected segment", (segment) => segment) }
+      ? { protectedSegments: mapEvidence(analysis.protectedSegments, occurrence, frame, "protected segment", (segment) => segment) }
       : {}),
   };
+}
+
+/** Map one source range onto an exact timeline occurrence. */
+export function mapSourceRangeToSequenceRange(
+  sourceRange: TimeRange,
+  occurrence: Pick<SpeechOccurrence, "sourceRange" | "sequenceRange">,
+): TimeRange {
+  validateRange(sourceRange, "source range");
+  validateRange(occurrence.sourceRange, "source occurrence range");
+  validateRange(occurrence.sequenceRange, "sequence occurrence range");
+  const sourceDuration = occurrence.sourceRange.end - occurrence.sourceRange.start;
+  const sequenceDuration = occurrence.sequenceRange.end - occurrence.sequenceRange.start;
+  if (Math.abs(sourceDuration - sequenceDuration) > 0.000000001) {
+    throw new Error("AMBIGUOUS_MAPPING: source and sequence occurrence durations differ");
+  }
+  const relation = relationToRange(sourceRange, occurrence.sourceRange);
+  if (relation === "outside") throw new Error("AMBIGUOUS_MAPPING: source range is outside the occurrence");
+  if (relation === "partial") throw new Error("AMBIGUOUS_MAPPING: source range crosses the occurrence boundary");
+  return translateRange(sourceRange, occurrence, validateSequenceRationalRange(occurrence.sequenceRange));
 }
 
 function mapEvidence<T extends { start: number; end: number }, M>(
   evidence: T[],
   occurrence: SpeechOccurrence,
-  sequenceStartTime: RationalTime,
   frame: RationalTime,
   label: string,
   clone: (value: T) => M,
@@ -118,7 +136,7 @@ function mapEvidence<T extends { start: number; end: number }, M>(
       throw new Error(`AMBIGUOUS_MAPPING: ${label} crosses the occurrence source boundary`);
     }
     const sourceRange = { start: value.start, end: value.end };
-    const sequenceRange = translateRange(sourceRange, occurrence, sequenceStartTime);
+    const sequenceRange = mapSourceRangeToSequenceRange(sourceRange, occurrence);
     const frameAlignedRange = alignRange(sequenceRange, frame);
     if (!containsRange(occurrence.sequenceRange, frameAlignedRange)) {
       throw new Error(`AMBIGUOUS_MAPPING: ${label} cannot be frame-aligned inside the occurrence`);
@@ -134,15 +152,21 @@ function mapEvidence<T extends { start: number; end: number }, M>(
   return mapped;
 }
 
-function translateRange(source: TimeRange, occurrence: SpeechOccurrence, sequenceStartTime: RationalTime): TimeRange {
+function translateRange(
+  source: TimeRange,
+  occurrence: Pick<SpeechOccurrence, "sourceRange" | "sequenceRange">,
+  sequenceStartTime: RationalTime,
+): TimeRange {
   const offset = source.start - occurrence.sourceRange.start;
   const duration = source.end - source.start;
-  const startTime = addRationalTimes(sequenceStartTime, secondsToRational(offset));
+  const offsetTime = source.startTime && occurrence.sourceRange.startTime
+    ? subtractRationalTimes(source.startTime, occurrence.sourceRange.startTime)
+    : secondsToRational(offset);
   return {
     start: occurrence.sequenceRange.start + offset,
-    end: occurrence.sequenceRange.start + offset + duration,
-    startTime,
-    durationTime: secondsToRational(duration),
+    end: occurrence.sequenceRange.start + (source.end - occurrence.sourceRange.start),
+    startTime: addRationalTimes(sequenceStartTime, offsetTime),
+    durationTime: source.durationTime ? { ...source.durationTime } : secondsToRational(duration),
   };
 }
 

--- a/packages/runtime/src/speech/mapping.ts
+++ b/packages/runtime/src/speech/mapping.ts
@@ -1,0 +1,268 @@
+import type {
+  RevisionBoundSpeechAnalysis,
+  SpeechSegment,
+  SpeechWord,
+} from "../domain/media.js";
+import type { ContextRevision, RationalTime, TimeRange } from "../domain/primitives.js";
+import { addRationalTimes, parseRational } from "../timeline/rational-time.js";
+
+export interface SpeechOccurrence {
+  occurrenceId: string;
+  mediaId: string;
+  revision: ContextRevision;
+  sourceRange: TimeRange;
+  sequenceRange: TimeRange;
+}
+
+export interface SpeechMappingOptions {
+  sequenceFrameDuration: RationalTime;
+}
+
+export interface MappedSpeechWord {
+  word: SpeechWord;
+  sourceRange: TimeRange;
+  sequenceRange: TimeRange;
+  frameAlignedRange: TimeRange;
+}
+
+export interface MappedSpeechSegment {
+  segment: SpeechSegment;
+  sourceRange: TimeRange;
+  sequenceRange: TimeRange;
+  frameAlignedRange: TimeRange;
+}
+
+export interface SpeechOccurrenceMapping {
+  occurrenceId: string;
+  mediaId: string;
+  revision: ContextRevision;
+  sourceRange: TimeRange;
+  sequenceRange: TimeRange;
+  sourceTimebase: RationalTime;
+  sequenceFrameDuration: RationalTime;
+  capability: RevisionBoundSpeechAnalysis["capability"];
+  words: MappedSpeechWord[];
+  vadSegments?: MappedSpeechSegment[];
+  silenceSegments?: MappedSpeechSegment[];
+  protectedSegments?: MappedSpeechSegment[];
+}
+
+/** Map validated source evidence onto one exact timeline occurrence. */
+export function mapSpeechAnalysisToOccurrence(
+  analysis: RevisionBoundSpeechAnalysis,
+  occurrence: SpeechOccurrence,
+  options: SpeechMappingOptions,
+): SpeechOccurrenceMapping {
+  validateOccurrence(occurrence);
+  if (analysis.mediaId !== occurrence.mediaId) {
+    throw new Error("TARGET_MISMATCH: speech analysis media does not match the timeline occurrence");
+  }
+  if (!sameRevision(analysis.revision, occurrence.revision)) {
+    throw new Error("STALE_CONTEXT: speech analysis revision does not match the timeline occurrence");
+  }
+  if (!analysis.sourceTimebase) {
+    throw new Error("ANALYSIS_INVALID: speech source timebase is required for mapping");
+  }
+  const sourceTimebase = validatePositiveRational(analysis.sourceTimebase, "ANALYSIS_INVALID", "speech source timebase");
+  const frame = validatePositiveRational(options.sequenceFrameDuration, "ANALYSIS_INVALID", "sequence frame duration");
+  const sourceDuration = occurrence.sourceRange.end - occurrence.sourceRange.start;
+  const sequenceDuration = occurrence.sequenceRange.end - occurrence.sequenceRange.start;
+  if (Math.abs(sourceDuration - sequenceDuration) > 0.000000001) {
+    throw new Error("AMBIGUOUS_MAPPING: source and sequence occurrence durations differ");
+  }
+  const sequenceStartTime = validateSequenceRationalRange(occurrence.sequenceRange);
+
+  return {
+    occurrenceId: occurrence.occurrenceId,
+    mediaId: occurrence.mediaId,
+    revision: structuredClone(occurrence.revision),
+    sourceRange: structuredClone(occurrence.sourceRange),
+    sequenceRange: structuredClone(occurrence.sequenceRange),
+    sourceTimebase,
+    sequenceFrameDuration: frame,
+    capability: analysis.capability,
+    words: mapEvidence(analysis.words, occurrence, sequenceStartTime, frame, "speech word", (word) => word),
+    ...(analysis.vadSegments
+      ? { vadSegments: mapEvidence(analysis.vadSegments, occurrence, sequenceStartTime, frame, "VAD segment", (segment) => segment) }
+      : {}),
+    ...(analysis.silenceSegments
+      ? { silenceSegments: mapEvidence(analysis.silenceSegments, occurrence, sequenceStartTime, frame, "silence segment", (segment) => segment) }
+      : {}),
+    ...(analysis.protectedSegments
+      ? { protectedSegments: mapEvidence(analysis.protectedSegments, occurrence, sequenceStartTime, frame, "protected segment", (segment) => segment) }
+      : {}),
+  };
+}
+
+function mapEvidence<T extends { start: number; end: number }, M>(
+  evidence: T[],
+  occurrence: SpeechOccurrence,
+  sequenceStartTime: RationalTime,
+  frame: RationalTime,
+  label: string,
+  clone: (value: T) => M,
+): Array<M extends SpeechWord ? MappedSpeechWord : MappedSpeechSegment> {
+  const mapped: Array<M extends SpeechWord ? MappedSpeechWord : MappedSpeechSegment> = [];
+  for (const value of evidence) {
+    const relation = relationToRange(value, occurrence.sourceRange);
+    if (relation === "outside") continue;
+    if (relation === "partial") {
+      throw new Error(`AMBIGUOUS_MAPPING: ${label} crosses the occurrence source boundary`);
+    }
+    const sourceRange = { start: value.start, end: value.end };
+    const sequenceRange = translateRange(sourceRange, occurrence, sequenceStartTime);
+    const frameAlignedRange = alignRange(sequenceRange, frame);
+    if (!containsRange(occurrence.sequenceRange, frameAlignedRange)) {
+      throw new Error(`AMBIGUOUS_MAPPING: ${label} cannot be frame-aligned inside the occurrence`);
+    }
+    const mappedValue = {
+      ...("text" in value ? { word: clone(value as T) as SpeechWord } : { segment: clone(value as T) as SpeechSegment }),
+      sourceRange,
+      sequenceRange,
+      frameAlignedRange,
+    } as M extends SpeechWord ? MappedSpeechWord : MappedSpeechSegment;
+    mapped.push(mappedValue);
+  }
+  return mapped;
+}
+
+function translateRange(source: TimeRange, occurrence: SpeechOccurrence, sequenceStartTime: RationalTime): TimeRange {
+  const offset = source.start - occurrence.sourceRange.start;
+  const duration = source.end - source.start;
+  const startTime = addRationalTimes(sequenceStartTime, secondsToRational(offset));
+  return {
+    start: occurrence.sequenceRange.start + offset,
+    end: occurrence.sequenceRange.start + offset + duration,
+    startTime,
+    durationTime: secondsToRational(duration),
+  };
+}
+
+function alignRange(range: TimeRange, frame: RationalTime): TimeRange {
+  if (!range.startTime || !range.durationTime) throw new Error("ANALYSIS_INVALID: mapped sequence range is missing rational timing");
+  const start = floorToFrame(range.startTime, frame);
+  const end = ceilToFrame(addRationalTimes(range.startTime, range.durationTime), frame);
+  return {
+    start: rationalToNumber(start),
+    end: rationalToNumber(end),
+    startTime: start,
+    durationTime: subtractRational(end, start),
+  };
+}
+
+function validateOccurrence(occurrence: SpeechOccurrence): void {
+  if (!occurrence.occurrenceId.trim()) throw new Error("ANALYSIS_INVALID: speech occurrence ID is required");
+  if (!occurrence.mediaId.trim()) throw new Error("ANALYSIS_INVALID: speech occurrence media ID is required");
+  validateRange(occurrence.sourceRange, "source occurrence range");
+  validateRange(occurrence.sequenceRange, "sequence occurrence range");
+}
+
+function validateSequenceRationalRange(range: TimeRange): RationalTime {
+  if (!range.startTime || !range.durationTime) {
+    throw new Error("ANALYSIS_INVALID: sequence occurrence requires exact rational timing");
+  }
+  const start = validateRational(range.startTime, "ANALYSIS_INVALID", "sequence occurrence start time");
+  const duration = validatePositiveRational(range.durationTime, "ANALYSIS_INVALID", "sequence occurrence duration time");
+  if (Math.abs(rationalToNumber(start) - range.start) > 0.000000001
+    || Math.abs(rationalToNumber(duration) - (range.end - range.start)) > 0.000000001) {
+    throw new Error("AMBIGUOUS_MAPPING: sequence occurrence seconds and rational timing differ");
+  }
+  return start;
+}
+
+function validateRange(range: TimeRange, label: string): void {
+  if (!Number.isFinite(range.start) || !Number.isFinite(range.end) || range.start < 0 || range.end <= range.start) {
+    throw new Error(`ANALYSIS_INVALID: ${label} is invalid`);
+  }
+}
+
+function validatePositiveRational(value: RationalTime, errorCode: string, label: string): RationalTime {
+  const rational = validateRational(value, errorCode, label);
+  if (parseRational(rational, errorCode).value <= 0n) throw new Error(`${errorCode}: ${label} must be positive`);
+  return rational;
+}
+
+function validateRational(value: RationalTime, errorCode: string, label: string): RationalTime {
+  try {
+    parseRational(value, errorCode);
+  } catch (error) {
+    throw new Error(`${errorCode}: ${label} is invalid: ${String(error)}`);
+  }
+  return { value: value.value, timescale: value.timescale };
+}
+
+function relationToRange(value: { start: number; end: number }, range: TimeRange): "inside" | "outside" | "partial" {
+  if (value.end <= range.start || value.start >= range.end) return "outside";
+  if (value.start >= range.start && value.end <= range.end) return "inside";
+  return "partial";
+}
+
+function containsRange(container: TimeRange, value: TimeRange): boolean {
+  return value.start >= container.start - 0.000000001 && value.end <= container.end + 0.000000001;
+}
+
+function floorToFrame(value: RationalTime, frame: RationalTime): RationalTime {
+  const valueParts = parseRational(value, "ANALYSIS_INVALID");
+  const frameParts = parseRational(frame, "ANALYSIS_INVALID");
+  const numerator = valueParts.value * frameParts.timescale;
+  const denominator = valueParts.timescale * frameParts.value;
+  const quotient = floorDivision(numerator, denominator);
+  return normalizeRational(quotient * frameParts.value, frameParts.timescale);
+}
+
+function ceilToFrame(value: RationalTime, frame: RationalTime): RationalTime {
+  const valueParts = parseRational(value, "ANALYSIS_INVALID");
+  const frameParts = parseRational(frame, "ANALYSIS_INVALID");
+  const numerator = valueParts.value * frameParts.timescale;
+  const denominator = valueParts.timescale * frameParts.value;
+  const quotient = floorDivision(numerator + denominator - 1n, denominator);
+  return normalizeRational(quotient * frameParts.value, frameParts.timescale);
+}
+
+function floorDivision(numerator: bigint, denominator: bigint): bigint {
+  if (numerator >= 0n) return numerator / denominator;
+  return -((-numerator + denominator - 1n) / denominator);
+}
+
+function subtractRational(left: RationalTime, right: RationalTime): RationalTime {
+  const leftParts = parseRational(left, "ANALYSIS_INVALID");
+  const rightParts = parseRational(right, "ANALYSIS_INVALID");
+  return normalizeRational(
+    leftParts.value * rightParts.timescale - rightParts.value * leftParts.timescale,
+    leftParts.timescale * rightParts.timescale,
+  );
+}
+
+function rationalToNumber(value: RationalTime): number {
+  const parts = parseRational(value, "ANALYSIS_INVALID");
+  const result = Number(parts.value) / Number(parts.timescale);
+  if (!Number.isFinite(result)) throw new Error("ANALYSIS_INVALID: rational mapping is outside supported range");
+  return result;
+}
+
+function secondsToRational(seconds: number): RationalTime {
+  const text = seconds.toFixed(6).replace(/0+$/, "").replace(/\.$/, "");
+  if (!text.includes(".")) return { value: text || "0", timescale: "1" };
+  const [whole, fraction = ""] = text.split(".");
+  const numerator = BigInt(`${whole}${fraction}`);
+  const denominator = 10n ** BigInt(fraction.length);
+  return normalizeRational(numerator, denominator);
+}
+
+function normalizeRational(value: bigint, timescale: bigint): RationalTime {
+  const divisor = greatestCommonDivisor(value < 0n ? -value : value, timescale);
+  return { value: String(value / divisor), timescale: String(timescale / divisor) };
+}
+
+function greatestCommonDivisor(left: bigint, right: bigint): bigint {
+  while (right !== 0n) {
+    const remainder = left % right;
+    left = right;
+    right = remainder;
+  }
+  return left || 1n;
+}
+
+function sameRevision(left: ContextRevision, right: ContextRevision): boolean {
+  return left.id === right.id && left.sequence === right.sequence && left.timestamp === right.timestamp;
+}

--- a/packages/runtime/src/speech/mapping.ts
+++ b/packages/runtime/src/speech/mapping.ts
@@ -12,6 +12,8 @@ export interface SpeechOccurrence {
   revision: ContextRevision;
   sourceRange: TimeRange;
   sequenceRange: TimeRange;
+  /** Expected source clock for this occurrence when the editor exposes one. */
+  sourceTimebase?: RationalTime;
 }
 
 export interface SpeechMappingOptions {
@@ -64,6 +66,12 @@ export function mapSpeechAnalysisToOccurrence(
     throw new Error("ANALYSIS_INVALID: speech source timebase is required for mapping");
   }
   const sourceTimebase = validatePositiveRational(analysis.sourceTimebase, "ANALYSIS_INVALID", "speech source timebase");
+  if (occurrence.sourceTimebase !== undefined) {
+    const occurrenceTimebase = validatePositiveRational(occurrence.sourceTimebase, "ANALYSIS_INVALID", "occurrence source timebase");
+    if (!sameRational(sourceTimebase, occurrenceTimebase)) {
+      throw new Error("AMBIGUOUS_MAPPING: speech source timebase does not match the timeline occurrence");
+    }
+  }
   const frame = validatePositiveRational(options.sequenceFrameDuration, "ANALYSIS_INVALID", "sequence frame duration");
   const sourceDuration = occurrence.sourceRange.end - occurrence.sourceRange.start;
   const sequenceDuration = occurrence.sequenceRange.end - occurrence.sequenceRange.start;
@@ -265,4 +273,10 @@ function greatestCommonDivisor(left: bigint, right: bigint): bigint {
 
 function sameRevision(left: ContextRevision, right: ContextRevision): boolean {
   return left.id === right.id && left.sequence === right.sequence && left.timestamp === right.timestamp;
+}
+
+function sameRational(left: RationalTime, right: RationalTime): boolean {
+  const leftParts = parseRational(left, "ANALYSIS_INVALID");
+  const rightParts = parseRational(right, "ANALYSIS_INVALID");
+  return leftParts.value * rightParts.timescale === rightParts.value * leftParts.timescale;
 }

--- a/packages/runtime/src/timeline/rational-time.ts
+++ b/packages/runtime/src/timeline/rational-time.ts
@@ -24,6 +24,15 @@ export function addRationalTimes(left: RationalTime, right: RationalTime, errorC
   );
 }
 
+export function subtractRationalTimes(left: RationalTime, right: RationalTime, errorCode = "ANALYSIS_INVALID"): RationalTime {
+  const leftParts = parseRational(left, errorCode);
+  const rightParts = parseRational(right, errorCode);
+  return normalizeRational(
+    leftParts.value * rightParts.timescale - rightParts.value * leftParts.timescale,
+    leftParts.timescale * rightParts.timescale,
+  );
+}
+
 export function isWithinClip(
   position: RationalParts,
   startTime: RationalTime,

--- a/packages/testkit/src/fixture-analyzers.ts
+++ b/packages/testkit/src/fixture-analyzers.ts
@@ -15,6 +15,7 @@ import type {
 
 export class FixtureSpeechAnalyzer implements SpeechAnalyzer {
   public readonly descriptor = { id: "fixture.speech", provider: "fixture", version: "1" };
+  public readonly capabilities = { transcription: true, vad: true };
 
   public async analyze(input: AnalysisInput, range?: TimeRange): Promise<SpeechAnalysis> {
     const speech = input.media.speech;

--- a/scripts/speech-analyzer-wrapper.mjs
+++ b/scripts/speech-analyzer-wrapper.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { access } from "node:fs/promises";
+import { constants } from "node:fs";
+
+const backend = process.env.FRAMEKIT_SPEECH_BACKEND?.trim();
+if (!backend) fail(78, "SPEECH_ANALYZER_SETUP_REQUIRED: set FRAMEKIT_SPEECH_BACKEND to one executable Whisper/VAD backend path");
+
+try {
+  await access(backend, constants.X_OK);
+} catch {
+  fail(78, `SPEECH_ANALYZER_SETUP_REQUIRED: speech backend is not executable: ${backend}`);
+}
+
+let input = "";
+for await (const chunk of process.stdin) input += chunk;
+
+let request;
+try {
+  request = JSON.parse(input);
+} catch (error) {
+  fail(65, `SPEECH_ANALYZER_REQUEST_INVALID: wrapper received invalid JSON: ${String(error)}`);
+}
+
+const child = spawn(backend, [], { stdio: ["pipe", "pipe", "pipe"] });
+const stdout = [];
+const stderr = [];
+child.stdout.on("data", (chunk) => stdout.push(chunk));
+child.stderr.on("data", (chunk) => stderr.push(chunk));
+child.once("error", (error) => {
+  fail(78, `SPEECH_ANALYZER_SETUP_REQUIRED: speech backend could not start: ${String(error)}`);
+});
+child.stdin.end(JSON.stringify(request));
+
+const exitCode = await new Promise((resolve) => child.once("close", (code) => resolve(code ?? 1)));
+const diagnostic = stderr.length > 0 ? `: ${Buffer.concat(stderr).toString("utf8").trim()}` : "";
+if (exitCode !== 0) fail(78, `SPEECH_ANALYZER_BACKEND_FAILED: backend exited with code ${exitCode}${diagnostic}`);
+
+let result;
+try {
+  result = JSON.parse(Buffer.concat(stdout).toString("utf8"));
+} catch (error) {
+  fail(65, `SPEECH_ANALYZER_BACKEND_INVALID_OUTPUT: backend returned invalid JSON: ${String(error)}`);
+}
+if (!result || typeof result !== "object" || Array.isArray(result)) {
+  fail(65, "SPEECH_ANALYZER_BACKEND_INVALID_OUTPUT: backend must return one JSON object");
+}
+process.stdout.write(JSON.stringify(result));
+
+function fail(code, message) {
+  process.stderr.write(`${message}\n`);
+  process.exit(code);
+}

--- a/tests/filler-removal/benchmark.ts
+++ b/tests/filler-removal/benchmark.ts
@@ -342,7 +342,7 @@ function createScenarioSpeechAnalyzer(scenario: FillerRemovalScenario): SpeechAn
       const words = editApplied && scenario.category === "success"
         ? originalWords.flatMap((word) => mapWordAfterDelete(word, scenario.range))
         : originalWords.map((word) => ({ ...word }));
-      return { words: range ? words.filter((word) => overlaps(word, range)) : words };
+      return { words: range ? words.filter((word) => word.start >= range.start && word.end <= range.end) : words };
     },
   };
 }
@@ -354,10 +354,6 @@ function mapWordAfterDelete(word: SpeechWord, range: TimeRange): SpeechWord[] {
     return [{ ...word, start: word.start - removedDuration, end: word.end - removedDuration }];
   }
   return [];
-}
-
-function overlaps(word: SpeechWord, range: TimeRange): boolean {
-  return word.end > range.start && word.start < range.end;
 }
 
 function transcriptMatches(expected: string[], actual: string[]): boolean {

--- a/tests/integration/filler-removal.test.ts
+++ b/tests/integration/filler-removal.test.ts
@@ -228,7 +228,7 @@ test("filler preview maps trimmed source speech onto an offset occurrence", asyn
     range: { start: 20, end: 23 },
   });
 
-  assert.deepEqual(preview.operations[0]?.range, {
+  assert.deepEqual((preview.operations[0] as { range?: unknown } | undefined)?.range, {
     start: 20.4,
     end: 21.1,
     startTime: { value: "102", timescale: "5" },

--- a/tests/integration/filler-removal.test.ts
+++ b/tests/integration/filler-removal.test.ts
@@ -191,6 +191,51 @@ test("filler preview rejects stale speech evidence before planning a delete", as
   assert.deepEqual(await adapter.readProject(), before);
 });
 
+test("filler preview maps trimmed source speech onto an offset occurrence", async () => {
+  const analyzer: SpeechAnalyzer = { analyze: async ({ media }) => structuredClone(media.speech!) };
+  const adapter = new InMemoryEditorAdapter({
+    projectId: "project-filler-trimmed",
+    projectName: "Trimmed Filler Fixture",
+    timelineId: "timeline-filler-trimmed",
+    timelineName: "Main Edit",
+    clips: [{
+      id: "clip-filler-trimmed",
+      mediaId: "media-filler-trimmed",
+      name: "Trimmed Interview",
+      start: 20,
+      duration: 3,
+      track: 0,
+      sourceStart: 10,
+      sourceStartTime: { value: "10", timescale: "1" },
+    }],
+    media: [{
+      mediaId: "media-filler-trimmed",
+      source: "interview-trimmed.wav",
+      speech: {
+        words: [
+          { text: "So", start: 10, end: 10.3, confidence: 0.99 },
+          { text: "um", start: 10.4, end: 10.7, confidence: 0.98, filler: true },
+          { text: "what", start: 11.6, end: 12, confidence: 0.99 },
+        ],
+      },
+    }],
+  });
+  const runtime = new AgentVideoRuntime(adapter, { speechAnalyzer: analyzer });
+  const before = await runtime.inspectProject();
+
+  const preview = await runtime.previewFillerRemoval({
+    baseRevision: before.revision,
+    range: { start: 20, end: 23 },
+  });
+
+  assert.deepEqual(preview.operations[0]?.range, {
+    start: 20.4,
+    end: 21.1,
+    startTime: { value: "102", timescale: "5" },
+    durationTime: { value: "7", timescale: "10" },
+  });
+});
+
 test("filler execution reanalyzes continuity and returns a reversible verified transaction", async () => {
   let calls = 0;
   const analyzer: SpeechAnalyzer = {

--- a/tests/integration/filler-removal.test.ts
+++ b/tests/integration/filler-removal.test.ts
@@ -174,6 +174,23 @@ test("filler preview maps media speech to a guarded timeline delete", async () =
   assert.deepEqual(await adapter.readProject(), before);
 });
 
+test("filler preview rejects stale speech evidence before planning a delete", async () => {
+  const analyzer: SpeechAnalyzer = {
+    analyze: async ({ media }) => ({
+      revision: { id: "rev-old", sequence: -1, timestamp: "2026-09-09T00:00:00.000Z" },
+      words: structuredClone(media.speech!.words),
+    }),
+  };
+  const { adapter, runtime } = createFillerRuntime(analyzer);
+  const before = await runtime.inspectProject();
+
+  await assert.rejects(
+    runtime.previewFillerRemoval({ baseRevision: before.revision, range: { start: 10, end: 13 } }),
+    /STALE_CONTEXT/,
+  );
+  assert.deepEqual(await adapter.readProject(), before);
+});
+
 test("filler execution reanalyzes continuity and returns a reversible verified transaction", async () => {
   let calls = 0;
   const analyzer: SpeechAnalyzer = {

--- a/tests/integration/mcp.test.ts
+++ b/tests/integration/mcp.test.ts
@@ -207,6 +207,11 @@ test("Phase 0 exposes read/write/diff through MCP stdio", async () => {
 
     const speech = await client.callTool({ name: "speech.analyze", arguments: { mediaId: "media-1" } });
     assert.equal(JSON.parse(textFrom(speech)).words[0].filler, true);
+    const rangedSpeech = await client.callTool({
+      name: "speech.analyze",
+      arguments: { mediaId: "media-1", range: { start: 0, end: 0.3 } },
+    });
+    assert.deepEqual(JSON.parse(textFrom(rangedSpeech)).requestedRange, { start: 0, end: 0.3 });
     const audio = await client.callTool({ name: "audio.analyze", arguments: { mediaId: "media-1" } });
     assert.equal(JSON.parse(textFrom(audio)).integratedLufs, -18);
     const visual = await client.callTool({ name: "visual.analyze", arguments: { mediaId: "media-1" } });

--- a/tests/integration/phase1.test.ts
+++ b/tests/integration/phase1.test.ts
@@ -318,6 +318,27 @@ test("FCPXML separates asset source starts from timeline offsets", async () => {
   assert.equal(snapshot.timeline.captions[0]?.start, 5);
 });
 
+test("FCPXML resource duration bounds silent full-media speech analysis", async () => {
+  const directory = await mkdtemp(join(os.tmpdir(), "framekit-fcpxml-speech-duration-"));
+  const path = join(directory, "project.fcpxml");
+  await writeFile(path, `<?xml version="1.0"?><fcpxml><resources>
+    <asset id="r1" src="file:///silent.wav" duration="12s" />
+  </resources><library><event><project uid="project-speech-duration"><sequence uid="sequence-speech-duration" duration="3s"><spine>
+    <asset-clip ref="r1" duration="3s" />
+  </spine></sequence></project></event></library></fcpxml>`);
+
+  const adapter = new FcpxmlDocumentAdapter(path);
+  const runtime = new AgentVideoRuntime(adapter, {
+    speechAnalyzer: { analyze: async () => ({ words: [] }) },
+  });
+
+  const result = await runtime.analyzeSpeech("r1");
+
+  assert.equal((await adapter.readProject()).media[0]?.duration, 12);
+  assert.deepEqual(result.requestedRange, { start: 0, end: 12 });
+  assert.deepEqual(result.observedRange, { start: 0, end: 12 });
+});
+
 test("Final Cut session composes document snapshot and live state providers", async () => {
   const directory = await mkdtemp(join(os.tmpdir(), "framekit-fcpxml-session-"));
   const path = join(directory, "project.fcpxml");

--- a/tests/integration/phase1.test.ts
+++ b/tests/integration/phase1.test.ts
@@ -524,7 +524,36 @@ test("post-write speech reanalysis retains evidence outside changed ranges", asy
   ]);
   assert.deepEqual(speech?.requestedRange, { start: 0, end: 10 });
   assert.deepEqual(speech?.observedRange, { start: 0, end: 10 });
-  assert.equal(speech?.revision.id, transaction.after.revision.id);
+  assert.equal(speech?.revision?.id, transaction.after.revision.id);
+});
+
+test("post-write speech reanalysis coalesces overlapping source ranges", async () => {
+  const ranges: Array<{ start: number; end: number }> = [];
+  const editor = new InMemoryEditorAdapter({
+    projectId: "project-coalesced-speech",
+    projectName: "Coalesced Speech Fixture",
+    timelineId: "timeline-coalesced-speech",
+    timelineName: "Main Edit",
+    clips: [{ id: "clip-coalesced-speech", mediaId: "media-coalesced-speech", name: "Interview", start: 0, duration: 10, track: 1 }],
+    media: [{ mediaId: "media-coalesced-speech", source: "interview.wav", duration: 10 }],
+  });
+  const runtime = new AgentVideoRuntime(editor, {
+    speechAnalyzer: {
+      analyze: async (_input, range) => {
+        if (range) ranges.push(range);
+        return { words: [] };
+      },
+    },
+  });
+
+  const transaction = await runtime.edit({
+    type: "trim-clip",
+    clipId: "clip-coalesced-speech",
+    duration: 9,
+  });
+
+  assert.equal(transaction.status, "VERIFIED");
+  assert.deepEqual(ranges, [{ start: 0, end: 9 }]);
 });
 
 test("missing live context reports the Framekit capability name", async () => {

--- a/tests/integration/phase1.test.ts
+++ b/tests/integration/phase1.test.ts
@@ -375,6 +375,25 @@ test("post-write verification invokes analyzers for affected ranges", async () =
   assert.ok(audioCalls > 0);
 });
 
+test("post-write verification rolls back when speech analysis is stale", async () => {
+  const editor = fixtureAdapter();
+  const before = await editor.readProject();
+  const runtime = new AgentVideoRuntime(editor, {
+    speechAnalyzer: {
+      analyze: async ({ media }) => ({
+        revision: { id: "rev-stale", sequence: -1, timestamp: "2026-09-09T00:00:00.000Z" },
+        words: structuredClone(media.speech?.words ?? []),
+      }),
+    },
+  });
+
+  await assert.rejects(
+    runtime.edit({ type: "rename-clip", clipId: "clip-1", name: "Must Not Persist" }),
+    /ANALYSIS_FAILED: post-write verification analysis failed .*STALE_CONTEXT/,
+  );
+  assert.deepEqual(await editor.readProject(), before);
+});
+
 test("post-write verification passes clip intersections in media-relative coordinates", async () => {
   const ranges = {
     speech: [] as Array<{ start: number; end: number }>,

--- a/tests/integration/phase1.test.ts
+++ b/tests/integration/phase1.test.ts
@@ -458,6 +458,75 @@ test("post-write verification passes clip intersections in media-relative coordi
   });
 });
 
+test("post-write speech reanalysis retains evidence outside changed ranges", async () => {
+  const sourceIdentity = {
+    mediaId: "media-retained-speech",
+    source: "interview.wav",
+    mediaKind: "audio" as const,
+    duration: 10,
+  };
+  const editor = new InMemoryEditorAdapter({
+    projectId: "project-retained-speech",
+    projectName: "Retained Speech Fixture",
+    timelineId: "timeline-retained-speech",
+    timelineName: "Main Edit",
+    clips: [{ id: "clip-retained-speech", mediaId: sourceIdentity.mediaId, name: "Interview", start: 0, duration: 10, track: 1 }],
+    media: [{
+      ...sourceIdentity,
+      speech: {
+        schemaVersion: 1,
+        mediaId: sourceIdentity.mediaId,
+        sourceIdentity,
+        requestedRange: { start: 0, end: 10 },
+        observedRange: { start: 0, end: 10 },
+        revision: { id: "rev-0", sequence: 0, timestamp: new Date(0).toISOString() },
+        provider: { id: "fixture.speech", provider: "fixture" },
+        sourceTimebase: { value: "1", timescale: "1000" },
+        capability: "transcription-plus-vad",
+        words: [
+          { text: "before", start: 1, end: 1.5, confidence: 0.99 },
+          { text: "old-middle", start: 4.1, end: 4.4, confidence: 0.8 },
+          { text: "after", start: 7, end: 7.5, confidence: 0.99 },
+        ],
+        vadSegments: [
+          { start: 1, end: 1.5, kind: "speech" },
+          { start: 4.1, end: 4.4, kind: "speech" },
+          { start: 7, end: 7.5, kind: "speech" },
+        ],
+      },
+    }],
+  });
+  const runtime = new AgentVideoRuntime(editor, {
+    speechAnalyzer: {
+      descriptor: { id: "fixture.speech", provider: "fixture" },
+      analyze: async (_input, range) => ({
+        requestedRange: range,
+        observedRange: range,
+        words: [{ text: "new-middle", start: 4.2, end: 4.6, confidence: 0.98 }],
+        vadSegments: [{ start: 4.2, end: 4.6, kind: "speech" }],
+      }),
+    },
+  });
+
+  const transaction = await runtime.edit({
+    type: "add-marker",
+    timelineId: "timeline-retained-speech",
+    marker: { id: "marker-retained-speech", start: 4, duration: 1, name: "Review" },
+  });
+
+  const speech = transaction.after.media[0]?.speech;
+  assert.equal(transaction.status, "VERIFIED");
+  assert.deepEqual(speech?.words.map(({ text }) => text), ["before", "new-middle", "after"]);
+  assert.deepEqual(speech?.vadSegments?.map(({ start, end }) => ({ start, end })), [
+    { start: 1, end: 1.5 },
+    { start: 4.2, end: 4.6 },
+    { start: 7, end: 7.5 },
+  ]);
+  assert.deepEqual(speech?.requestedRange, { start: 0, end: 10 });
+  assert.deepEqual(speech?.observedRange, { start: 0, end: 10 });
+  assert.equal(speech?.revision.id, transaction.after.revision.id);
+});
+
 test("missing live context reports the Framekit capability name", async () => {
   await assert.rejects(
     new AgentVideoRuntime(fixtureAdapter()).inspectLiveEditor(),

--- a/tests/integration/phase1.test.ts
+++ b/tests/integration/phase1.test.ts
@@ -312,6 +312,8 @@ test("FCPXML separates asset source starts from timeline offsets", async () => {
   assert.equal(snapshot.timeline.duration, 3);
   assert.deepEqual(snapshot.timeline.clips[0]?.startTime, { value: "0", timescale: "1" });
   assert.equal(snapshot.timeline.clips[0]?.start, 0);
+  assert.equal(snapshot.timeline.clips[0]?.sourceStart, 4);
+  assert.deepEqual(snapshot.timeline.clips[0]?.sourceStartTime, { value: "4", timescale: "1" });
   assert.equal(snapshot.timeline.markers[0]?.start, 2);
   assert.equal(snapshot.timeline.captions[0]?.start, 5);
 });

--- a/tests/integration/phase1.test.ts
+++ b/tests/integration/phase1.test.ts
@@ -391,7 +391,8 @@ test("post-write verification rolls back when speech analysis is stale", async (
     runtime.edit({ type: "rename-clip", clipId: "clip-1", name: "Must Not Persist" }),
     /ANALYSIS_FAILED: post-write verification analysis failed .*STALE_CONTEXT/,
   );
-  assert.deepEqual(await editor.readProject(), before);
+  const restored = await editor.readProject();
+  assert.deepEqual({ ...restored, revision: before.revision }, before);
 });
 
 test("post-write verification passes clip intersections in media-relative coordinates", async () => {

--- a/tests/speech/capabilities.test.ts
+++ b/tests/speech/capabilities.test.ts
@@ -37,3 +37,12 @@ test("editor inspection reports a configured transcription-plus-VAD provider", a
   assert.equal(inspected.capabilities.analyzers.speechCapability, "transcription-plus-vad");
   assert.equal(inspected.capabilities.families.analyzers.speechVad.available, true);
 });
+
+test("editor inspection honors an explicit unavailable speech provider", async () => {
+  const runtime = runtimeWithSpeechCapabilities({ transcription: false, vad: false });
+  const inspected = await runtime.inspectEditor();
+
+  assert.equal(inspected.capabilities.analyzers.speechTranscribe, false);
+  assert.equal(inspected.capabilities.analyzers.speechVad, false);
+  assert.equal(inspected.capabilities.analyzers.speechCapability, "unavailable");
+});

--- a/tests/speech/capabilities.test.ts
+++ b/tests/speech/capabilities.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { AgentVideoRuntime, type SpeechAnalyzer } from "@framekit/runtime";
+import { InMemoryEditorAdapter } from "@framekit/testkit";
+
+function runtimeWithSpeechCapabilities(capabilities: SpeechAnalyzer["capabilities"]) {
+  return new AgentVideoRuntime(new InMemoryEditorAdapter({
+    projectId: "project-1",
+    projectName: "Speech capabilities",
+    timelineId: "timeline-1",
+    timelineName: "Main",
+    clips: [],
+    media: [{ mediaId: "media-1", source: "speech.wav", duration: 1 }],
+  }), {
+    speechAnalyzer: {
+      capabilities,
+      analyze: async () => ({ words: [] }),
+    },
+  });
+}
+
+test("editor inspection reports a configured transcription-only speech provider", async () => {
+  const runtime = runtimeWithSpeechCapabilities({ transcription: true, vad: false });
+  const inspected = await runtime.inspectEditor();
+
+  assert.equal(inspected.capabilities.analyzers.speechTranscribe, true);
+  assert.equal(inspected.capabilities.analyzers.speechVad, false);
+  assert.equal(inspected.capabilities.analyzers.speechCapability, "transcription-only");
+  assert.equal(inspected.capabilities.families.analyzers.speechTranscribe.available, true);
+  assert.equal(inspected.capabilities.families.analyzers.speechVad.available, false);
+});
+
+test("editor inspection reports a configured transcription-plus-VAD provider", async () => {
+  const runtime = runtimeWithSpeechCapabilities({ transcription: true, vad: true });
+  const inspected = await runtime.inspectEditor();
+
+  assert.equal(inspected.capabilities.analyzers.speechCapability, "transcription-plus-vad");
+  assert.equal(inspected.capabilities.families.analyzers.speechVad.available, true);
+});

--- a/tests/speech/command-analyzer.test.ts
+++ b/tests/speech/command-analyzer.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { CommandSpeechAnalyzer } from "@framekit/final-cut";
+import type { AnalysisInput } from "@framekit/runtime";
+
+function createInput(mediaSource: string): AnalysisInput {
+  return {
+    project: {
+      projectId: "project-1",
+      projectName: "Command analyzer fixture",
+      timeline: { id: "timeline-1", name: "Main", duration: 12, clips: [], storyElements: [], markers: [], captions: [] },
+      media: [{ mediaId: "media-1", source: mediaSource, sourceDigest: "sha256:source", mediaKind: "audio", duration: 12 }],
+      revision: { id: "rev-4", sequence: 4, timestamp: "2026-09-10T00:00:00.000Z" },
+    },
+    media: { mediaId: "media-1", source: mediaSource, sourceDigest: "sha256:source", mediaKind: "audio", duration: 12 },
+  };
+}
+
+async function createWrapper(directory: string, output: unknown, capturePath?: string): Promise<string> {
+  const wrapperPath = join(directory, "speech-wrapper.mjs");
+  const capture = capturePath ? `await writeFile(${JSON.stringify(capturePath)}, JSON.stringify(request));` : "";
+  await writeFile(wrapperPath, [
+    "#!/usr/bin/env node",
+    'import { readFile, writeFile } from "node:fs/promises";',
+    'const request = JSON.parse(await readFile("/dev/stdin", "utf8"));',
+    capture,
+    `process.stdout.write(${JSON.stringify(JSON.stringify(output))});`,
+  ].filter(Boolean).join("\n"));
+  await chmod(wrapperPath, 0o755);
+  return wrapperPath;
+}
+
+test("command speech analyzer sends a safe identity-bound request and returns VAD evidence", async () => {
+  const directory = await mkdtemp(join(os.tmpdir(), "framekit-speech-wrapper-"));
+  const mediaPath = join(directory, "interview.wav");
+  const capturePath = join(directory, "request.json");
+  await writeFile(mediaPath, "media");
+  const wrapper = await createWrapper(directory, {
+    words: [{ text: "hello", start: 2, end: 2.5, confidence: 0.98 }],
+    vadSegments: [{ start: 2, end: 2.5, kind: "speech" }],
+    sourceTimebase: { value: "1", timescale: "1000" },
+  }, capturePath);
+  const input = createInput(mediaPath);
+
+  const result = await new CommandSpeechAnalyzer({ command: wrapper }).analyze(
+    input,
+    { start: 2, end: 6 },
+  );
+  const request = JSON.parse(await readFile(capturePath, "utf8")) as Record<string, unknown>;
+
+  assert.deepEqual(request, {
+    schemaVersion: 1,
+    media: input.media,
+    revision: input.project.revision,
+    range: { start: 2, end: 6 },
+  });
+  assert.equal(result.mediaId, "media-1");
+  assert.deepEqual(result.sourceIdentity, input.media);
+  assert.deepEqual(result.requestedRange, { start: 2, end: 6 });
+  assert.deepEqual(result.observedRange, { start: 2, end: 6 });
+  assert.deepEqual(result.revision, input.project.revision);
+  assert.deepEqual(result.provider, { id: "command.speech", provider: "command" });
+  assert.equal(result.capability, "transcription-plus-vad");
+});
+
+test("command speech analyzer keeps transcription-only output distinct", async () => {
+  const directory = await mkdtemp(join(os.tmpdir(), "framekit-speech-transcription-"));
+  const mediaPath = join(directory, "interview.wav");
+  await writeFile(mediaPath, "media");
+  const wrapper = await createWrapper(directory, {
+    words: [{ text: "hello", start: 0, end: 1, confidence: 0.98 }],
+  });
+
+  const result = await new CommandSpeechAnalyzer({ command: wrapper }).analyze(createInput(mediaPath));
+
+  assert.equal(result.capability, "transcription-only");
+  assert.equal(result.vadSegments, undefined);
+});
+
+test("command speech analyzer fails closed for missing executables and malformed VAD", async () => {
+  const directory = await mkdtemp(join(os.tmpdir(), "framekit-speech-errors-"));
+  const mediaPath = join(directory, "interview.wav");
+  await writeFile(mediaPath, "media");
+  const input = createInput(mediaPath);
+  const invalidWrapper = await createWrapper(directory, {
+    words: [{ text: "hello", start: 0, end: 1, confidence: 0.98 }],
+    vadSegments: [{ start: 0, end: 2, kind: "speech" }, { start: 1, end: 3, kind: "silence" }],
+  });
+
+  await assert.rejects(
+    new CommandSpeechAnalyzer({ command: join(directory, "missing-wrapper") }).analyze(input),
+    /ANALYZER_FAILED: speech analyzer could not start/,
+  );
+  await assert.rejects(
+    new CommandSpeechAnalyzer({ command: invalidWrapper }).analyze(input),
+    /ANALYZER_INVALID_OUTPUT: speech analyzer returned invalid JSON or schema/,
+  );
+});

--- a/tests/speech/command-analyzer.test.ts
+++ b/tests/speech/command-analyzer.test.ts
@@ -4,7 +4,8 @@ import os from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { CommandSpeechAnalyzer } from "@framekit/final-cut";
-import type { AnalysisInput } from "@framekit/runtime";
+import { AgentVideoRuntime, type AnalysisInput } from "@framekit/runtime";
+import { InMemoryEditorAdapter } from "@framekit/testkit";
 
 function createInput(mediaSource: string): AnalysisInput {
   return {
@@ -80,6 +81,24 @@ test("command speech analyzer keeps transcription-only output distinct", async (
 
   assert.equal(result.capability, "transcription-only");
   assert.equal(result.vadSegments, undefined);
+});
+
+test("command speech analyzer advertises only guaranteed capabilities", async () => {
+  const analyzer = new CommandSpeechAnalyzer({ command: "/usr/bin/true" });
+  const runtime = new AgentVideoRuntime(new InMemoryEditorAdapter({
+    projectId: "project-1",
+    projectName: "Command capability fixture",
+    timelineId: "timeline-1",
+    timelineName: "Main",
+    clips: [],
+    media: [{ mediaId: "media-1", source: "/fixtures/interview.wav", duration: 12 }],
+  }), { speechAnalyzer: analyzer });
+
+  const inspected = await runtime.inspectEditor();
+
+  assert.equal(inspected.capabilities.analyzers.speechTranscribe, true);
+  assert.equal(inspected.capabilities.analyzers.speechVad, false);
+  assert.equal(inspected.capabilities.analyzers.speechCapability, "transcription-only");
 });
 
 test("command speech analyzer fails closed for missing executables and malformed VAD", async () => {

--- a/tests/speech/command-analyzer.test.ts
+++ b/tests/speech/command-analyzer.test.ts
@@ -24,8 +24,10 @@ async function createWrapper(directory: string, output: unknown, capturePath?: s
   const capture = capturePath ? `await writeFile(${JSON.stringify(capturePath)}, JSON.stringify(request));` : "";
   await writeFile(wrapperPath, [
     "#!/usr/bin/env node",
-    'import { readFile, writeFile } from "node:fs/promises";',
-    'const request = JSON.parse(await readFile("/dev/stdin", "utf8"));',
+    'import { writeFile } from "node:fs/promises";',
+    'let input = "";',
+    'for await (const chunk of process.stdin) input += chunk;',
+    "const request = JSON.parse(input);",
     capture,
     `process.stdout.write(${JSON.stringify(JSON.stringify(output))});`,
   ].filter(Boolean).join("\n"));

--- a/tests/speech/conformance.test.ts
+++ b/tests/speech/conformance.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { CommandSpeechAnalyzer } from "@framekit/final-cut";
+import { AgentVideoRuntime, type SpeechAnalyzer } from "@framekit/runtime";
+import { FixtureSpeechAnalyzer, InMemoryEditorAdapter } from "@framekit/testkit";
+
+const words = [
+  { text: "hello", start: 0, end: 1, confidence: 0.98 },
+  { text: "world", start: 2, end: 3, confidence: 0.97 },
+];
+const vadSegments = [
+  { start: 0, end: 1, kind: "speech" as const },
+  { start: 1, end: 2, kind: "silence" as const },
+  { start: 2, end: 3, kind: "speech" as const },
+];
+
+test("fixture and configured speech providers satisfy the shared contract", async () => {
+  const directory = await mkdtemp(join(os.tmpdir(), "framekit-speech-conformance-"));
+  const mediaPath = join(directory, "interview.wav");
+  await writeFile(mediaPath, "fixture media");
+  const command = join(directory, "speech-wrapper.mjs");
+  await writeFile(command, [
+    "#!/usr/bin/env node",
+    `process.stdout.write(${JSON.stringify(JSON.stringify({ words, vadSegments, sourceTimebase: { value: "1", timescale: "1000" } }))});`,
+  ].join("\n"));
+  await chmod(command, 0o755);
+
+  const providers: Array<[string, () => SpeechAnalyzer, string]> = [
+    ["fixture", () => new FixtureSpeechAnalyzer(), "fixture.speech"],
+    ["command", () => new CommandSpeechAnalyzer({ command }), "command.speech"],
+  ];
+  for (const [name, createAnalyzer, providerId] of providers) {
+    const adapter = new InMemoryEditorAdapter({
+      projectId: "project-speech-conformance",
+      projectName: "Speech Conformance",
+      timelineId: "timeline-speech-conformance",
+      timelineName: "Main",
+      clips: [],
+      media: [{
+        mediaId: "media-speech-conformance",
+        source: mediaPath,
+        mediaKind: "audio",
+        duration: 6,
+        speech: { words, vadSegments },
+      }],
+    });
+    const runtime = new AgentVideoRuntime(adapter, { speechAnalyzer: createAnalyzer() });
+    const result = await runtime.analyzeSpeech("media-speech-conformance");
+
+    assert.equal(result.mediaId, "media-speech-conformance", name);
+    assert.ok(result.provider, name);
+    assert.equal(result.provider.id, providerId, name);
+    assert.deepEqual(result.sourceIdentity, {
+      mediaId: "media-speech-conformance",
+      source: mediaPath,
+      mediaKind: "audio",
+      duration: 6,
+    }, name);
+    assert.deepEqual(result.revision, (await adapter.readProject()).revision, name);
+    assert.deepEqual(result.requestedRange, { start: 0, end: 6 }, name);
+    assert.deepEqual(result.observedRange, { start: 0, end: 6 }, name);
+    assert.deepEqual(result.sourceTimebase, { value: "1", timescale: "1000" }, name);
+    assert.equal(result.capability, "transcription-plus-vad", name);
+    assert.deepEqual(result.words, words, name);
+    assert.deepEqual(result.vadSegments, vadSegments, name);
+  }
+});

--- a/tests/speech/local-wrapper.test.ts
+++ b/tests/speech/local-wrapper.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, writeFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import os from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+function run(command: string, input: unknown, environment: NodeJS.ProcessEnv): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, [], { env: environment, stdio: ["pipe", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => { stdout += chunk; });
+    child.stderr.on("data", (chunk: string) => { stderr += chunk; });
+    child.once("error", reject);
+    child.once("close", (code) => resolve({ code, stdout, stderr }));
+    child.stdin.end(JSON.stringify(input));
+  });
+}
+
+test("local speech wrapper delegates one JSON request to a configured backend", async () => {
+  const directory = await mkdtemp(join(os.tmpdir(), "framekit-local-speech-wrapper-"));
+  const backend = join(directory, "whisper-vad-backend.mjs");
+  await writeFile(backend, [
+    "#!/usr/bin/env node",
+    'let input = "";',
+    'for await (const chunk of process.stdin) input += chunk;',
+    "const request = JSON.parse(input);",
+    'process.stdout.write(JSON.stringify({ words: [{ text: "hello", start: 0, end: 1, confidence: 0.98 }], vadSegments: [{ start: 0, end: 1, kind: "speech" }], sourceTimebase: { value: "1", timescale: "1000" }, receivedMediaId: request.media.mediaId }));',
+  ].join("\n"));
+  await chmod(backend, 0o755);
+
+  const result = await run(join(process.cwd(), "scripts/speech-analyzer-wrapper.mjs"), {
+    schemaVersion: 1,
+    media: { mediaId: "media-1", source: "/media/interview.wav" },
+  }, { ...process.env, FRAMEKIT_SPEECH_BACKEND: backend });
+
+  assert.equal(result.code, 0);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    words: [{ text: "hello", start: 0, end: 1, confidence: 0.98 }],
+    vadSegments: [{ start: 0, end: 1, kind: "speech" }],
+    sourceTimebase: { value: "1", timescale: "1000" },
+    receivedMediaId: "media-1",
+  });
+});
+
+test("local speech wrapper reports an actionable setup failure", async () => {
+  const result = await run(join(process.cwd(), "scripts/speech-analyzer-wrapper.mjs"), {}, {
+    ...process.env,
+    FRAMEKIT_SPEECH_BACKEND: "",
+  });
+
+  assert.equal(result.code, 78);
+  assert.match(result.stderr, /SPEECH_ANALYZER_SETUP_REQUIRED/);
+});

--- a/tests/speech/mapping.test.ts
+++ b/tests/speech/mapping.test.ts
@@ -80,9 +80,10 @@ test("speech mapping fails closed for stale, ambiguous, and unsupported targets"
   const mismatched = { ...occurrence(30), mediaId: "other-media" };
   const unequal = { ...occurrence(30), sequenceRange: { ...occurrence(30).sequenceRange, end: 33 } };
   const missingRational = { ...occurrence(30), sequenceRange: { start: 30, end: 32 } };
+  const mismatchedTimebase = { ...occurrence(30), sourceTimebase: { value: "1", timescale: "30" } };
   const partialWord = { ...analysis, words: [{ text: "cut", start: 9.9, end: 10.1, confidence: 0.9 }] };
 
-  for (const target of [stale, mismatched, unequal, missingRational]) {
+  for (const target of [stale, mismatched, unequal, missingRational, mismatchedTimebase]) {
     assert.throws(
       () => mapSpeechAnalysisToOccurrence(analysis, target, { sequenceFrameDuration: { value: "1", timescale: "10" } }),
       /STALE_CONTEXT|TARGET_MISMATCH|AMBIGUOUS_MAPPING|ANALYSIS_INVALID/,

--- a/tests/speech/mapping.test.ts
+++ b/tests/speech/mapping.test.ts
@@ -72,7 +72,7 @@ test("speech mapping keeps repeated occurrences independent", () => {
 
   assert.equal(first.words[0]?.sequenceRange.start, 30.25);
   assert.equal(second.words[0]?.sequenceRange.start, 100.25);
-  assert.notEqual(first.words[0]?.frameAlignedRange.startTime.value, second.words[0]?.frameAlignedRange.startTime.value);
+  assert.notEqual(first.words[0]?.frameAlignedRange.startTime?.value, second.words[0]?.frameAlignedRange.startTime?.value);
 });
 
 test("speech mapping fails closed for stale, ambiguous, and unsupported targets", () => {

--- a/tests/speech/mapping.test.ts
+++ b/tests/speech/mapping.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  mapSpeechAnalysisToOccurrence,
+  type RevisionBoundSpeechAnalysis,
+  type SpeechOccurrence,
+} from "@framekit/runtime";
+
+const revision = { id: "rev-4", sequence: 4, timestamp: "2026-09-10T00:00:00.000Z" };
+const analysis: RevisionBoundSpeechAnalysis = {
+  mediaId: "media-1",
+  sourceIdentity: { mediaId: "media-1", source: "/media/interview.wav", duration: 60 },
+  requestedRange: { start: 0, end: 60 },
+  observedRange: { start: 0, end: 60 },
+  revision,
+  provider: { id: "local.speech", provider: "wrapper", version: "1" },
+  sourceTimebase: { value: "1", timescale: "1000" },
+  capability: "transcription-plus-vad",
+  words: [
+    { text: "before", start: 9, end: 9.4, confidence: 0.99 },
+    { text: "um", start: 10.25, end: 10.35, confidence: 0.98, filler: true },
+    { text: "after", start: 10.7, end: 11.1, confidence: 0.99 },
+    { text: "other", start: 20, end: 20.4, confidence: 0.99 },
+  ],
+  vadSegments: [{ start: 10.25, end: 10.35, kind: "speech" }],
+};
+
+function occurrence(sequenceStart: number): SpeechOccurrence {
+  return {
+    occurrenceId: `occurrence-${sequenceStart}`,
+    mediaId: "media-1",
+    revision,
+    sourceRange: { start: 10, end: 12 },
+    sequenceRange: {
+      start: sequenceStart,
+      end: sequenceStart + 2,
+      startTime: { value: String(sequenceStart * 10), timescale: "10" },
+      durationTime: { value: "2", timescale: "1" },
+    },
+  };
+}
+
+test("speech mapping translates trimmed source evidence to offset rational sequence ranges", () => {
+  const mapped = mapSpeechAnalysisToOccurrence(analysis, occurrence(30), {
+    sequenceFrameDuration: { value: "1", timescale: "10" },
+  });
+
+  assert.equal(mapped.occurrenceId, "occurrence-30");
+  assert.equal(mapped.mediaId, "media-1");
+  assert.deepEqual(mapped.words.map(({ word }) => word.text), ["um", "after"]);
+  assert.deepEqual(mapped.words[0]?.sequenceRange, {
+    start: 30.25,
+    end: 30.35,
+    startTime: { value: "121", timescale: "4" },
+    durationTime: { value: "1", timescale: "10" },
+  });
+  assert.deepEqual(mapped.words[0]?.frameAlignedRange, {
+    start: 30.2,
+    end: 30.4,
+    startTime: { value: "151", timescale: "5" },
+    durationTime: { value: "1", timescale: "5" },
+  });
+});
+
+test("speech mapping keeps repeated occurrences independent", () => {
+  const first = mapSpeechAnalysisToOccurrence(analysis, occurrence(30), {
+    sequenceFrameDuration: { value: "1", timescale: "10" },
+  });
+  const second = mapSpeechAnalysisToOccurrence(analysis, occurrence(100), {
+    sequenceFrameDuration: { value: "1", timescale: "10" },
+  });
+
+  assert.equal(first.words[0]?.sequenceRange.start, 30.25);
+  assert.equal(second.words[0]?.sequenceRange.start, 100.25);
+  assert.notEqual(first.words[0]?.frameAlignedRange.startTime.value, second.words[0]?.frameAlignedRange.startTime.value);
+});
+
+test("speech mapping fails closed for stale, ambiguous, and unsupported targets", () => {
+  const stale = { ...occurrence(30), revision: { ...revision, id: "rev-old", sequence: 3 } };
+  const mismatched = { ...occurrence(30), mediaId: "other-media" };
+  const unequal = { ...occurrence(30), sequenceRange: { ...occurrence(30).sequenceRange, end: 33 } };
+  const missingRational = { ...occurrence(30), sequenceRange: { start: 30, end: 32 } };
+  const partialWord = { ...analysis, words: [{ text: "cut", start: 9.9, end: 10.1, confidence: 0.9 }] };
+
+  for (const target of [stale, mismatched, unequal, missingRational]) {
+    assert.throws(
+      () => mapSpeechAnalysisToOccurrence(analysis, target, { sequenceFrameDuration: { value: "1", timescale: "10" } }),
+      /STALE_CONTEXT|TARGET_MISMATCH|AMBIGUOUS_MAPPING|ANALYSIS_INVALID/,
+    );
+  }
+  assert.throws(
+    () => mapSpeechAnalysisToOccurrence(partialWord, occurrence(30), { sequenceFrameDuration: { value: "1", timescale: "10" } }),
+    /AMBIGUOUS_MAPPING/,
+  );
+});

--- a/tests/speech/mapping.test.ts
+++ b/tests/speech/mapping.test.ts
@@ -8,6 +8,7 @@ import {
 
 const revision = { id: "rev-4", sequence: 4, timestamp: "2026-09-10T00:00:00.000Z" };
 const analysis: RevisionBoundSpeechAnalysis = {
+  schemaVersion: 1,
   mediaId: "media-1",
   sourceIdentity: { mediaId: "media-1", source: "/media/interview.wav", duration: 60 },
   requestedRange: { start: 0, end: 60 },

--- a/tests/speech/mapping.test.ts
+++ b/tests/speech/mapping.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  mapSourceRangeToSequenceRange,
   mapSpeechAnalysisToOccurrence,
   type RevisionBoundSpeechAnalysis,
   type SpeechOccurrence,
@@ -74,6 +75,35 @@ test("speech mapping keeps repeated occurrences independent", () => {
   assert.equal(first.words[0]?.sequenceRange.start, 30.25);
   assert.equal(second.words[0]?.sequenceRange.start, 100.25);
   assert.notEqual(first.words[0]?.frameAlignedRange.startTime?.value, second.words[0]?.frameAlignedRange.startTime?.value);
+});
+
+test("speech mapping translates exact source ranges for edit planning", () => {
+  const mapped = mapSourceRangeToSequenceRange({
+    start: 4.2,
+    end: 4.9,
+    startTime: { value: "21", timescale: "5" },
+    durationTime: { value: "7", timescale: "10" },
+  }, {
+    sourceRange: {
+      start: 4,
+      end: 7,
+      startTime: { value: "4", timescale: "1" },
+      durationTime: { value: "3", timescale: "1" },
+    },
+    sequenceRange: {
+      start: 20,
+      end: 23,
+      startTime: { value: "20", timescale: "1" },
+      durationTime: { value: "3", timescale: "1" },
+    },
+  });
+
+  assert.deepEqual(mapped, {
+    start: 20.2,
+    end: 20.9,
+    startTime: { value: "101", timescale: "5" },
+    durationTime: { value: "7", timescale: "10" },
+  });
 });
 
 test("speech mapping fails closed for stale, ambiguous, and unsupported targets", () => {

--- a/tests/speech/revision-bound-analysis.test.ts
+++ b/tests/speech/revision-bound-analysis.test.ts
@@ -57,6 +57,7 @@ test("speech binding attaches revision, range, identity, provider, and source ti
   }, { input, provider, range: { start: 2, end: 6 } });
 
   assert.deepEqual(result, {
+    schemaVersion: 1,
     mediaId: sourceIdentity.mediaId,
     sourceIdentity,
     revision: input.project.revision,

--- a/tests/speech/revision-bound-analysis.test.ts
+++ b/tests/speech/revision-bound-analysis.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  bindSpeechAnalysis,
+  type AnalysisInput,
+  type AnalyzerDescriptor,
+  type MediaSourceIdentity,
+  type SpeechAnalysis,
+} from "@framekit/runtime";
+
+const sourceIdentity: MediaSourceIdentity = {
+  mediaId: "media-1",
+  source: "/media/interview.wav",
+  sourceDigest: "sha256:interview",
+  mediaKind: "audio",
+  duration: 12,
+};
+
+const input: AnalysisInput = {
+  project: {
+    projectId: "project-1",
+    projectName: "Speech contract fixture",
+    timeline: {
+      id: "timeline-1",
+      name: "Main",
+      duration: 12,
+      clips: [],
+      storyElements: [],
+      markers: [],
+      captions: [],
+    },
+    media: [{ mediaId: sourceIdentity.mediaId, source: sourceIdentity.source, sourceDigest: sourceIdentity.sourceDigest, mediaKind: sourceIdentity.mediaKind, duration: sourceIdentity.duration }],
+    revision: { id: "rev-7", sequence: 7, timestamp: "2026-09-10T00:00:00.000Z" },
+  },
+  media: { ...sourceIdentity },
+};
+
+const provider: AnalyzerDescriptor = {
+  id: "local.whisper-silero",
+  provider: "local-wrapper",
+  version: "2.1.0",
+};
+
+test("speech binding attaches revision, range, identity, provider, and source timebase", () => {
+  const result = bindSpeechAnalysis({
+    mediaId: sourceIdentity.mediaId,
+    sourceIdentity,
+    revision: input.project.revision,
+    requestedRange: { start: 2, end: 6 },
+    observedRange: { start: 2, end: 6 },
+    provider,
+    sourceTimebase: { value: "1", timescale: "1000" },
+    words: [{ text: "hello", start: 2, end: 2.5, confidence: 0.98 }],
+    vadSegments: [{ start: 2, end: 2.5, kind: "speech" }],
+  }, { input, provider, range: { start: 2, end: 6 } });
+
+  assert.deepEqual(result, {
+    mediaId: sourceIdentity.mediaId,
+    sourceIdentity,
+    revision: input.project.revision,
+    requestedRange: { start: 2, end: 6 },
+    observedRange: { start: 2, end: 6 },
+    provider,
+    sourceTimebase: { value: "1", timescale: "1000" },
+    capability: "transcription-plus-vad",
+    words: [{ text: "hello", start: 2, end: 2.5, confidence: 0.98 }],
+    vadSegments: [{ start: 2, end: 2.5, kind: "speech" }],
+  });
+});
+
+test("speech binding preserves transcription-only capability without inventing VAD", () => {
+  const result = bindSpeechAnalysis({
+    words: [{ text: "hello", start: 0, end: 1, confidence: 0.98 }],
+  }, { input, provider });
+
+  assert.equal(result.capability, "transcription-only");
+  assert.equal(result.vadSegments, undefined);
+  assert.deepEqual(result.sourceIdentity, sourceIdentity);
+  assert.deepEqual(result.revision, input.project.revision);
+  assert.deepEqual(result.requestedRange, { start: 0, end: 12 });
+  assert.deepEqual(result.observedRange, { start: 0, end: 12 });
+});
+
+test("speech binding fails closed for stale or mismatched provenance", () => {
+  const cases: Array<[string, Partial<SpeechAnalysis>]> = [
+    ["media identity", { mediaId: "other-media" }],
+    ["source identity", { sourceIdentity: { ...sourceIdentity, sourceDigest: "sha256:other" } }],
+    ["revision", { revision: { ...input.project.revision, id: "rev-6", sequence: 6 } }],
+    ["observed range", { observedRange: { start: 0, end: 13 } }],
+  ];
+
+  for (const [label, patch] of cases) {
+    assert.throws(
+      () => bindSpeechAnalysis({
+        words: [{ text: "hello", start: 0, end: 1, confidence: 0.98 }],
+        ...patch,
+      }, { input, provider }),
+      /ANALYSIS_INVALID|STALE_CONTEXT|TARGET_MISMATCH/,
+      label,
+    );
+  }
+});
+
+test("speech binding rejects unordered, overlapping, and invalid evidence", () => {
+  const invalidAnalyses: SpeechAnalysis[] = [
+    {
+      words: [
+        { text: "later", start: 2, end: 3, confidence: 0.9 },
+        { text: "earlier", start: 1, end: 2, confidence: 0.9 },
+      ],
+    },
+    {
+      words: [
+        { text: "one", start: 0, end: 2, confidence: 0.9 },
+        { text: "two", start: 1, end: 3, confidence: 0.9 },
+      ],
+    },
+    { words: [{ text: "outside", start: 0, end: 13, confidence: 0.9 }] },
+    {
+      words: [{ text: "word", start: 0, end: 1, confidence: 0.9 }],
+      vadSegments: [
+        { start: 0, end: 2, kind: "speech" },
+        { start: 1, end: 3, kind: "silence" },
+      ],
+    },
+  ];
+
+  for (const analysis of invalidAnalyses) {
+    assert.throws(
+      () => bindSpeechAnalysis(analysis, { input, provider }),
+      /ANALYSIS_INVALID/,
+    );
+  }
+});

--- a/tests/speech/revision-bound-analysis.test.ts
+++ b/tests/speech/revision-bound-analysis.test.ts
@@ -126,6 +126,10 @@ test("speech binding rejects unordered, overlapping, and invalid evidence", () =
         { start: 1, end: 3, kind: "silence" },
       ],
     },
+    {
+      words: [{ text: "word", start: 0, end: 1, confidence: 0.9 }],
+      vadSegments: [{ start: 0, end: 13, kind: "speech" }],
+    },
   ];
 
   for (const analysis of invalidAnalyses) {

--- a/tests/speech/revision-bound-analysis.test.ts
+++ b/tests/speech/revision-bound-analysis.test.ts
@@ -97,7 +97,7 @@ test("speech binding fails closed for stale or mismatched provenance", () => {
       () => bindSpeechAnalysis({
         words: [{ text: "hello", start: 0, end: 1, confidence: 0.98 }],
         ...patch,
-      }, { input, provider }),
+      }, { input, provider, range: { start: 2, end: 6 } }),
       /ANALYSIS_INVALID|STALE_CONTEXT|TARGET_MISMATCH/,
       label,
     );

--- a/tests/speech/revision-bound-analysis.test.ts
+++ b/tests/speech/revision-bound-analysis.test.ts
@@ -1,12 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  AgentVideoRuntime,
   bindSpeechAnalysis,
   type AnalysisInput,
   type AnalyzerDescriptor,
   type MediaSourceIdentity,
   type SpeechAnalysis,
 } from "@framekit/runtime";
+import { InMemoryEditorAdapter } from "@framekit/testkit";
 
 const sourceIdentity: MediaSourceIdentity = {
   mediaId: "media-1",
@@ -131,4 +133,50 @@ test("speech binding rejects unordered, overlapping, and invalid evidence", () =
       /ANALYSIS_INVALID/,
     );
   }
+});
+
+test("runtime binds legacy analyzer output before returning speech analysis", async () => {
+  const adapter = new InMemoryEditorAdapter({
+    projectId: "project-1",
+    projectName: "Runtime speech fixture",
+    timelineId: "timeline-1",
+    timelineName: "Main",
+    clips: [],
+    media: [{ ...sourceIdentity }],
+  });
+  const runtime = new AgentVideoRuntime(adapter, {
+    speechAnalyzer: {
+      descriptor: provider,
+      analyze: async () => ({ words: [{ text: "hello", start: 0, end: 1, confidence: 0.98 }] }),
+    },
+  });
+
+  const result = await runtime.analyzeSpeech("media-1");
+
+  assert.equal(result.mediaId, "media-1");
+  assert.deepEqual(result.sourceIdentity, sourceIdentity);
+  assert.deepEqual(result.revision, (await adapter.readProject()).revision);
+  assert.deepEqual(result.provider, provider);
+  assert.equal(result.capability, "transcription-only");
+});
+
+test("runtime rejects stale revisions returned by a speech provider", async () => {
+  const adapter = new InMemoryEditorAdapter({
+    projectId: "project-1",
+    projectName: "Stale speech fixture",
+    timelineId: "timeline-1",
+    timelineName: "Main",
+    clips: [],
+    media: [{ ...sourceIdentity }],
+  });
+  const runtime = new AgentVideoRuntime(adapter, {
+    speechAnalyzer: {
+      analyze: async () => ({
+        revision: { id: "rev-old", sequence: 1, timestamp: "2026-09-09T00:00:00.000Z" },
+        words: [{ text: "hello", start: 0, end: 1, confidence: 0.98 }],
+      }),
+    },
+  });
+
+  await assert.rejects(runtime.analyzeSpeech("media-1"), /STALE_CONTEXT/);
 });

--- a/tests/speech/revision-bound-analysis.test.ts
+++ b/tests/speech/revision-bound-analysis.test.ts
@@ -84,6 +84,18 @@ test("speech binding preserves transcription-only capability without inventing V
   assert.deepEqual(result.observedRange, { start: 0, end: 12 });
 });
 
+test("speech binding fills omitted partial source identity fields", () => {
+  const result = bindSpeechAnalysis({
+    sourceIdentity: {
+      mediaId: sourceIdentity.mediaId,
+      source: sourceIdentity.source,
+    },
+    words: [],
+  }, { input, provider });
+
+  assert.deepEqual(result.sourceIdentity, sourceIdentity);
+});
+
 test("speech binding fails closed for stale or mismatched provenance", () => {
   const cases: Array<[string, Partial<SpeechAnalysis>]> = [
     ["media identity", { mediaId: "other-media" }],

--- a/tests/speech/revision-bound-analysis.test.ts
+++ b/tests/speech/revision-bound-analysis.test.ts
@@ -161,6 +161,35 @@ test("runtime binds legacy analyzer output before returning speech analysis", as
   assert.equal(result.capability, "transcription-only");
 });
 
+test("runtime forwards and binds requested speech ranges", async () => {
+  const adapter = new InMemoryEditorAdapter({
+    projectId: "project-1",
+    projectName: "Ranged speech fixture",
+    timelineId: "timeline-1",
+    timelineName: "Main",
+    clips: [],
+    media: [{ ...sourceIdentity }],
+  });
+  let receivedRange;
+  const runtime = new AgentVideoRuntime(adapter, {
+    speechAnalyzer: {
+      analyze: async (_input, range) => {
+        receivedRange = range;
+        return {
+          requestedRange: range,
+          observedRange: range,
+          words: [{ text: "hello", start: 2, end: 2.5, confidence: 0.98 }],
+        };
+      },
+    },
+  });
+
+  const result = await runtime.analyzeSpeech("media-1", { start: 2, end: 6 });
+
+  assert.deepEqual(receivedRange, { start: 2, end: 6 });
+  assert.deepEqual(result.requestedRange, { start: 2, end: 6 });
+});
+
 test("runtime rejects stale revisions returned by a speech provider", async () => {
   const adapter = new InMemoryEditorAdapter({
     projectId: "project-1",

--- a/tests/speech/revision-bound-analysis.test.ts
+++ b/tests/speech/revision-bound-analysis.test.ts
@@ -88,6 +88,7 @@ test("speech binding fails closed for stale or mismatched provenance", () => {
     ["media identity", { mediaId: "other-media" }],
     ["source identity", { sourceIdentity: { ...sourceIdentity, sourceDigest: "sha256:other" } }],
     ["revision", { revision: { ...input.project.revision, id: "rev-6", sequence: 6 } }],
+    ["requested range", { requestedRange: { start: 0, end: 1 } }],
     ["observed range", { observedRange: { start: 0, end: 13 } }],
   ];
 


### PR DESCRIPTION
Closes #40

## Summary

- Added revision-bound speech and VAD analysis contracts with media, range, revision, provider, source-timebase, and capability provenance.
- Added a documented executable local speech wrapper and configured command-provider validation.
- Added deterministic source-to-occurrence mapping for trimmed, offset, repeated, and rational frame-aligned occurrences.
- Integrated validated analysis with filler-removal planning and ranged MCP speech analysis.
- Added shared fixture/command-provider conformance tests and fail-closed safety coverage.

## Validation

The validation skill passed:

```bash
pnpm install --frozen-lockfile
pnpm run build
pnpm run test
pnpm run check:boundaries
```

Native Xcode checks were skipped because this change does not modify Swift or native Final Cut files.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Public MCP behavior and package interfaces are documented.
- [x] Existing adapters and deterministic fixtures remain compatible.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [x] Documentation reflects changed wrapper paths and environment variables.
