### PR TITLE
fix: decouple edits from optional analyzers

### DIFF
--- a/packages/runtime/src/application/media-analysis-service.ts
+++ b/packages/runtime/src/application/media-analysis-service.ts
@@ -29,6 +29,13 @@ import { planRoughCut } from "../planning/rough-cut.js";
 import { bindSpeechAnalysis } from "../speech/analysis.js";
 import { parseRational } from "../timeline/rational-time.js";
 
+export interface PostWriteAnalysisRequirements {
+  speech?: boolean;
+  audio?: boolean;
+  noise?: boolean;
+  visual?: boolean;
+}
+
 export class MediaAnalysisService {
   public constructor(
     private readonly project: ProjectService,
@@ -221,7 +228,10 @@ export class MediaAnalysisService {
       .filter((entry) => matchesMediaIndexQuery(entry, query));
   }
 
-  public async reanalyzeAffectedRanges(transaction: EditTransaction): Promise<ProjectSnapshot> {
+  public async reanalyzeAffectedRanges(
+    transaction: EditTransaction,
+    requirements: PostWriteAnalysisRequirements,
+  ): Promise<ProjectSnapshot> {
     const affectedMediaRanges = transaction.diff.affectedRanges.flatMap((range) =>
       transaction.attemptedAfter.timeline.clips.flatMap((clip) => {
         const intersectionStart = Math.max(range.start, clip.start);
@@ -247,7 +257,7 @@ export class MediaAnalysisService {
         .filter((affected) => affected.mediaId === mediaId)
         .map((affected) => affected.range));
       const input = { project: next, media };
-      if (this.options.speechAnalyzer) {
+      if (requirements.speech && this.options.speechAnalyzer) {
         const analyses = await Promise.all(ranges.map(async (range) => bindSpeechAnalysis(
           await this.options.speechAnalyzer!.analyze(input, range),
           { input, range, provider: this.options.speechAnalyzer!.descriptor },
@@ -260,15 +270,15 @@ export class MediaAnalysisService {
           });
         }
       }
-      if (this.options.audioAnalyzer) {
+      if (requirements.audio && this.options.audioAnalyzer) {
         const analyses = await Promise.all(ranges.map((range) => this.options.audioAnalyzer!.analyze(input, range)));
         if (analyses[analyses.length - 1]) media.audio = analyses[analyses.length - 1];
       }
-      if (this.options.noiseAnalyzer) {
+      if (requirements.noise && this.options.noiseAnalyzer) {
         const analyses = await Promise.all(ranges.map((range) => this.options.noiseAnalyzer!.analyze(input, range)));
         if (analyses[analyses.length - 1]) media.noise = analyses[analyses.length - 1];
       }
-      if (this.options.visualAnalyzer) {
+      if (requirements.visual && this.options.visualAnalyzer) {
         const analyses = await Promise.all(ranges.map((range) => this.options.visualAnalyzer!.analyze(input, range)));
         media.visual = {
           scenes: analyses.flatMap((analysis) => analysis.scenes),
@@ -277,7 +287,10 @@ export class MediaAnalysisService {
           motion: analyses[analyses.length - 1]?.motion,
         };
       }
-      if (this.options.speechAnalyzer || this.options.audioAnalyzer || this.options.noiseAnalyzer || this.options.visualAnalyzer) {
+      if ((requirements.speech && this.options.speechAnalyzer)
+        || (requirements.audio && this.options.audioAnalyzer)
+        || (requirements.noise && this.options.noiseAnalyzer)
+        || (requirements.visual && this.options.visualAnalyzer)) {
         for (const candidate of next.media) {
           if (candidate.mediaId === mediaId) candidate.analysisRevision = next.revision.id;
         }

--- a/packages/runtime/src/editing/edit-service.ts
+++ b/packages/runtime/src/editing/edit-service.ts
@@ -19,7 +19,7 @@ import type { ProjectSnapshot } from "../domain/project.js";
 import type { TimelineDiff } from "../domain/diff.js";
 import type { VerificationEngine, VerificationPolicy } from "../domain/verification.js";
 import { sameRevision } from "../context/revision.js";
-import { MediaAnalysisService } from "../application/media-analysis-service.js";
+import { MediaAnalysisService, type PostWriteAnalysisRequirements } from "../application/media-analysis-service.js";
 import { ProjectService } from "../application/project-service.js";
 import type { RuntimeOptions } from "../application/runtime-options.js";
 import { TransactionStore } from "../application/transaction-store.js";
@@ -118,8 +118,7 @@ export class EditService {
       status: "APPLIED",
     };
     try {
-      transaction.attemptedAfter = await this.analysis.reanalyzeAffectedRanges(transaction);
-      transaction.after = transaction.attemptedAfter;
+      await this.reanalyzeForVerification(transaction, verificationPolicy);
     } catch (error) {
       await this.adapter.restore(before, attemptedAfter.revision);
       this.assertRestored(before, await this.project.inspectProject());
@@ -275,8 +274,7 @@ export class EditService {
       status: "APPLIED",
     };
     try {
-      transaction.attemptedAfter = await this.analysis.reanalyzeAffectedRanges(transaction);
-      transaction.after = transaction.attemptedAfter;
+      await this.reanalyzeForVerification(transaction, verificationPolicy);
     } catch (error) {
       await this.adapter.restore(before, attemptedAfter.revision);
       this.assertRestored(before, await this.project.inspectProject());
@@ -318,6 +316,16 @@ export class EditService {
 
   public async verifyTransaction(transactionId: string): Promise<NonNullable<EditTransaction["verification"]>> {
     return this.getTransaction(transactionId).verification!;
+  }
+
+  private async reanalyzeForVerification(
+    transaction: EditTransaction,
+    policy: VerificationPolicy,
+  ): Promise<void> {
+    const requirements = postWriteAnalysisRequirements(policy);
+    if (!Object.values(requirements).some(Boolean)) return;
+    transaction.attemptedAfter = await this.analysis.reanalyzeAffectedRanges(transaction, requirements);
+    transaction.after = transaction.attemptedAfter;
   }
 
   public async undo(transactionId: string): Promise<ProjectSnapshot> {
@@ -478,6 +486,18 @@ export class EditService {
       if (now > Date.parse(preview.expiresAt)) this.editPreviews.delete(previewToken);
     }
   }
+}
+
+function postWriteAnalysisRequirements(policy: VerificationPolicy): PostWriteAnalysisRequirements {
+  const assertions = policy.assertions ?? [];
+  return {
+    speech: policy.requireSpeechContinuity === true,
+    audio: policy.maxTruePeakDb !== undefined
+      || policy.targetLufs !== undefined
+      || assertions.some((assertion) => assertion.type === "audio-audibility" || assertion.type === "audio-loudness"),
+    noise: assertions.some((assertion) => assertion.type === "audio-noise"),
+    visual: assertions.some((assertion) => assertion.type === "visual-content"),
+  };
 }
 
 function assertValidWorkflowOperation(operation: WorkflowOperation): void {

--- a/tests/integration/composite-transactions.test.ts
+++ b/tests/integration/composite-transactions.test.ts
@@ -411,6 +411,26 @@ test("composite execute restores canonical state when verification throws", asyn
   assert.deepEqual(projectContent(await runtime.inspectProject()), projectContent(before));
 });
 
+test("composite execute ignores optional analyzer failures without verification policy", async () => {
+  let visualCalls = 0;
+  const { runtime } = createCompositeRuntime({
+    visualAnalyzer: {
+      analyze: async () => {
+        visualCalls += 1;
+        throw new Error("ANALYZER_MEDIA_UNAVAILABLE");
+      },
+    },
+  });
+  const before = await runtime.inspectProject();
+  const preview = await runtime.previewEdit({ baseRevision: before.revision, operations: workflowOperations() });
+
+  const transaction = await runtime.executeEdit(preview.previewToken);
+
+  assert.equal(transaction.status, "VERIFIED");
+  assert.equal(visualCalls, 0);
+  assert.equal(transaction.after.media.length, 2);
+});
+
 test("composite execute rejects a failed-verification rollback that does not restore canonical state", async () => {
   const failingVerification: VerificationEngine = {
     verify: async () => ({
@@ -431,7 +451,11 @@ test("composite execute rejects an analysis rollback that does not restore canon
     speechAnalyzer: { analyze: async () => { throw new Error("FIXTURE_ANALYSIS_ERROR"); } },
   });
   const before = await runtime.inspectProject();
-  const preview = await runtime.previewEdit({ baseRevision: before.revision, operations: workflowOperations() });
+  const preview = await runtime.previewEdit({
+    baseRevision: before.revision,
+    operations: workflowOperations(),
+    verification: { requireSpeechContinuity: true },
+  });
   adapter.restore = async () => {};
 
   await assert.rejects(runtime.executeEdit(preview.previewToken), /ROLLBACK_FAILED/);

--- a/tests/integration/phase1.test.ts
+++ b/tests/integration/phase1.test.ts
@@ -386,14 +386,39 @@ test("post-write verification invokes analyzers for affected ranges", async () =
   const editor = fixtureAdapter();
   let speechCalls = 0;
   let audioCalls = 0;
+  let visualCalls = 0;
   const runtime = new AgentVideoRuntime(editor, {
     speechAnalyzer: { analyze: async ({ media }) => { speechCalls += 1; return structuredClone(media.speech!); } },
     audioAnalyzer: { analyze: async ({ media }) => { audioCalls += 1; return structuredClone(media.audio!); } },
+    visualAnalyzer: { analyze: async () => { visualCalls += 1; throw new Error("ANALYZER_MEDIA_UNAVAILABLE"); } },
   });
-  const transaction = await runtime.edit({ type: "rename-clip", clipId: "clip-1", name: "Analyzed" });
+  const transaction = await runtime.edit(
+    { type: "rename-clip", clipId: "clip-1", name: "Analyzed" },
+    { requireSpeechContinuity: true, targetLufs: -18 },
+  );
   assert.equal(transaction.status, "VERIFIED");
   assert.ok(speechCalls > 0);
   assert.ok(audioCalls > 0);
+  assert.equal(visualCalls, 0);
+});
+
+test("unrelated edits ignore optional analyzer failures without verification policy", async () => {
+  const editor = fixtureAdapter();
+  let visualCalls = 0;
+  const runtime = new AgentVideoRuntime(editor, {
+    visualAnalyzer: {
+      analyze: async () => {
+        visualCalls += 1;
+        throw new Error("ANALYZER_MEDIA_UNAVAILABLE");
+      },
+    },
+  });
+
+  const transaction = await runtime.edit({ type: "rename-clip", clipId: "clip-1", name: "Independent" });
+
+  assert.equal(transaction.status, "VERIFIED");
+  assert.equal(transaction.after.timeline.clips[0]?.name, "Independent");
+  assert.equal(visualCalls, 0);
 });
 
 test("post-write verification rolls back when speech analysis is stale", async () => {
@@ -409,7 +434,10 @@ test("post-write verification rolls back when speech analysis is stale", async (
   });
 
   await assert.rejects(
-    runtime.edit({ type: "rename-clip", clipId: "clip-1", name: "Must Not Persist" }),
+    runtime.edit(
+      { type: "rename-clip", clipId: "clip-1", name: "Must Not Persist" },
+      { requireSpeechContinuity: true },
+    ),
     /ANALYSIS_FAILED: post-write verification analysis failed .*STALE_CONTEXT/,
   );
   const restored = await editor.readProject();
@@ -441,15 +469,22 @@ test("post-write verification passes clip intersections in media-relative coordi
     } },
     visualAnalyzer: { analyze: async (_input, range) => {
       if (range) ranges.visual.push(range);
-      return { scenes: [], subjects: [], keyframes: [] };
+      return { scenes: [], subjects: [{ id: "subject-person", label: "person", confidence: 1 }], keyframes: [] };
     } },
   });
 
-  await runtime.edit({
-    type: "add-marker",
-    timelineId: "timeline-analysis-range",
-    marker: { id: "marker-analysis", start: 8, duration: 4, name: "Review" },
-  });
+  await runtime.edit(
+    {
+      type: "add-marker",
+      timelineId: "timeline-analysis-range",
+      marker: { id: "marker-analysis", start: 8, duration: 4, name: "Review" },
+    },
+    {
+      requireSpeechContinuity: true,
+      targetLufs: -18,
+      assertions: [{ type: "visual-content", mediaId: "media-analysis", label: "person" }],
+    },
+  );
 
   assert.deepEqual(ranges, {
     speech: [{ start: 0, end: 2 }],
@@ -508,11 +543,14 @@ test("post-write speech reanalysis retains evidence outside changed ranges", asy
     },
   });
 
-  const transaction = await runtime.edit({
-    type: "add-marker",
-    timelineId: "timeline-retained-speech",
-    marker: { id: "marker-retained-speech", start: 4, duration: 1, name: "Review" },
-  });
+  const transaction = await runtime.edit(
+    {
+      type: "add-marker",
+      timelineId: "timeline-retained-speech",
+      marker: { id: "marker-retained-speech", start: 4, duration: 1, name: "Review" },
+    },
+    { requireSpeechContinuity: true },
+  );
 
   const speech = transaction.after.media[0]?.speech;
   assert.equal(transaction.status, "VERIFIED");
@@ -546,11 +584,14 @@ test("post-write speech reanalysis coalesces overlapping source ranges", async (
     },
   });
 
-  const transaction = await runtime.edit({
-    type: "trim-clip",
-    clipId: "clip-coalesced-speech",
-    duration: 9,
-  });
+  const transaction = await runtime.edit(
+    {
+      type: "trim-clip",
+      clipId: "clip-coalesced-speech",
+      duration: 9,
+    },
+    { requireSpeechContinuity: true },
+  );
 
   assert.equal(transaction.status, "VERIFIED");
   assert.deepEqual(ranges, [{ start: 0, end: 9 }]);

--- a/tests/integration/semantic-media.test.ts
+++ b/tests/integration/semantic-media.test.ts
@@ -138,11 +138,14 @@ test("media understanding cache invalidates after a timeline revision", async ()
   const understanding = await runtime.understandMedia("media-semantic-1");
   assert.equal(understanding.analysisRevision.id, before.revision.id);
 
-  const transaction = await runtime.edit({
-    type: "rename-clip",
-    clipId: "clip-semantic-1",
-    name: "Interview - Clean",
-  });
+  const transaction = await runtime.edit(
+    {
+      type: "rename-clip",
+      clipId: "clip-semantic-1",
+      name: "Interview - Clean",
+    },
+    { assertions: [{ type: "visual-content", mediaId: "media-semantic-1", label: "person" }] },
+  );
   assert.equal(transaction.after.revision.id, "rev-1");
   assert.equal(transaction.after.media[0]?.analysisRevision, transaction.after.revision.id);
 


### PR DESCRIPTION
- [x] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [x] Github issue: Closes: #138

## Summary

Post-write analyzer execution is now driven by the requested verification policy. Unrelated direct and composite edits no longer invoke configured optional analyzers, so an unreadable analyzer source cannot roll back an otherwise valid edit. Analyzer-backed verification still invokes only the required analyzer families.

The TDD changes include regression coverage for direct edits, composite execute, analyzer selection, stale required analysis, and semantic cache refresh when visual verification is explicitly requested.

## Validation

```bash
pnpm install --frozen-lockfile
pnpm run build
pnpm run test
pnpm run check:boundaries
```

All validation passed: 522 tests, build, install, and package boundaries. Native checks were skipped because no native files changed.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Public MCP behavior or package interfaces are documented if changed.
- [x] Existing adapters and test fixtures remain compatible, or the migration is explained above.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [x] Documentation reflects any changed commands, paths, or environment variables.
