### PR TITLE
fix: preserve analyzer-provider provenance

### DIFF
--- a/packages/runtime/src/application/project-service.ts
+++ b/packages/runtime/src/application/project-service.ts
@@ -125,10 +125,20 @@ export class ProjectService {
       visualTrack: capabilities.analyzers.visualTrack || Boolean(this.options.visualAnalyzer),
       metadataDescribe: capabilities.analyzers.metadataDescribe || Boolean(this.options.metadataAnalyzer),
     };
+    const analyzerBackends = {
+      speechTranscribe: speechAnalyzer?.descriptor?.provider,
+      speechVad: speechAnalyzer?.descriptor?.provider,
+      audioLoudness: this.options.audioAnalyzer?.descriptor?.provider,
+      audioNoise: this.options.noiseAnalyzer?.descriptor?.provider,
+      visualTrack: this.options.visualAnalyzer?.descriptor?.provider,
+    };
     return {
       identity,
       capabilities: {
-        ...withCapabilityFamilies({ ...capabilities, analyzers }, { backend: identity.backend }),
+        ...withCapabilityFamilies({ ...capabilities, analyzers }, {
+          backend: identity.backend,
+          analyzerBackends,
+        }),
       },
     };
   }

--- a/packages/runtime/src/capabilities.ts
+++ b/packages/runtime/src/capabilities.ts
@@ -41,7 +41,6 @@ export function withCanonicalTimelineMode(capabilities: RuntimeCapabilities): Ru
     nativeBackend: previous.native.selectionWrite.backend,
     publishingBackend: previous.publishing.projectCreation.backend,
     exportBackend: previous.export.timeline.backend,
-    analyzerBackend: previous.analyzers.speechTranscribe.backend,
     connection: previous.connection.status,
     native: nativeAvailability(previous.native),
     publishing: previous.publishing.projectCreation,
@@ -56,6 +55,7 @@ export interface CapabilityFamilyOptions {
   publishingBackend?: string;
   exportBackend?: string;
   analyzerBackend?: string;
+  analyzerBackends?: Partial<Record<keyof CapabilityFamilies["analyzers"], string | undefined>>;
   connection?: boolean | CapabilityDescriptor;
   native?: Partial<Record<NativeCapabilityOperation, boolean>>;
   publishing?: boolean | CapabilityDescriptor;
@@ -81,6 +81,11 @@ export function withCapabilityFamilies(
     },
   };
   const editor = normalized.editor;
+  const analyzerBackend = (operation: keyof CapabilityFamilies["analyzers"]): string =>
+    options.analyzerBackends?.[operation]
+    ?? options.analyzerBackend
+    ?? previous?.analyzers[operation]?.backend
+    ?? backend;
   const native = {
     ...nativeAvailability(previous?.native),
     ...options.native,
@@ -147,11 +152,11 @@ export function withCapabilityFamilies(
       ),
     },
     analyzers: {
-      speechTranscribe: analyzerDescriptor(capabilities.analyzers.speechTranscribe, options.analyzerBackend ?? backend, "speech transcription"),
-      speechVad: analyzerDescriptor(capabilities.analyzers.speechVad, options.analyzerBackend ?? backend, "speech VAD"),
-      audioLoudness: analyzerDescriptor(capabilities.analyzers.audioLoudness, options.analyzerBackend ?? backend, "audio loudness analysis"),
-      audioNoise: analyzerDescriptor(Boolean(capabilities.analyzers.audioNoise), options.analyzerBackend ?? backend, "audio noise analysis"),
-      visualTrack: analyzerDescriptor(capabilities.analyzers.visualTrack, options.analyzerBackend ?? backend, "visual analysis"),
+      speechTranscribe: analyzerDescriptor(capabilities.analyzers.speechTranscribe, analyzerBackend("speechTranscribe"), "speech transcription"),
+      speechVad: analyzerDescriptor(capabilities.analyzers.speechVad, analyzerBackend("speechVad"), "speech VAD"),
+      audioLoudness: analyzerDescriptor(capabilities.analyzers.audioLoudness, analyzerBackend("audioLoudness"), "audio loudness analysis"),
+      audioNoise: analyzerDescriptor(Boolean(capabilities.analyzers.audioNoise), analyzerBackend("audioNoise"), "audio noise analysis"),
+      visualTrack: analyzerDescriptor(capabilities.analyzers.visualTrack, analyzerBackend("visualTrack"), "visual analysis"),
     },
   };
   return { ...normalized, families };

