### PR TITLE
fix: preserve media roles in canonical clips

### DIFF
--- a/packages/testkit/src/in-memory-editor.ts
+++ b/packages/testkit/src/in-memory-editor.ts
@@ -326,6 +326,7 @@ export class InMemoryEditorAdapter implements EditorPort {
         start: operation.start,
         duration: operation.duration,
         track: typeof lane === "number" ? lane : 0,
+        role: operation.role,
       });
       return {
         ...snapshot,

--- a/tests/golden/corpus.json
+++ b/tests/golden/corpus.json
@@ -2527,6 +2527,7 @@
                 "start": 0,
                 "duration": 8,
                 "track": 0,
+                "role": "video",
                 "startTime": {
                   "value": "0",
                   "timescale": "1"
@@ -2543,6 +2544,7 @@
                 "start": 0,
                 "duration": 8,
                 "track": -1,
+                "role": "music",
                 "startTime": {
                   "value": "0",
                   "timescale": "1"
@@ -2666,6 +2668,7 @@
                 "start": 0,
                 "duration": 8,
                 "track": 0,
+                "role": "video",
                 "startTime": {
                   "value": "0",
                   "timescale": "1"
@@ -2686,6 +2689,7 @@
                 "start": 0,
                 "duration": 8,
                 "track": -1,
+                "role": "music",
                 "startTime": {
                   "value": "0",
                   "timescale": "1"

--- a/tests/integration/media-role-preservation.test.ts
+++ b/tests/integration/media-role-preservation.test.ts
@@ -34,7 +34,7 @@ function createRoleRuntime() {
       },
     ],
   });
-  return { adapter, runtime: new AgentVideoRuntime(adapter) };
+  return new AgentVideoRuntime(adapter);
 }
 
 function mediaAddOperations(): WorkflowOperation[] {
@@ -70,7 +70,7 @@ function mediaAddOperations(): WorkflowOperation[] {
 }
 
 test("media additions preserve video, audio, and music roles in canonical clips", async () => {
-  const { runtime } = createRoleRuntime();
+  const runtime = createRoleRuntime();
   const before = await runtime.inspectProject();
   const preview = await runtime.previewEdit({
     baseRevision: before.revision,
@@ -91,13 +91,13 @@ test("media additions preserve video, audio, and music roles in canonical clips"
 });
 
 test("music clips reject moves to the primary storyline", async () => {
-  const { runtime } = createRoleRuntime();
+  const runtime = createRoleRuntime();
   const before = await runtime.inspectProject();
   const addPreview = await runtime.previewEdit({
     baseRevision: before.revision,
     operations: [mediaAddOperations()[2]!],
   });
-  const added = await runtime.executeEdit(addPreview.previewToken);
+  await runtime.executeEdit(addPreview.previewToken);
   const beforeMove = await runtime.inspectProject();
 
   await assert.rejects(

--- a/tests/integration/media-role-preservation.test.ts
+++ b/tests/integration/media-role-preservation.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { AgentVideoRuntime, type WorkflowOperation } from "@framekit/runtime";
+import { InMemoryEditorAdapter } from "@framekit/testkit";
+
+function createRoleRuntime() {
+  const adapter = new InMemoryEditorAdapter({
+    projectId: "project-media-roles",
+    projectName: "Media Role Fixture",
+    timelineId: "timeline-media-roles",
+    timelineName: "Main Edit",
+    clips: [],
+    media: [
+      {
+        mediaId: "media-video",
+        source: "/fixtures/video.mov",
+        mediaKind: "video",
+        duration: 10,
+        sourceDigest: "sha256:video",
+      },
+      {
+        mediaId: "media-audio",
+        source: "/fixtures/audio.wav",
+        mediaKind: "audio",
+        duration: 10,
+        sourceDigest: "sha256:audio",
+      },
+      {
+        mediaId: "media-music",
+        source: "/fixtures/music.wav",
+        mediaKind: "audio",
+        duration: 10,
+        sourceDigest: "sha256:music",
+      },
+    ],
+  });
+  return { adapter, runtime: new AgentVideoRuntime(adapter) };
+}
+
+function mediaAddOperations(): WorkflowOperation[] {
+  return [
+    {
+      type: "timeline.media.add",
+      occurrenceId: "clip-video",
+      mediaId: "media-video",
+      role: "video",
+      start: 0,
+      duration: 2,
+      targetLane: "primary",
+    },
+    {
+      type: "timeline.media.add",
+      occurrenceId: "clip-audio",
+      mediaId: "media-audio",
+      role: "audio",
+      start: 0,
+      duration: 2,
+      targetLane: -1,
+    },
+    {
+      type: "timeline.media.add",
+      occurrenceId: "clip-music",
+      mediaId: "media-music",
+      role: "music",
+      start: 0,
+      duration: 2,
+      targetLane: -2,
+    },
+  ];
+}
+
+test("media additions preserve video, audio, and music roles in canonical clips", async () => {
+  const { runtime } = createRoleRuntime();
+  const before = await runtime.inspectProject();
+  const preview = await runtime.previewEdit({
+    baseRevision: before.revision,
+    operations: mediaAddOperations(),
+  });
+
+  const transaction = await runtime.executeEdit(preview.previewToken);
+
+  assert.equal(transaction.status, "VERIFIED");
+  assert.deepEqual(
+    transaction.after.timeline.clips.map(({ id, role, track }) => ({ id, role, track })),
+    [
+      { id: "clip-video", role: "video", track: 0 },
+      { id: "clip-audio", role: "audio", track: -1 },
+      { id: "clip-music", role: "music", track: -2 },
+    ],
+  );
+});
+
+test("music clips reject moves to the primary storyline", async () => {
+  const { runtime } = createRoleRuntime();
+  const before = await runtime.inspectProject();
+  const addPreview = await runtime.previewEdit({
+    baseRevision: before.revision,
+    operations: [mediaAddOperations()[2]!],
+  });
+  const added = await runtime.executeEdit(addPreview.previewToken);
+  const beforeMove = await runtime.inspectProject();
+
+  await assert.rejects(
+    runtime.previewEdit({
+      baseRevision: beforeMove.revision,
+      operations: [{
+        type: "timeline.media.move",
+        occurrenceId: "clip-music",
+        start: 1,
+        targetLane: "primary",
+      }],
+    }),
+    /INVALID_OPERATION: audio and title clips require a non-primary lane/,
+  );
+  assert.deepEqual(await runtime.inspectProject(), beforeMove);
+});


### PR DESCRIPTION
Closes #140

## Summary

- Preserve the requested `video`, `audio`, or `music` role on canonical timeline clips created by `timeline.media.add`.
- Add regression coverage proving role-specific lane safety rejects moving a music occurrence to the primary storyline without mutation.
- Update the affected golden workflow expectations.

## Validation

```bash
pnpm install --frozen-lockfile
pnpm run build
pnpm run test
pnpm run check:boundaries
```

All deterministic gates pass: 522 tests passed. The focused media-role suite passes both regression cases. Native Xcode checks were not required because no native files changed.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Existing fixture and runtime contracts remain compatible; canonical clips now retain the role already supplied by the operation.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] No generated files or build artifacts were added.
- [x] No documentation or environment-variable changes were required.
