### PR TITLE
perf: advertise music.add cross-field constraints

### DIFF
--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -216,6 +216,12 @@ const verificationPolicySchema = z.object({
   loudnessToleranceDb: z.number().finite().nonnegative().optional(),
   assertions: z.array(verificationAssertionSchema).optional(),
 }).strict();
+function mcpObjectSchema<Schema extends z.ZodTypeAny>(schema: Schema): Schema {
+  // The MCP SDK only serializes schemas it recognizes as object-shaped.
+  Object.defineProperty(schema, "shape", { value: {}, enumerable: false });
+  return schema;
+}
+
 function mcpDiscriminatedUnion<const Options extends readonly [z.AnyZodObject, ...z.AnyZodObject[]]>(
   options: Options,
 ): z.ZodType<z.output<Options[number]>, z.ZodTypeDef, z.input<Options[number]>> {
@@ -223,18 +229,14 @@ function mcpDiscriminatedUnion<const Options extends readonly [z.AnyZodObject, .
     z.ZodDiscriminatedUnionOption<"type">,
     ...z.ZodDiscriminatedUnionOption<"type">[],
   ]);
-  // The MCP SDK only serializes schemas it recognizes as object-shaped.
-  Object.defineProperty(schema, "shape", { value: {}, enumerable: false });
-  return schema;
+  return mcpObjectSchema(schema);
 }
 
 function mcpUnion<const Options extends readonly [z.AnyZodObject, ...z.AnyZodObject[]]>(
   options: Options,
 ): z.ZodType<z.output<Options[number]>, z.ZodTypeDef, z.input<Options[number]>> {
   const schema = z.union(options as unknown as [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]);
-  // The MCP SDK only serializes schemas it recognizes as object-shaped.
-  Object.defineProperty(schema, "shape", { value: {}, enumerable: false });
-  return schema;
+  return mcpObjectSchema(schema);
 }
 
 function createEditToolInputSchema<Target extends z.ZodRawShape = {}>(

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -228,6 +228,15 @@ function mcpDiscriminatedUnion<const Options extends readonly [z.AnyZodObject, .
   return schema;
 }
 
+function mcpUnion<const Options extends readonly [z.AnyZodObject, ...z.AnyZodObject[]]>(
+  options: Options,
+): z.ZodType<z.output<Options[number]>, z.ZodTypeDef, z.input<Options[number]>> {
+  const schema = z.union(options as unknown as [z.ZodTypeAny, z.ZodTypeAny, ...z.ZodTypeAny[]]);
+  // The MCP SDK only serializes schemas it recognizes as object-shaped.
+  Object.defineProperty(schema, "shape", { value: {}, enumerable: false });
+  return schema;
+}
+
 function createEditToolInputSchema<Target extends z.ZodRawShape = {}>(
   target: Target = {} as Target,
   baseRevision: z.ZodTypeAny = revisionSchema,
@@ -406,13 +415,9 @@ const musicDuckingSchema = z.object({
   dialogueClipIds: z.array(z.string().min(1)).optional(),
   reductionDb: z.number().finite().optional(),
 });
-const musicAddInputSchema = {
+const musicAddCommonInputSchema = {
   baseRevision: revisionValueSchema,
   occurrenceId: z.string().min(1),
-  mediaId: z.string().min(1).optional(),
-  import: musicImportSchema.optional(),
-  placement: z.enum(["append", "insert"]),
-  start: z.number().nonnegative().optional(),
   duration: z.number().positive().optional(),
   targetLane: z.number().int().refine((lane) => lane !== 0, "music requires a non-primary lane"),
   gainDb: z.number().finite().optional(),
@@ -421,6 +426,30 @@ const musicAddInputSchema = {
   ducking: musicDuckingSchema.optional(),
   verification: verificationPolicySchema.optional(),
 };
+const musicAddInputSchema = mcpUnion([
+  z.object({
+    ...musicAddCommonInputSchema,
+    mediaId: z.string().min(1),
+    placement: z.literal("append"),
+  }).strict(),
+  z.object({
+    ...musicAddCommonInputSchema,
+    import: musicImportSchema,
+    placement: z.literal("append"),
+  }).strict(),
+  z.object({
+    ...musicAddCommonInputSchema,
+    mediaId: z.string().min(1),
+    placement: z.literal("insert"),
+    start: z.number().nonnegative(),
+  }).strict(),
+  z.object({
+    ...musicAddCommonInputSchema,
+    import: musicImportSchema,
+    placement: z.literal("insert"),
+    start: z.number().nonnegative(),
+  }).strict(),
+]);
 const fillerRemovalInputSchema = {
   baseRevision: revisionValueSchema,
   range: rangeSchema,

--- a/tests/integration/music-mixing.test.ts
+++ b/tests/integration/music-mixing.test.ts
@@ -40,6 +40,14 @@ function textFrom(result: unknown): string {
   return first.text as string;
 }
 
+type PublishedMusicSchema = {
+  anyOf?: Array<{
+    additionalProperties?: boolean;
+    properties?: Record<string, { const?: unknown }>;
+    required?: string[];
+  }>;
+};
+
 test("music workflow previews, mixes, verifies, and undoes an appended music bed", async () => {
   const { runtime } = createMusicRuntime();
   const before = await runtime.inspectProject();
@@ -148,6 +156,60 @@ test("MCP exposes guarded music preview, execute, verification, and undo", async
     assert.equal(ducked.isError, true);
     assert.match(textFrom(ducked), /CAPABILITY_UNAVAILABLE: dialogue ducking/);
     assert.deepEqual(await runtime.inspectProject(), undone);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
+
+test("music.add publishes source and placement constraints", async () => {
+  const { runtime } = createMusicRuntime();
+  const server = createMcpServer(runtime);
+  const client = new Client({ name: "music-schema-test", version: "0.1.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  try {
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+    const tools = await client.listTools();
+    const musicAdd = tools.tools.find((tool) => tool.name === "music.add");
+    assert.ok(musicAdd);
+    const schema = musicAdd.inputSchema as PublishedMusicSchema;
+    const variants = (schema.anyOf ?? []).map((branch) => ({
+      placement: branch.properties?.placement?.const,
+      requiresMediaId: branch.required?.includes("mediaId") ?? false,
+      requiresImport: branch.required?.includes("import") ?? false,
+      requiresStart: branch.required?.includes("start") ?? false,
+      forbidsExtraFields: branch.additionalProperties === false,
+    }));
+    assert.deepEqual(variants.sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right))), [
+      { placement: "append", requiresMediaId: true, requiresImport: false, requiresStart: false, forbidsExtraFields: true },
+      { placement: "append", requiresMediaId: false, requiresImport: true, requiresStart: false, forbidsExtraFields: true },
+      { placement: "insert", requiresMediaId: true, requiresImport: false, requiresStart: true, forbidsExtraFields: true },
+      { placement: "insert", requiresMediaId: false, requiresImport: true, requiresStart: true, forbidsExtraFields: true },
+    ].sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right))));
+
+    const before = await runtime.inspectProject();
+    const shared = {
+      baseRevision: before.revision,
+      occurrenceId: "invalid-schema-request",
+      targetLane: -1,
+      duration: 1,
+    };
+    for (const arguments_ of [
+      { ...shared, placement: "append" },
+      {
+        ...shared,
+        mediaId: "media-dialogue",
+        import: { mediaId: "media-import", source: "music.wav", duration: 1, sourceDigest: "sha256:music" },
+        placement: "append",
+      },
+      { ...shared, mediaId: "media-dialogue", placement: "insert" },
+      { ...shared, mediaId: "media-dialogue", placement: "append", start: 0 },
+    ]) {
+      const result = await client.callTool({ name: "music.add", arguments: arguments_ });
+      assert.equal(result.isError, true);
+      assert.match(textFrom(result), /Input validation error/);
+    }
   } finally {
     await client.close();
     await server.close();


### PR DESCRIPTION
- [x] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pulls/) draft.
- [x] Github issue: Closes: #141

## Summary

`music.add` now publishes machine-readable cross-field placement constraints:

- exactly one of `mediaId` or `import` is accepted;
- `append` rejects `start`;
- `insert` requires a non-negative `start`.

The runtime's existing fail-closed validation remains unchanged.

## Validation

TDD was implemented in incremental commits: a failing schema-contract test, the minimal schema implementation, and a green helper refactor.

```bash
pnpm install --frozen-lockfile
pnpm run build
pnpm run test
pnpm run check:boundaries
pnpm exec tsx --test tests/integration/music-mixing.test.ts
```

All required deterministic gates passed: 521 tests, build, and package boundaries. Native Xcode gates were not required because no native files changed.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Public MCP behavior is covered by `tools/list` and invalid-call integration tests.
- [x] Existing runtime behavior and test fixtures remain compatible.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [x] Documentation and environment-variable contracts are unchanged.