--- a/tests/integration/capabilities.test.ts
+++ b/tests/integration/capabilities.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import {
+  CommandVisualAnalyzer,
   FcpxmlDocumentAdapter,
   FinalCutConnectionManager,
   FinalCutLiveAdapter,
@@ -277,6 +278,35 @@ test("MCP editor inspection exposes native, publishing, export, and analyzer fam
     assert.equal(payload.capabilities.families.publishing.projectCreation.backend, "fcpxml-publisher");
     assert.equal(payload.capabilities.families.export.timeline.available, true);
     assert.equal(payload.capabilities.families.export.timeline.backend, "final-cut-native-export");
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
+
+test("MCP editor inspection preserves configured analyzer provider provenance", async () => {
+  const runtime = new AgentVideoRuntime(new InMemoryEditorAdapter({
+    projectId: "project-1",
+    projectName: "Analyzer Provenance Fixture",
+    timelineId: "timeline-1",
+    timelineName: "Main",
+    clips: [],
+  }), {
+    visualAnalyzer: new CommandVisualAnalyzer({ command: "/usr/bin/true" }),
+  });
+  const server = createMcpServer(runtime);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "analyzer-provenance-test", version: "0.1.0" });
+
+  try {
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    const result = await client.callTool({ name: "editor.inspect", arguments: {} });
+    const payload = JSON.parse(textFrom(result));
+
+    assert.equal(payload.identity.backend, "fixture");
+    assert.equal(payload.capabilities.families.analyzers.visualTrack.available, true);
+    assert.equal(payload.capabilities.families.analyzers.visualTrack.backend, "command");
   } finally {
     await client.close();
     await server.close();

--- a/tests/integration/capabilities.test.ts
+++ b/tests/integration/capabilities.test.ts
@@ -313,6 +313,55 @@ test("MCP editor inspection preserves configured analyzer provider provenance", 
   }
 });
 
+test("editor inspection preserves each configured analyzer provider backend", async () => {
+  const runtime = new AgentVideoRuntime(new InMemoryEditorAdapter({
+    projectId: "project-1",
+    projectName: "Analyzer Provider Fixture",
+    timelineId: "timeline-1",
+    timelineName: "Main",
+    clips: [],
+  }), {
+    speechAnalyzer: {
+      descriptor: { id: "speech.test", provider: "speech-provider" },
+      capabilities: { transcription: true, vad: true },
+      analyze: async () => ({ words: [] }),
+    },
+    audioAnalyzer: {
+      descriptor: { id: "audio.test", provider: "audio-provider" },
+      analyze: async () => ({ integratedLufs: -18, truePeakDb: -3, silenceMs: 0 }),
+    },
+    noiseAnalyzer: {
+      descriptor: { id: "noise.test", provider: "noise-provider" },
+      analyze: async () => ({
+        noiseFloorDb: -60,
+        affectedRanges: [],
+        recommendedReductionDb: 0,
+        confidence: 1,
+      }),
+    },
+    visualAnalyzer: {
+      descriptor: { id: "visual.test", provider: "visual-provider" },
+      analyze: async () => ({ scenes: [], subjects: [], keyframes: [] }),
+    },
+  });
+  const inspected = await runtime.inspectEditor();
+  const analyzers = inspected.capabilities.families.analyzers;
+
+  assert.deepEqual({
+    speechTranscribe: analyzers.speechTranscribe.backend,
+    speechVad: analyzers.speechVad.backend,
+    audioLoudness: analyzers.audioLoudness.backend,
+    audioNoise: analyzers.audioNoise?.backend,
+    visualTrack: analyzers.visualTrack.backend,
+  }, {
+    speechTranscribe: "speech-provider",
+    speechVad: "speech-provider",
+    audioLoudness: "audio-provider",
+    audioNoise: "noise-provider",
+    visualTrack: "visual-provider",
+  });
+});
+
 test("capability documentation describes the versioned operation contract", async () => {
   const architecture = await readFile(join(process.cwd(), "docs/architecture/capability-model.md"), "utf8");
   const mcp = await readFile(join(process.cwd(), "docs/mcp/capabilities-and-errors.md"), "utf8");


### PR DESCRIPTION
<!-- Title naming policy -->

- [x] Request PR review
- [ ] If you are unable to review, please set it as a draft.
- [x] Github issue: Closes: #139

## Summary

Preserve configured analyzer-provider provenance in capability families. `editor.inspect` now reports each analyzer family backend from its configured analyzer descriptor, while retaining the editor backend for editor-owned capabilities and preserving analyzer provenance through MCP normalization.

## Validation

Focused TDD coverage:

```bash
PATH=/Users/shotomorisaki/.nix-profile/bin:$PATH pnpm exec tsx --test tests/integration/capabilities.test.ts tests/speech/capabilities.test.ts
```

Repository validation:

```bash
PATH=/Users/shotomorisaki/.nix-profile/bin:$PATH .agents/skills/validate-framekit/scripts/validate.sh
```

Passed: frozen install, build, 522 tests, and package-boundary checks. Native Xcode gates were skipped because no native files changed.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Existing adapters and test fixtures remain compatible.
- [x] MCP contract remains additive and existing capability documentation already describes provider-specific analyzer backends.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [x] No timeline or media mutation behavior changed.
