### PR TITLE
perf: run CodeQL only for affected languages

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,8 +26,65 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  changes:
+    name: Detect CodeQL paths
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      javascript_typescript: ${{ steps.filter.outputs.javascript_typescript }}
+      swift: ${{ steps.filter.outputs.swift }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Determine affected languages
+        id: filter
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          CURRENT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$GITHUB_EVENT_NAME" != "pull_request" ]]; then
+            {
+              echo 'javascript_typescript=true'
+              echo 'swift=true'
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed="$(git diff --name-only "$BASE_SHA...$CURRENT_SHA")"
+          printf '%s\n' "$changed"
+
+          javascript_pattern='(^|/)[^/]+\.(cjs|cts|js|jsx|mjs|mts|ts|tsx)$|(^|/)(package\.json|pnpm-lock\.yaml|tsconfig[^/]*\.json)$|^\.github/(codeql/|workflows/codeql\.yml$)'
+          swift_pattern='^adapters/final-cut/swift-bridge/|^\.github/(codeql/|workflows/codeql\.yml$)'
+
+          if printf '%s\n' "$changed" | grep -Eq "$javascript_pattern"; then
+            javascript_typescript=true
+          else
+            javascript_typescript=false
+          fi
+
+          if printf '%s\n' "$changed" | grep -Eq "$swift_pattern"; then
+            swift=true
+          else
+            swift=false
+          fi
+
+          {
+            echo "javascript_typescript=$javascript_typescript"
+            echo "swift=$swift"
+          } >> "$GITHUB_OUTPUT"
+
   analyze:
     name: Analyze (${{ matrix.language }})
+    needs: changes
+    # A detector failure must fail open to a full scan, not skip a required check.
+    if: ${{ !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.javascript_typescript == 'true') }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
@@ -55,6 +112,9 @@ jobs:
 
   analyze-swift:
     name: Analyze (swift)
+    needs: changes
+    # A detector failure must fail open to a full scan, not skip a required check.
+    if: ${{ !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.swift == 'true') }}
     runs-on: macos-26
     timeout-minutes: 40
 

--- a/docs/ci/codeql.md
+++ b/docs/ci/codeql.md
@@ -13,6 +13,21 @@ Pull-request scans cancel an older active scan for the same pull request when a
 newer pull-request event arrives. This bounds work for obsolete pull-request
 commits while leaving different pull requests independent.
 
+## Pull-request path filtering
+
+Pull requests first run the lightweight `Detect CodeQL paths` job on
+`ubuntu-latest`. The JavaScript/TypeScript analysis runs when a JavaScript or
+TypeScript source, its package or TypeScript configuration, the CodeQL
+configuration, or this workflow changes. The Swift analysis runs when the
+Swift bridge, the CodeQL configuration, or this workflow changes.
+
+Pushes to `main`, scheduled scans, and manual scans analyze both languages so
+that path filtering does not reduce default-branch coverage. The language jobs
+use job-level conditions rather than workflow-level path filters: a skipped
+job reports success for a required pull-request check, while a skipped
+workflow would leave its check pending and block merging. If path detection
+fails, both language jobs deliberately fall back to a full scan.
+
 The policy intentionally does not suppress genuine CodeQL failures, delete
 historical analyses, or change the configured security rules and query suites.
 

--- a/tests/integration/codeql-workflow.test.ts
+++ b/tests/integration/codeql-workflow.test.ts
@@ -26,6 +26,22 @@ test("CodeQL still supersedes obsolete pull-request runs", async () => {
   assert.match(workflow, /github\.event_name == 'pull_request'/);
 });
 
+test("CodeQL filters language jobs by changed paths", async () => {
+  const workflow = await readRepositoryFile(".github/workflows/codeql.yml");
+
+  assert.match(workflow, /\n  changes:\n/);
+  assert.match(workflow, /name: Detect CodeQL paths/);
+  assert.match(workflow, /javascript_typescript: \$\{\{ steps\.filter\.outputs\.javascript_typescript \}\}/);
+  assert.match(workflow, /swift: \$\{\{ steps\.filter\.outputs\.swift \}\}/);
+  assert.match(workflow, /fetch-depth: 0/);
+  assert.match(workflow, /git diff --name-only "\$BASE_SHA\.\.\..*\$CURRENT_SHA"/);
+  assert.match(workflow, /javascript_pattern=/);
+  assert.match(workflow, /swift_pattern=/);
+  assert.match(workflow, /needs: changes/);
+  assert.match(workflow, /if: \$\{\{ !cancelled\(\) && \(needs\.changes\.result != 'success' \|\| needs\.changes\.outputs\.javascript_typescript == 'true'\) \}\}/);
+  assert.match(workflow, /if: \$\{\{ !cancelled\(\) && \(needs\.changes\.result != 'success' \|\| needs\.changes\.outputs\.swift == 'true'\) \}\}/);
+});
+
 test("CodeQL concurrency policy is documented for operators", async () => {
   const documentation = await readRepositoryFile("docs/ci/codeql.md");
 


### PR DESCRIPTION
## Summary

- Add a lightweight Ubuntu path detector for CodeQL language jobs.
- Run JavaScript/TypeScript CodeQL only for relevant source, package/configuration, CodeQL, or workflow changes.
- Run Swift CodeQL only for Swift bridge, CodeQL, or workflow changes.
- Keep both language scans enabled for `main` pushes, schedules, and manual runs, with a full-scan fallback if detection fails.
- Document the required-check-safe job-level filtering behavior.

## Validation

- `PATH=/Users/shotomorisaki/.nix-profile/bin:$PATH pnpm exec tsx --test tests/integration/codeql-workflow.test.ts`
- `PATH=/Users/shotomorisaki/.nix-profile/bin:$PATH .agents/skills/validate-framekit/scripts/validate.sh`
- YAML parse and `git diff --check`

All repository gates passed: build, 486 tests, and package boundaries. Native checks were not required because no native source or Xcode files changed.
