### PR TITLE
fix: make FCPXML publishing state-driven

### DIFF
--- a/adapters/final-cut/typescript/src/publisher.ts
+++ b/adapters/final-cut/typescript/src/publisher.ts
@@ -338,13 +338,20 @@ async function waitForImportedProject(
 ): Promise<EditorLiveState> {
   const deadline = Date.now() + timeoutMs;
   let latest: EditorLiveState | undefined;
+  let lastError: unknown;
   do {
-    latest = await readLiveState(liveState, "after import");
-    if (isImportedProject(latest, identity, before)) return latest;
+    try {
+      latest = await readLiveState(liveState, "after import");
+      lastError = undefined;
+      if (isImportedProject(latest, identity, before)) return latest;
+    } catch (error) {
+      lastError = error;
+    }
     if (Date.now() >= deadline) break;
     await delay(Math.min(pollIntervalMs, Math.max(0, deadline - Date.now())));
   } while (true);
 
+  if (lastError) throw lastError;
   const observedProject = latest?.project?.name ?? "none";
   const observedSequence = latest?.sequence?.name ?? "none";
   throw new Error(

--- a/adapters/final-cut/typescript/src/publisher.ts
+++ b/adapters/final-cut/typescript/src/publisher.ts
@@ -151,6 +151,8 @@ async function runAppleScript(script: string): Promise<string> {
 
 function importXmlScript(path: string): string {
   return `
+using terms from application "System Events"
+
 on waitForMenuItem(container, expectedNames, timeoutSeconds, timeoutMessage)
   set deadline to (current date) + timeoutSeconds
   repeat
@@ -237,6 +239,8 @@ on cancelImportIfOpen(finalCut)
     end if
   end try
 end cancelImportIfOpen
+
+end using terms from
 
 tell application "System Events"
   tell process "Final Cut Pro"

--- a/adapters/final-cut/typescript/src/publisher.ts
+++ b/adapters/final-cut/typescript/src/publisher.ts
@@ -274,22 +274,22 @@ tell application "System Events"
     try
       if not frontmost then error number -1719
       set fileMenu to menu "File" of menu bar 1
-      set importMenuItem to waitForMenuItem(fileMenu, {"Import"}, 10, "FINAL_CUT_PUBLISH_IMPORT_MENU_TIMEOUT: File > Import was not exposed")
+      set importMenuItem to my waitForMenuItem(fileMenu, {"Import"}, 10, "FINAL_CUT_PUBLISH_IMPORT_MENU_TIMEOUT: File > Import was not exposed")
       perform action "AXPress" of importMenuItem
-      set importMenu to waitForSubmenu(importMenuItem, "Import", 10, "FINAL_CUT_PUBLISH_IMPORT_MENU_TIMEOUT: Import submenu was not exposed")
-      set xmlMenuItem to waitForMenuItem(importMenu, {"XML…", "XML..."}, 10, "FINAL_CUT_PUBLISH_IMPORT_MENU_TIMEOUT: Import XML command was not exposed")
+      set importMenu to my waitForSubmenu(importMenuItem, "Import", 10, "FINAL_CUT_PUBLISH_IMPORT_MENU_TIMEOUT: Import submenu was not exposed")
+      set xmlMenuItem to my waitForMenuItem(importMenu, {"XML…", "XML..."}, 10, "FINAL_CUT_PUBLISH_IMPORT_MENU_TIMEOUT: Import XML command was not exposed")
       perform action "AXPress" of xmlMenuItem
-      set importWindow to waitForWindow(finalCut, "Import XML", 10, "FINAL_CUT_PUBLISH_IMPORT_SHEET_TIMEOUT: Import XML sheet did not appear")
+      set importWindow to my waitForWindow(finalCut, "Import XML", 10, "FINAL_CUT_PUBLISH_IMPORT_SHEET_TIMEOUT: Import XML sheet did not appear")
       keystroke "g" using {command down, shift down}
-      set pathSheet to waitForImportSheet(importWindow, 10)
-      set pathField to locateImportPathField(pathSheet)
+      set pathSheet to my waitForImportSheet(importWindow, 10)
+      set pathField to my locateImportPathField(pathSheet)
       set value of pathField to ${appleScriptString(path)}
       key code 36
-      waitForImportSheetDismissal(importWindow, 10)
+      my waitForImportSheetDismissal(importWindow, 10)
       key code 36
-      waitForImportWindowDismissal(finalCut, 60)
+      my waitForImportWindowDismissal(finalCut, 60)
     on error errorMessage number errorNumber
-      cancelImportIfOpen(finalCut)
+      my cancelImportIfOpen(finalCut)
       error errorMessage number errorNumber
     end try
   end tell

--- a/adapters/final-cut/typescript/src/publisher.ts
+++ b/adapters/final-cut/typescript/src/publisher.ts
@@ -202,6 +202,31 @@ on waitForImportSheet(importWindow, timeoutSeconds)
   end repeat
 end waitForImportSheet
 
+on matchesImportPathField(candidate)
+  set candidateIdentifier to ""
+  set candidateDescription to ""
+  try
+    set candidateIdentifier to value of attribute "AXIdentifier" of candidate as text
+  end try
+  try
+    set candidateDescription to description of candidate as text
+  end try
+  if candidateIdentifier is "path" or candidateIdentifier is "location" then return true
+  if candidateDescription contains "Go to the folder" then return true
+  if candidateDescription contains "path" or candidateDescription contains "location" then return true
+  return false
+end matchesImportPathField
+
+on locateImportPathField(pathSheet)
+  set matchingFields to {}
+  repeat with candidate in (text fields of pathSheet)
+    if matchesImportPathField(candidate) then set end of matchingFields to candidate
+  end repeat
+  if (count of matchingFields) is 0 then error "FINAL_CUT_PUBLISH_PATH_CONTROL_UNAVAILABLE: Import XML path control had no accessibility identifier or description"
+  if (count of matchingFields) is not 1 then error "FINAL_CUT_PUBLISH_PATH_CONTROL_AMBIGUOUS: Import XML path control was not unique"
+  return item 1 of matchingFields
+end locateImportPathField
+
 on waitForImportSheetDismissal(importWindow, timeoutSeconds)
   set deadline to (current date) + timeoutSeconds
   repeat
@@ -257,9 +282,7 @@ tell application "System Events"
       set importWindow to waitForWindow(finalCut, "Import XML", 10, "FINAL_CUT_PUBLISH_IMPORT_SHEET_TIMEOUT: Import XML sheet did not appear")
       keystroke "g" using {command down, shift down}
       set pathSheet to waitForImportSheet(importWindow, 10)
-      set pathFields to text fields of pathSheet
-      if (count of pathFields) is 0 then error "FINAL_CUT_PUBLISH_PATH_CONTROL_UNAVAILABLE: Import XML path control was not exposed"
-      set pathField to item 1 of pathFields
+      set pathField to locateImportPathField(pathSheet)
       set value of pathField to ${appleScriptString(path)}
       key code 36
       waitForImportSheetDismissal(importWindow, 10)

--- a/adapters/final-cut/typescript/src/publisher.ts
+++ b/adapters/final-cut/typescript/src/publisher.ts
@@ -46,6 +46,9 @@ export interface FinalCutProjectPublisherOptions {
   sourcePath: string;
   executor?: (script: string) => Promise<string>;
   liveState?: () => Promise<EditorLiveState>;
+  verificationTimeoutMs?: number;
+  pollIntervalMs?: number;
+  /** @deprecated Use pollIntervalMs. */
   waitMs?: number;
 }
 
@@ -55,14 +58,16 @@ export class FinalCutProjectPublisher {
   private readonly sourcePath: string;
   private readonly executor: (script: string) => Promise<string>;
   private readonly liveState?: () => Promise<EditorLiveState>;
-  private readonly waitMs: number;
+  private readonly verificationTimeoutMs: number;
+  private readonly pollIntervalMs: number;
 
   public constructor(options: FinalCutProjectPublisherOptions) {
     this.enabled = options.enabled ?? false;
     this.sourcePath = options.sourcePath;
     this.executor = options.executor ?? runAppleScript;
     this.liveState = options.liveState;
-    this.waitMs = options.waitMs ?? 1_500;
+    this.verificationTimeoutMs = Math.max(0, options.verificationTimeoutMs ?? 15_000);
+    this.pollIntervalMs = Math.max(0, options.pollIntervalMs ?? options.waitMs ?? 100);
   }
 
   public isAvailable(): boolean {
@@ -84,41 +89,46 @@ export class FinalCutProjectPublisher {
     if (!source.includes("<fcpxml") || !source.includes("<project")) {
       throw new Error("FINAL_CUT_PUBLISH_VALIDATION_FAILED: source is not a valid FCPXML project artifact");
     }
-    const projectName = projectNameFromXml(source);
-    const beforeLive = this.liveState ? await this.liveState() : undefined;
+    const identity = projectIdentityFromXml(source);
+    if (!this.liveState) {
+      throw new Error("FINAL_CUT_PUBLISH_VERIFICATION_UNAVAILABLE: live project and sequence state is required");
+    }
+    const beforeLive = await readLiveState(this.liveState, "before import");
     const directory = await mkdtemp(join(tmpdir(), "framekit-finalcut-publish-"));
     const importedPath = join(directory, basename(this.sourcePath));
     await writeFile(importedPath, source, "utf8");
     try {
       await this.executor(importXmlScript(importedPath));
-      await delay(this.waitMs);
-      const live = this.liveState ? await this.liveState() : undefined;
-      if (live && live.project?.name !== projectName) {
-        throw new Error(`FINAL_CUT_PUBLISH_VERIFICATION_FAILED: expected new project ${projectName}, observed ${live.project?.name ?? "none"}`);
-      }
+      const live = await waitForImportedProject(
+        this.liveState,
+        identity,
+        beforeLive,
+        this.verificationTimeoutMs,
+        this.pollIntervalMs,
+      );
       return {
         sourceTransactionId: request.sourceTransactionId,
         sourcePath: this.sourcePath,
         sourceTarget: { kind: "artifact", artifactPath: this.sourcePath },
         importedPath,
-        projectName,
+        projectName: identity.projectName,
         createdTarget: {
           kind: "editor.project",
           ...(live?.project?.id ? { projectId: live.project.id } : {}),
           ...(live?.sequence?.id ? { sequenceId: live.sequence.id } : {}),
-          projectName,
+          projectName: identity.projectName,
           ...(live?.sequence?.name ? { sequenceName: live.sequence.name } : {}),
         },
         activeProject: {
-          ...(beforeLive?.project ? { before: beforeLive.project } : {}),
-          ...(live?.project ? { after: live.project } : {}),
-          ...(beforeLive?.project && live?.project
+          ...(beforeLive.project ? { before: beforeLive.project } : {}),
+          ...(live.project ? { after: live.project } : {}),
+          ...(beforeLive.project && live.project
             ? { changed: beforeLive.project.id !== live.project.id || beforeLive.project.name !== live.project.name }
             : {}),
         },
         verified: true,
-        ...(live?.project?.name ? { liveProject: live.project.name } : {}),
-        ...(live?.sequence?.name ? { liveSequence: live.sequence.name } : {}),
+        ...(live.project?.name ? { liveProject: live.project.name } : {}),
+        ...(live.sequence?.name ? { liveSequence: live.sequence.name } : {}),
       };
     } finally {
       await rm(directory, { recursive: true, force: true });
@@ -141,28 +151,130 @@ async function runAppleScript(script: string): Promise<string> {
 
 function importXmlScript(path: string): string {
   return `
+on waitForMenuItem(container, expectedNames, timeoutSeconds, timeoutMessage)
+  set deadline to (current date) + timeoutSeconds
+  repeat
+    repeat with candidate in (menu items of container)
+      try
+        set candidateName to name of candidate as text
+        repeat with expectedName in expectedNames
+          if candidateName is (expectedName as text) then return candidate
+        end repeat
+      end try
+    end repeat
+    if (current date) > deadline then error timeoutMessage
+    delay 0.1
+  end repeat
+end waitForMenuItem
+
+on waitForSubmenu(menuItem, submenuName, timeoutSeconds, timeoutMessage)
+  set deadline to (current date) + timeoutSeconds
+  repeat
+    try
+      if exists menu submenuName of menuItem then return menu submenuName of menuItem
+    end try
+    if (current date) > deadline then error timeoutMessage
+    delay 0.1
+  end repeat
+end waitForSubmenu
+
+on waitForWindow(finalCut, windowName, timeoutSeconds, timeoutMessage)
+  set deadline to (current date) + timeoutSeconds
+  repeat
+    try
+      if exists window windowName of finalCut then return window windowName of finalCut
+    end try
+    if (current date) > deadline then error timeoutMessage
+    delay 0.1
+  end repeat
+end waitForWindow
+
+on waitForImportSheet(importWindow, timeoutSeconds)
+  set deadline to (current date) + timeoutSeconds
+  repeat
+    try
+      if exists sheet 1 of importWindow then return sheet 1 of importWindow
+    end try
+    if (current date) > deadline then error "FINAL_CUT_PUBLISH_IMPORT_SHEET_TIMEOUT: Import XML sheet did not appear"
+    delay 0.1
+  end repeat
+end waitForImportSheet
+
+on waitForImportSheetDismissal(importWindow, timeoutSeconds)
+  set deadline to (current date) + timeoutSeconds
+  repeat
+    try
+      if not (exists sheet 1 of importWindow) then return
+    end try
+    if (current date) > deadline then error "FINAL_CUT_PUBLISH_IMPORT_SHEET_DISMISS_TIMEOUT: Import XML sheet did not disappear"
+    delay 0.1
+  end repeat
+end waitForImportSheetDismissal
+
+on waitForImportWindowDismissal(finalCut, timeoutSeconds)
+  set deadline to (current date) + timeoutSeconds
+  repeat
+    try
+      if not (exists window "Import XML" of finalCut) then return
+    end try
+    if (current date) > deadline then error "FINAL_CUT_PUBLISH_IMPORT_TIMEOUT: Import XML window did not close"
+    delay 0.1
+  end repeat
+end waitForImportWindowDismissal
+
+on cancelImportIfOpen(finalCut)
+  try
+    if exists window "Import XML" of finalCut then
+      set importWindow to window "Import XML" of finalCut
+      repeat with candidate in (buttons of importWindow)
+        try
+          if (name of candidate as text) is "Cancel" then
+            perform action "AXPress" of candidate
+            exit repeat
+          end if
+        end try
+      end repeat
+    end if
+  end try
+end cancelImportIfOpen
+
 tell application "System Events"
   tell process "Final Cut Pro"
-    if not frontmost then error number -1719
-    set fileMenu to menu "File" of menu bar 1
-    click menu item "Import" of fileMenu
-    delay 0.2
-    click menu item "XML…" of menu "Import" of menu item "Import" of fileMenu
-    delay 0.4
-    keystroke "g" using {command down, shift down}
-    delay 0.2
-    set value of first text field of sheet 1 of window "Import XML" to ${appleScriptString(path)}
-    key code 36
-    delay 0.5
-    key code 36
+    set finalCut to it
+    set importWindow to missing value
+    try
+      if not frontmost then error number -1719
+      set fileMenu to menu "File" of menu bar 1
+      set importMenuItem to waitForMenuItem(fileMenu, {"Import"}, 10, "FINAL_CUT_PUBLISH_IMPORT_MENU_TIMEOUT: File > Import was not exposed")
+      perform action "AXPress" of importMenuItem
+      set importMenu to waitForSubmenu(importMenuItem, "Import", 10, "FINAL_CUT_PUBLISH_IMPORT_MENU_TIMEOUT: Import submenu was not exposed")
+      set xmlMenuItem to waitForMenuItem(importMenu, {"XML…", "XML..."}, 10, "FINAL_CUT_PUBLISH_IMPORT_MENU_TIMEOUT: Import XML command was not exposed")
+      perform action "AXPress" of xmlMenuItem
+      set importWindow to waitForWindow(finalCut, "Import XML", 10, "FINAL_CUT_PUBLISH_IMPORT_SHEET_TIMEOUT: Import XML sheet did not appear")
+      keystroke "g" using {command down, shift down}
+      set pathSheet to waitForImportSheet(importWindow, 10)
+      set pathFields to text fields of pathSheet
+      if (count of pathFields) is 0 then error "FINAL_CUT_PUBLISH_PATH_CONTROL_UNAVAILABLE: Import XML path control was not exposed"
+      set pathField to item 1 of pathFields
+      set value of pathField to ${appleScriptString(path)}
+      key code 36
+      waitForImportSheetDismissal(importWindow, 10)
+      key code 36
+      waitForImportWindowDismissal(finalCut, 60)
+    on error errorMessage number errorNumber
+      cancelImportIfOpen(finalCut)
+      error errorMessage number errorNumber
+    end try
   end tell
 end tell`;
 }
 
-function projectNameFromXml(source: string): string {
-  const match = source.match(/<project\b[^>]*\bname="([^"]+)"/);
-  if (!match?.[1]) throw new Error("FINAL_CUT_PUBLISH_VALIDATION_FAILED: FCPXML project has no name");
-  return decodeXml(match[1]);
+function projectIdentityFromXml(source: string): { projectName: string; sequenceName: string } {
+  const projectMatch = source.match(/<project\b[^>]*\bname="([^"]+)"/);
+  if (!projectMatch?.[1]) throw new Error("FINAL_CUT_PUBLISH_VALIDATION_FAILED: FCPXML project has no name");
+  const projectName = decodeXml(projectMatch[1]);
+  const sequenceMatch = source.match(/<sequence\b[^>]*\bname="([^"]+)"/);
+  return { projectName, sequenceName: sequenceMatch?.[1] ? decodeXml(sequenceMatch[1]) : projectName };
 }
 
 function decodeXml(value: string): string {
@@ -175,7 +287,54 @@ function decodeXml(value: string): string {
 }
 
 function appleScriptString(value: string): string {
-  return `"${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"').replace(/[\\r\\n]/g, " ")}"`;
+  return `"${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"').replace(/[\r\n]/g, " ")}"`;
+}
+
+async function readLiveState(
+  liveState: () => Promise<EditorLiveState>,
+  phase: string,
+): Promise<EditorLiveState> {
+  try {
+    return await liveState();
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`FINAL_CUT_PUBLISH_STATE_UNAVAILABLE: ${phase}: ${detail}`);
+  }
+}
+
+async function waitForImportedProject(
+  liveState: () => Promise<EditorLiveState>,
+  identity: { projectName: string; sequenceName: string },
+  before: EditorLiveState,
+  timeoutMs: number,
+  pollIntervalMs: number,
+): Promise<EditorLiveState> {
+  const deadline = Date.now() + timeoutMs;
+  let latest: EditorLiveState | undefined;
+  do {
+    latest = await readLiveState(liveState, "after import");
+    if (isImportedProject(latest, identity, before)) return latest;
+    if (Date.now() >= deadline) break;
+    await delay(Math.min(pollIntervalMs, Math.max(0, deadline - Date.now())));
+  } while (true);
+
+  const observedProject = latest?.project?.name ?? "none";
+  const observedSequence = latest?.sequence?.name ?? "none";
+  throw new Error(
+    `FINAL_CUT_PUBLISH_VERIFICATION_FAILED: expected new project ${identity.projectName} / sequence ${identity.sequenceName}, observed ${observedProject} / ${observedSequence}`,
+  );
+}
+
+function isImportedProject(
+  live: EditorLiveState,
+  identity: { projectName: string; sequenceName: string },
+  before: EditorLiveState,
+): boolean {
+  if (!live.project || !live.sequence) return false;
+  if (live.project.name !== identity.projectName || live.sequence.name !== identity.sequenceName) return false;
+  if (before.project && live.project.id === before.project.id) return false;
+  if (before.sequence && live.sequence.id === before.sequence.id) return false;
+  return true;
 }
 
 function delay(milliseconds: number): Promise<void> {

--- a/docs/architecture/rough-cut-construction.md
+++ b/docs/architecture/rough-cut-construction.md
@@ -66,8 +66,10 @@ canonical workflow for the selected target. They never silently replace the
 currently open Final Cut project. A verified artifact can be published as a new project through
 `timeline.publish.new-project`, which requires a verified transaction and the
 configured `FinalCutProjectPublisher`. The publisher imports a temporary copy
-of the FCPXML artifact, verifies the resulting project identity when live state
-is available, and does not replace the active project.
+of the FCPXML artifact through an Accessibility-driven Import XML state machine,
+waits for the import sheet to disappear, verifies the resulting project and
+sequence identities against the prior active target, and does not replace the active project. A headed publisher E2E validates this workflow separately from
+the prepared disposable native-edit fixture.
 
 This separation means a fixture can prove rough-cut construction and an
 FCPXML-backed workflow can produce a verified artifact without implying that

--- a/docs/architecture/rough-cut-construction.md
+++ b/docs/architecture/rough-cut-construction.md
@@ -68,8 +68,11 @@ currently open Final Cut project. A verified artifact can be published as a new 
 configured `FinalCutProjectPublisher`. The publisher imports a temporary copy
 of the FCPXML artifact through an Accessibility-driven Import XML state machine,
 waits for the import sheet to disappear, verifies the resulting project and
-sequence identities against the prior active target, and does not replace the active project. A headed publisher E2E validates this workflow separately from
-the prepared disposable native-edit fixture.
+sequence identities against the prior active target. Final Cut makes the imported
+project active, and the publisher verifies that the project and sequence
+identities differ from the prior active target. It never modifies the previously
+open project. A headed publisher E2E validates this workflow separately from the
+prepared disposable native-edit fixture.
 
 This separation means a fixture can prove rough-cut construction and an
 FCPXML-backed workflow can produce a verified artifact without implying that

--- a/docs/tests/final-cut-live-e2e.md
+++ b/docs/tests/final-cut-live-e2e.md
@@ -158,6 +158,31 @@ no private media paths, raw snapshots, transaction identifiers, credentials,
 or diagnostics. The runner and sanitizer both fail closed when the mutation,
 undo, required tool sequence, or full commit provenance is incomplete.
 
+## FCPXML publisher headed E2E
+
+Publisher validation is a separate workflow from native editing. Prepare a
+disposable FCPXML artifact and an existing Final Cut project, then run:
+
+```sh
+FRAMEKIT_FINAL_CUT_E2E_FCPXML_PATH="/absolute/path/to/disposable publisher.fcpxml" \
+FRAMEKIT_FINAL_CUT_E2E_PUBLISH_PROJECT="Imported Publisher E2E" \
+FRAMEKIT_FINAL_CUT_E2E_PUBLISH_SEQUENCE="Main" \
+pnpm run test:final-cut-publisher-headed \
+  > docs/tests/evidence/$(date +%F)-publisher-live.json
+```
+
+The runner checks the managed artifact, prepares it through a verified artifact
+transaction, calls `artifact.publish` with explicit confirmation, and compares
+the live project and sequence identities before and after import. The publisher
+Accessibility state machine discovers the nested Import XML command, targets the
+path control in the Import XML sheet, waits for the sheet and window to close,
+and returns a precise timeout or cleanup error. Paths containing spaces are
+supported.
+
+This runner does not call `editor.native.*`, create a native fixture project, or
+claim that a native timeline edit succeeded. Use the prepared disposable fixture
+project and the native runners below for native editing evidence.
+
 ## Disposable native edit evidence
 
 When the live bridge advertises a canonical read provider and native selection

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test:final-cut-headless": "tsx --test tests/integration/connection.test.ts tests/integration/finalcut-mcp.test.ts tests/integration/native.test.ts",
     "test:final-cut-overlay-headed": "node scripts/final-cut-overlay-headed-e2e.mjs",
     "test:final-cut-canonical-read-headed": "node scripts/final-cut-canonical-read-headed-e2e.mjs",
+    "test:final-cut-publisher-headed": "node scripts/final-cut-publisher-headed-e2e.mjs",
     "test:final-cut-project-selection-headed": "node scripts/final-cut-project-selection-headed-e2e.mjs",
     "test:final-cut-canonical-headed": "node scripts/final-cut-canonical-headed-e2e.mjs",
     "test:final-cut-filler-headed": "node scripts/final-cut-filler-removal-headed-e2e.mjs",

--- a/scripts/final-cut-publisher-headed-e2e.mjs
+++ b/scripts/final-cut-publisher-headed-e2e.mjs
@@ -1,0 +1,141 @@
+import { basename } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const artifactPath = process.env.FRAMEKIT_FINAL_CUT_E2E_FCPXML_PATH;
+const expectedProject = process.env.FRAMEKIT_FINAL_CUT_E2E_PUBLISH_PROJECT;
+const expectedSequence = process.env.FRAMEKIT_FINAL_CUT_E2E_PUBLISH_SEQUENCE;
+
+if (process.argv.includes("--help")) {
+  process.stdout.write([
+    "FCPXML publisher headed Final Cut E2E",
+    "",
+    "Required:",
+    "  FRAMEKIT_FINAL_CUT_E2E_FCPXML_PATH=/absolute/path/to/disposable.fcpxml",
+    "  FRAMEKIT_FINAL_CUT_E2E_PUBLISH_PROJECT=exact-imported-project-name",
+    "Optional:",
+    "  FRAMEKIT_FINAL_CUT_E2E_PUBLISH_SEQUENCE=exact-imported-sequence-name",
+    "",
+    "The artifact is edited and published as a new project; native editing is not exercised.",
+  ].join("\n"));
+  process.stdout.write("\n");
+  process.exit(0);
+}
+
+if (!artifactPath || !expectedProject) {
+  throw new Error("Set FRAMEKIT_FINAL_CUT_E2E_FCPXML_PATH and FRAMEKIT_FINAL_CUT_E2E_PUBLISH_PROJECT before running the publisher headed E2E");
+}
+
+const transport = new StdioClientTransport({
+  command: process.execPath,
+  args: ["--import", "tsx", join(root, "apps/mcp-server/src/main.ts")],
+  env: {
+    ...process.env,
+    FRAMEKIT_EDITOR: "final-cut-live",
+    FRAMEKIT_AUTO_CONNECT: "0",
+    FRAMEKIT_FCPXML_PATH: artifactPath,
+    FRAMEKIT_FINAL_CUT_HEADLESS: "0",
+    FRAMEKIT_FINAL_CUT_NATIVE_WRITES: "1",
+  },
+  stderr: "pipe",
+});
+const client = new Client({ name: "framekit-publisher-headed-e2e", version: "0.1.0" });
+let artifactTransactionId;
+let published = false;
+
+try {
+  await client.connect(transport);
+  const editor = await callJson("editor.inspect");
+  if (editor.capabilities?.editor?.artifactPublish !== true) {
+    throw new Error("CAPABILITY_UNAVAILABLE: artifact publishing is not advertised by the live editor");
+  }
+
+  const artifact = await callJson("artifact.inspect");
+  if (artifact.path !== artifactPath || artifact.format !== "fcpxml") {
+    throw new Error(`PUBLISH_TARGET_MISMATCH: expected managed FCPXML artifact ${artifactPath}`);
+  }
+
+  const source = await callJson("project.inspect");
+  if (source.projectName !== expectedProject) {
+    throw new Error(`FINAL_CUT_E2E_PUBLISH_PROJECT_MISMATCH: expected ${expectedProject}, observed ${source.projectName ?? "unknown"}`);
+  }
+  const sourceSequence = source.timeline?.name;
+  if (expectedSequence && sourceSequence !== expectedSequence) {
+    throw new Error(`FINAL_CUT_E2E_PUBLISH_SEQUENCE_MISMATCH: expected ${expectedSequence}, observed ${sourceSequence ?? "unknown"}`);
+  }
+
+  const beforeLive = await callJson("editor.live.inspect");
+  if (!beforeLive.project?.id || !beforeLive.sequence?.id) {
+    throw new Error("TARGET_UNAVAILABLE: live project and sequence identities are required before publish");
+  }
+
+  const edited = await callJson("artifact.edit", {
+    artifactPath,
+    type: "add-marker",
+    timelineId: source.timeline.id,
+    marker: { id: "framekit-publisher-e2e", start: 0, duration: 0, name: "Framekit Publisher E2E" },
+    baseRevision: source.revision,
+  });
+  if (edited.status !== "VERIFIED") {
+    throw new Error("FINAL_CUT_E2E_PUBLISH_ARTIFACT_EDIT_FAILED: disposable artifact preparation was not verified");
+  }
+  artifactTransactionId = edited.id;
+
+  const result = await callJson("artifact.publish", {
+    artifactPath,
+    transactionId: artifactTransactionId,
+    confirm: true,
+  });
+  published = true;
+  if (result.verified !== true || result.createdTarget?.projectName !== expectedProject) {
+    throw new Error("FINAL_CUT_E2E_PUBLISH_VERIFICATION_FAILED: publisher did not return the requested project identity");
+  }
+  if (result.createdTarget?.sequenceName !== (expectedSequence ?? sourceSequence)) {
+    throw new Error("FINAL_CUT_E2E_PUBLISH_SEQUENCE_VERIFICATION_FAILED: publisher did not return the requested sequence identity");
+  }
+  if (result.activeProject?.before?.id !== beforeLive.project.id || result.activeProject?.after?.id !== result.createdTarget?.projectId) {
+    throw new Error("FINAL_CUT_E2E_PUBLISH_TARGET_VERIFICATION_FAILED: active project identity was not changed to the imported project");
+  }
+
+  const afterLive = await callJson("editor.live.inspect");
+  if (afterLive.project?.id !== result.createdTarget?.projectId || afterLive.sequence?.id !== result.createdTarget?.sequenceId) {
+    throw new Error("FINAL_CUT_E2E_PUBLISH_LIVE_STATE_MISMATCH: live state does not match the imported target");
+  }
+
+  process.stdout.write(`${JSON.stringify({
+    passed: true,
+    workflow: "fcpxml-publisher",
+    artifact: basename(artifactPath),
+    sourceTarget: result.sourceTarget,
+    createdTarget: result.createdTarget,
+    activeProject: result.activeProject,
+    beforeLive: { projectId: beforeLive.project.id, sequenceId: beforeLive.sequence.id },
+    afterLive: { projectId: afterLive.project.id, sequenceId: afterLive.sequence.id },
+  }, null, 2)}\n`);
+} catch (error) {
+  if (artifactTransactionId && !published) {
+    try {
+      await callJson("edit.undo", { transactionId: artifactTransactionId });
+    } catch (rollbackError) {
+      throw new AggregateError([error, rollbackError], "Publisher headed E2E failed and artifact cleanup also failed");
+    }
+  }
+  throw error;
+} finally {
+  await client.close().catch(() => {});
+  await transport.close().catch(() => {});
+}
+
+async function callJson(name, arguments_ = {}) {
+  const result = await client.callTool({ name, arguments: arguments_ });
+  const text = result.content?.find((item) => item.type === "text")?.text ?? "";
+  if (result.isError) throw new Error(text || `${name} failed`);
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(`${name} returned invalid JSON: ${text}`);
+  }
+}

--- a/scripts/final-cut-publisher-headed-e2e.mjs
+++ b/scripts/final-cut-publisher-headed-e2e.mjs
@@ -3,6 +3,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
+import { verifyPublishedTarget } from "./final-cut-publisher-verification.mjs";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const artifactPath = process.env.FRAMEKIT_FINAL_CUT_E2E_FCPXML_PATH;
@@ -90,20 +91,9 @@ try {
     confirm: true,
   });
   published = true;
-  if (result.verified !== true || result.createdTarget?.projectName !== expectedProject) {
-    throw new Error("FINAL_CUT_E2E_PUBLISH_VERIFICATION_FAILED: publisher did not return the requested project identity");
-  }
-  if (result.createdTarget?.sequenceName !== (expectedSequence ?? sourceSequence)) {
-    throw new Error("FINAL_CUT_E2E_PUBLISH_SEQUENCE_VERIFICATION_FAILED: publisher did not return the requested sequence identity");
-  }
-  if (result.activeProject?.before?.id !== beforeLive.project.id || result.activeProject?.after?.id !== result.createdTarget?.projectId) {
-    throw new Error("FINAL_CUT_E2E_PUBLISH_TARGET_VERIFICATION_FAILED: active project identity was not changed to the imported project");
-  }
 
   const afterLive = await callJson("editor.live.inspect");
-  if (afterLive.project?.id !== result.createdTarget?.projectId || afterLive.sequence?.id !== result.createdTarget?.sequenceId) {
-    throw new Error("FINAL_CUT_E2E_PUBLISH_LIVE_STATE_MISMATCH: live state does not match the imported target");
-  }
+  verifyPublishedTarget({ result, beforeLive, afterLive, expectedProject, expectedSequence, sourceSequence });
 
   process.stdout.write(`${JSON.stringify({
     passed: true,

--- a/scripts/final-cut-publisher-headed-e2e.mjs
+++ b/scripts/final-cut-publisher-headed-e2e.mjs
@@ -109,7 +109,7 @@ try {
     passed: true,
     workflow: "fcpxml-publisher",
     artifact: basename(artifactPath),
-    sourceTarget: result.sourceTarget,
+    sourceTarget: { kind: result.sourceTarget.kind, artifactPath: basename(result.sourceTarget.artifactPath) },
     createdTarget: result.createdTarget,
     activeProject: result.activeProject,
     beforeLive: { projectId: beforeLive.project.id, sequenceId: beforeLive.sequence.id },

--- a/scripts/final-cut-publisher-verification.d.mts
+++ b/scripts/final-cut-publisher-verification.d.mts
@@ -1,0 +1,8 @@
+export declare function verifyPublishedTarget(input: {
+  result: any;
+  beforeLive: any;
+  afterLive: any;
+  expectedProject: string;
+  expectedSequence?: string;
+  sourceSequence?: string;
+}): void;

--- a/scripts/final-cut-publisher-verification.mjs
+++ b/scripts/final-cut-publisher-verification.mjs
@@ -1,0 +1,26 @@
+export function verifyPublishedTarget({ result, beforeLive, afterLive, expectedProject, expectedSequence, sourceSequence }) {
+  if (result.verified !== true || result.createdTarget?.projectName !== expectedProject) {
+    throw new Error("FINAL_CUT_E2E_PUBLISH_VERIFICATION_FAILED: publisher did not return the requested project identity");
+  }
+
+  if (result.createdTarget?.sequenceName !== (expectedSequence ?? sourceSequence)) {
+    throw new Error("FINAL_CUT_E2E_PUBLISH_SEQUENCE_VERIFICATION_FAILED: publisher did not return the requested sequence identity");
+  }
+
+  const projectId = result.createdTarget?.projectId;
+  const sequenceId = result.createdTarget?.sequenceId;
+  const activeProjectAfterId = result.activeProject?.after?.id;
+  if (!projectId || !sequenceId || !activeProjectAfterId) {
+    throw new Error("FINAL_CUT_E2E_PUBLISH_TARGET_VERIFICATION_FAILED: publisher did not return imported target identities");
+  }
+  if (result.activeProject?.before?.id !== beforeLive.project.id || activeProjectAfterId !== projectId) {
+    throw new Error("FINAL_CUT_E2E_PUBLISH_TARGET_VERIFICATION_FAILED: active project identity was not changed to the imported project");
+  }
+
+  if (!afterLive.project?.id || !afterLive.sequence?.id) {
+    throw new Error("FINAL_CUT_E2E_PUBLISH_LIVE_STATE_MISMATCH: live state did not return imported target identities");
+  }
+  if (afterLive.project.id !== projectId || afterLive.sequence.id !== sequenceId) {
+    throw new Error("FINAL_CUT_E2E_PUBLISH_LIVE_STATE_MISMATCH: live state does not match the imported target");
+  }
+}

--- a/tests/integration/edit-targets.test.ts
+++ b/tests/integration/edit-targets.test.ts
@@ -29,6 +29,33 @@ function fixtureAdapter() {
   });
 }
 
+function publisherLiveState(projectName: string) {
+  let imported = false;
+  return async () => {
+    const wasImported = imported;
+    const state = imported
+      ? {
+          project: { id: "published-project", name: projectName },
+          sequence: { id: "published-sequence", name: projectName },
+        }
+      : {
+          project: { id: "existing-project", name: "Existing Project" },
+          sequence: { id: "existing-sequence", name: "Existing Sequence" },
+        };
+    imported = true;
+    return {
+      ...state,
+      sequence: {
+        ...state.sequence,
+        startTime: { value: "0", timescale: "1" },
+        duration: { value: "1", timescale: "1" },
+        frameDuration: { value: "1", timescale: "24" },
+      },
+      revision: { id: wasImported ? "revision-after" : "revision-before", sequence: wasImported ? 2 : 1, timestamp: new Date(0).toISOString() },
+    };
+  };
+}
+
 test("editor timeline edits bind the active project, sequence, and verification target", async () => {
   const runtime = new AgentVideoRuntime(fixtureAdapter());
   const before = await runtime.inspectProject();
@@ -143,6 +170,7 @@ test("MCP publishing requires the verified artifact target and returns the creat
         sourcePath: artifactPath,
         waitMs: 0,
         executor: async () => "imported",
+        liveState: publisherLiveState("Artifact Project"),
       }),
     });
     const client = new Client({ name: "artifact-publish-test", version: "0.1.0" });
@@ -160,7 +188,13 @@ test("MCP publishing requires the verified artifact target and returns the creat
       assert.equal(published.isError, undefined);
       const result = JSON.parse(textFrom(published));
       assert.deepEqual(result.sourceTarget, { kind: "artifact", artifactPath });
-      assert.deepEqual(result.createdTarget, { kind: "editor.project", projectName: "Artifact Project" });
+      assert.deepEqual(result.createdTarget, {
+        kind: "editor.project",
+        projectId: "published-project",
+        sequenceId: "published-sequence",
+        projectName: "Artifact Project",
+        sequenceName: "Artifact Project",
+      });
 
       const unconfirmed = await client.callTool({
         name: "artifact.publish",

--- a/tests/integration/editing-surface-docs.test.ts
+++ b/tests/integration/editing-surface-docs.test.ts
@@ -27,5 +27,5 @@ test("editing surface docs distinguish artifact, publish, and live targets", asy
   assert.match(liveE2e, /FCPXML publisher headed E2E/);
   assert.match(liveE2e, /FRAMEKIT_FINAL_CUT_E2E_FCPXML_PATH/);
   assert.match(liveE2e, /test:final-cut-publisher-headed/);
-  assert.match(liveE2e, /prepared disposable fixture project/);
+  assert.match(liveE2e, /prepared disposable fixture[\s\S]*project/);
 });

--- a/tests/integration/editing-surface-docs.test.ts
+++ b/tests/integration/editing-surface-docs.test.ts
@@ -11,6 +11,7 @@ test("editing surface docs distinguish artifact, publish, and live targets", asy
   const backendSelection = await readFile(join(repositoryRoot, "docs/architecture/backend-selection.md"), "utf8");
   const mcpTools = await readFile(join(repositoryRoot, "docs/mcp/tools.md"), "utf8");
   const liveE2e = await readFile(join(repositoryRoot, "docs/tests/final-cut-live-e2e.md"), "utf8");
+  const roughCutConstruction = await readFile(join(repositoryRoot, "docs/architecture/rough-cut-construction.md"), "utf8");
 
   assert.match(compatibility, /## Editing surface semantics/);
   assert.match(compatibility, /Target[\s\S]*Revision[\s\S]*Read-after-write[\s\S]*Undo[\s\S]*Resulting project state/);
@@ -28,4 +29,6 @@ test("editing surface docs distinguish artifact, publish, and live targets", asy
   assert.match(liveE2e, /FRAMEKIT_FINAL_CUT_E2E_FCPXML_PATH/);
   assert.match(liveE2e, /test:final-cut-publisher-headed/);
   assert.match(liveE2e, /prepared disposable fixture[\s\S]*project/);
+  assert.match(roughCutConstruction, /Final Cut makes the imported project active/);
+  assert.match(roughCutConstruction, /It never modifies the previously open project/);
 });

--- a/tests/integration/editing-surface-docs.test.ts
+++ b/tests/integration/editing-surface-docs.test.ts
@@ -10,6 +10,7 @@ test("editing surface docs distinguish artifact, publish, and live targets", asy
   const compatibility = await readFile(join(repositoryRoot, "docs/COMPATIBILITY.md"), "utf8");
   const backendSelection = await readFile(join(repositoryRoot, "docs/architecture/backend-selection.md"), "utf8");
   const mcpTools = await readFile(join(repositoryRoot, "docs/mcp/tools.md"), "utf8");
+  const liveE2e = await readFile(join(repositoryRoot, "docs/tests/final-cut-live-e2e.md"), "utf8");
 
   assert.match(compatibility, /## Editing surface semantics/);
   assert.match(compatibility, /Target[\s\S]*Revision[\s\S]*Read-after-write[\s\S]*Undo[\s\S]*Resulting project state/);
@@ -23,4 +24,8 @@ test("editing surface docs distinguish artifact, publish, and live targets", asy
   assert.match(mcpTools, /PUBLISH_CONFIRMATION_REQUIRED/);
   assert.doesNotMatch(mcpTools, /\| `timeline\.edit` \|/);
   assert.doesNotMatch(mcpTools, /\| `timeline\.publish\.new-project` \|/);
+  assert.match(liveE2e, /FCPXML publisher headed E2E/);
+  assert.match(liveE2e, /FRAMEKIT_FINAL_CUT_E2E_FCPXML_PATH/);
+  assert.match(liveE2e, /test:final-cut-publisher-headed/);
+  assert.match(liveE2e, /prepared disposable fixture project/);
 });

--- a/tests/integration/editing-surface-docs.test.ts
+++ b/tests/integration/editing-surface-docs.test.ts
@@ -29,6 +29,6 @@ test("editing surface docs distinguish artifact, publish, and live targets", asy
   assert.match(liveE2e, /FRAMEKIT_FINAL_CUT_E2E_FCPXML_PATH/);
   assert.match(liveE2e, /test:final-cut-publisher-headed/);
   assert.match(liveE2e, /prepared disposable fixture[\s\S]*project/);
-  assert.match(roughCutConstruction, /Final Cut makes the imported project active/);
-  assert.match(roughCutConstruction, /It never modifies the previously open project/);
+  assert.match(roughCutConstruction, /Final Cut makes the imported\s+project active/);
+  assert.match(roughCutConstruction, /It never modifies the previously\s+open project/);
 });

--- a/tests/integration/publisher-e2e.test.ts
+++ b/tests/integration/publisher-e2e.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import test from "node:test";
+
+const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), "../..");
+
+test("publisher headed E2E is a separate FCPXML workflow", async () => {
+  const packageJson = JSON.parse(await readFile(join(repositoryRoot, "package.json"), "utf8")) as {
+    scripts?: Record<string, string>;
+  };
+  const publisherRunner = await readFile(join(repositoryRoot, "scripts/final-cut-publisher-headed-e2e.mjs"), "utf8");
+  const nativeRunner = await readFile(join(repositoryRoot, "scripts/final-cut-disposable-native-headed-e2e.mjs"), "utf8");
+
+  assert.equal(typeof packageJson.scripts?.["test:final-cut-publisher-headed"], "string");
+  assert.match(publisherRunner, /FRAMEKIT_FINAL_CUT_E2E_FCPXML_PATH/);
+  assert.match(publisherRunner, /FRAMEKIT_FCPXML_PATH/);
+  assert.match(publisherRunner, /artifact\.inspect/);
+  assert.match(publisherRunner, /artifact\.publish/);
+  assert.match(publisherRunner, /editor\.live\.inspect/);
+  assert.match(publisherRunner, /confirm: true/);
+  assert.equal(publisherRunner.includes("editor.native."), false);
+  assert.equal(nativeRunner.includes("artifact.publish"), false);
+  assert.match(nativeRunner, /FRAMEKIT_FCPXML_PATH: ""/);
+});

--- a/tests/integration/publisher-e2e.test.ts
+++ b/tests/integration/publisher-e2e.test.ts
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import test from "node:test";
+import { verifyPublishedTarget } from "../../scripts/final-cut-publisher-verification.mjs";
 
 const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), "../..");
 
@@ -23,4 +24,19 @@ test("publisher headed E2E is a separate FCPXML workflow", async () => {
   assert.equal(publisherRunner.includes("editor.native."), false);
   assert.equal(nativeRunner.includes("artifact.publish"), false);
   assert.match(nativeRunner, /FRAMEKIT_FCPXML_PATH: ""/);
+});
+
+test("publisher headed E2E rejects missing post-import identities", () => {
+  assert.throws(() => verifyPublishedTarget({
+    result: {
+      verified: true,
+      createdTarget: { projectName: "Imported", sequenceName: "Main" },
+      activeProject: { before: { id: "before-project" }, after: {} },
+    },
+    beforeLive: { project: { id: "before-project" }, sequence: { id: "before-sequence" } },
+    afterLive: { project: { name: "Imported" }, sequence: { name: "Main" } },
+    expectedProject: "Imported",
+    expectedSequence: "Main",
+    sourceSequence: "Main",
+  }), /FINAL_CUT_E2E_PUBLISH_TARGET_VERIFICATION_FAILED/);
 });

--- a/tests/integration/publisher.test.ts
+++ b/tests/integration/publisher.test.ts
@@ -67,6 +67,14 @@ test("FCPXML publisher imports a validated artifact as a new project", async () 
   assert.match(scripts[0], /waitForMenuItem/);
   assert.match(scripts[0], /waitForImportSheet/);
   assert.match(scripts[0], /waitForSubmenu\(importMenuItem, "Import"/);
+  assert.match(scripts[0], /my waitForMenuItem/);
+  assert.match(scripts[0], /my waitForSubmenu/);
+  assert.match(scripts[0], /my waitForWindow/);
+  assert.match(scripts[0], /my waitForImportSheet/);
+  assert.match(scripts[0], /my locateImportPathField/);
+  assert.match(scripts[0], /my waitForImportSheetDismissal/);
+  assert.match(scripts[0], /my waitForImportWindowDismissal/);
+  assert.match(scripts[0], /my cancelImportIfOpen/);
   assert.match(scripts[0], /perform action "AXPress"/);
   assert.match(scripts[0], /keystroke "g" using \{command down, shift down\}/);
   assert.match(scripts[0], /text fields of pathSheet/);

--- a/tests/integration/publisher.test.ts
+++ b/tests/integration/publisher.test.ts
@@ -70,7 +70,11 @@ test("FCPXML publisher imports a validated artifact as a new project", async () 
   assert.match(scripts[0], /perform action "AXPress"/);
   assert.match(scripts[0], /keystroke "g" using \{command down, shift down\}/);
   assert.match(scripts[0], /text fields of pathSheet/);
-  assert.match(scripts[0], /set pathField to item 1 of pathFields/);
+  assert.match(scripts[0], /locateImportPathField/);
+  assert.match(scripts[0], /value of attribute "AXIdentifier"/);
+  assert.match(scripts[0], /description of candidate/);
+  assert.match(scripts[0], /FINAL_CUT_PUBLISH_PATH_CONTROL_AMBIGUOUS/);
+  assert.equal(scripts[0].includes("set pathField to item 1 of pathFields"), false);
   assert.match(scripts[0], /waitForImportSheetDismissal/);
   assert.match(scripts[0], /on error/);
   assert.match(scripts[0], /Cancel/);

--- a/tests/integration/publisher.test.ts
+++ b/tests/integration/publisher.test.ts
@@ -178,6 +178,47 @@ test("FCPXML publisher waits for the imported project identity to settle", async
   assert.equal(stateIndex, 3);
 });
 
+test("FCPXML publisher retries transient live-state errors", async () => {
+  const directory = await mkdtemp(join(os.tmpdir(), "framekit-publisher-transient-"));
+  const sourcePath = join(directory, "project.fcpxml");
+  const source = '<fcpxml version="1.11"><library><event><project name="Published Edit"><sequence name="Main" /></project></event></library></fcpxml>';
+  await writeFile(sourcePath, source);
+  let liveStateCalls = 0;
+
+  const result = await new FinalCutProjectPublisher({
+    enabled: true,
+    sourcePath,
+    verificationTimeoutMs: 100,
+    pollIntervalMs: 0,
+    executor: async () => "imported",
+    liveState: async () => {
+      liveStateCalls += 1;
+      if (liveStateCalls === 2) throw new Error("temporary bridge unavailable");
+      const imported = liveStateCalls >= 3;
+      return {
+        project: { id: imported ? "imported-project" : "before-project", name: imported ? "Published Edit" : "Existing" },
+        sequence: {
+          id: imported ? "imported-sequence" : "before-sequence",
+          name: imported ? "Main" : "Existing",
+          startTime: { value: "0", timescale: "1" },
+          duration: { value: "1", timescale: "1" },
+          frameDuration: { value: "1", timescale: "24" },
+        },
+        revision: { id: `revision-${liveStateCalls}`, sequence: liveStateCalls, timestamp: new Date(0).toISOString() },
+      };
+    },
+  }).publishNewProject({
+    sourceTransactionId: "txn-transient",
+    artifactPath: sourcePath,
+    artifactDigest: digest(source),
+    confirm: true,
+  });
+
+  assert.equal(result.createdTarget.projectId, "imported-project");
+  assert.equal(result.createdTarget.sequenceId, "imported-sequence");
+  assert.equal(liveStateCalls, 3);
+});
+
 test("FCPXML publisher rejects invalid artifacts before automation", async () => {
   const directory = await mkdtemp(join(os.tmpdir(), "framekit-publisher-invalid-"));
   const sourcePath = join(directory, "invalid.fcpxml");

--- a/tests/integration/publisher.test.ts
+++ b/tests/integration/publisher.test.ts
@@ -66,15 +66,16 @@ test("FCPXML publisher imports a validated artifact as a new project", async () 
   });
   assert.match(scripts[0], /waitForMenuItem/);
   assert.match(scripts[0], /waitForImportSheet/);
-  assert.match(scripts[0], /menu "Import" of importMenuItem/);
+  assert.match(scripts[0], /waitForSubmenu\(importMenuItem, "Import"/);
   assert.match(scripts[0], /perform action "AXPress"/);
   assert.match(scripts[0], /keystroke "g" using \{command down, shift down\}/);
-  assert.match(scripts[0], /first text field of pathSheet/);
+  assert.match(scripts[0], /text fields of pathSheet/);
+  assert.match(scripts[0], /set pathField to item 1 of pathFields/);
   assert.match(scripts[0], /waitForImportSheetDismissal/);
   assert.match(scripts[0], /on error/);
   assert.match(scripts[0], /Cancel/);
   assert.equal(scripts[0].includes("delay 0.4"), false);
-  assert.match(scripts[0], /artifact with spaces/);
+  assert.match(scripts[0], /published project\.fcpxml/);
   await assert.rejects(readFile(result.importedPath), /ENOENT/);
 });
 

--- a/tests/integration/publisher.test.ts
+++ b/tests/integration/publisher.test.ts
@@ -123,6 +123,49 @@ test("FCPXML publisher requires live project and sequence verification", async (
   }), /FINAL_CUT_PUBLISH_VERIFICATION_UNAVAILABLE/);
 });
 
+test("FCPXML publisher waits for the imported project identity to settle", async () => {
+  const directory = await mkdtemp(join(os.tmpdir(), "framekit-publisher-poll-"));
+  const sourcePath = join(directory, "project.fcpxml");
+  const source = '<fcpxml version="1.11"><library><event><project name="Published Edit"><sequence name="Main" /></project></event></library></fcpxml>';
+  await writeFile(sourcePath, source);
+  const states = [
+    { project: { id: "before-project", name: "Existing" }, sequence: { id: "before-sequence", name: "Existing" } },
+    { project: { id: "before-project", name: "Existing" }, sequence: { id: "before-sequence", name: "Existing" } },
+    { project: { id: "imported-project", name: "Published Edit" }, sequence: { id: "imported-sequence", name: "Main" } },
+  ];
+  let stateIndex = 0;
+
+  const result = await new FinalCutProjectPublisher({
+    enabled: true,
+    sourcePath,
+    verificationTimeoutMs: 100,
+    pollIntervalMs: 0,
+    executor: async () => "imported",
+    liveState: async () => {
+      const state = states[Math.min(stateIndex++, states.length - 1)]!;
+      return {
+        ...state,
+        sequence: {
+          ...state.sequence,
+          startTime: { value: "0", timescale: "1" },
+          duration: { value: "1", timescale: "1" },
+          frameDuration: { value: "1", timescale: "24" },
+        },
+        revision: { id: `revision-${stateIndex}`, sequence: stateIndex, timestamp: new Date(0).toISOString() },
+      };
+    },
+  }).publishNewProject({
+    sourceTransactionId: "txn-poll",
+    artifactPath: sourcePath,
+    artifactDigest: digest(source),
+    confirm: true,
+  });
+
+  assert.equal(result.createdTarget.projectId, "imported-project");
+  assert.equal(result.createdTarget.sequenceId, "imported-sequence");
+  assert.equal(stateIndex, 3);
+});
+
 test("FCPXML publisher rejects invalid artifacts before automation", async () => {
   const directory = await mkdtemp(join(os.tmpdir(), "framekit-publisher-invalid-"));
   const sourcePath = join(directory, "invalid.fcpxml");

--- a/tests/integration/publisher.test.ts
+++ b/tests/integration/publisher.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -12,20 +12,29 @@ function digest(content: string): string {
 
 test("FCPXML publisher imports a validated artifact as a new project", async () => {
   const directory = await mkdtemp(join(os.tmpdir(), "framekit-publisher-"));
-  const sourcePath = join(directory, "project.fcpxml");
-  const source = '<fcpxml version="1.11"><library><event><project name="Published Edit"><sequence /></project></event></library></fcpxml>';
+  const artifactDirectory = join(directory, "artifact with spaces");
+  await mkdir(artifactDirectory);
+  const sourcePath = join(artifactDirectory, "published project.fcpxml");
+  const source = '<fcpxml version="1.11"><library><event><project uid="published-project" name="Published Edit"><sequence uid="published-sequence" name="Published Sequence" /></project></event></library></fcpxml>';
   await writeFile(sourcePath, source);
   const scripts: string[] = [];
+  let liveStateCalls = 0;
   const result = await new FinalCutProjectPublisher({
     enabled: true,
     sourcePath,
+    verificationTimeoutMs: 0,
+    pollIntervalMs: 0,
     executor: async (script) => {
       scripts.push(script);
       return "imported";
     },
     liveState: async () => ({
-      project: { id: "project-2", name: "Published Edit" },
-      sequence: { id: "sequence-2", name: "Published Edit", startTime: { value: "0", timescale: "1" }, duration: { value: "10", timescale: "1" }, frameDuration: { value: "1", timescale: "24" } },
+      project: liveStateCalls++ === 0
+        ? { id: "project-before", name: "Existing Project" }
+        : { id: "project-2", name: "Published Edit" },
+      sequence: liveStateCalls <= 1
+        ? { id: "sequence-before", name: "Existing Sequence", startTime: { value: "0", timescale: "1" }, duration: { value: "10", timescale: "1" }, frameDuration: { value: "1", timescale: "24" } }
+        : { id: "sequence-2", name: "Published Sequence", startTime: { value: "0", timescale: "1" }, duration: { value: "10", timescale: "1" }, frameDuration: { value: "1", timescale: "24" } },
       playheadTime: { value: "0", timescale: "1" },
       sequenceTimeRange: { start: { value: "0", timescale: "1" }, duration: { value: "10", timescale: "1" } },
       revision: { id: "rev-1", sequence: 1, timestamp: new Date(0).toISOString() },
@@ -41,25 +50,76 @@ test("FCPXML publisher imports a validated artifact as a new project", async () 
   assert.equal(result.sourceTransactionId, "txn-publish-1");
   assert.equal(result.projectName, "Published Edit");
   assert.equal(result.liveProject, "Published Edit");
+  assert.equal(result.liveSequence, "Published Sequence");
   assert.deepEqual(result.sourceTarget, { kind: "artifact", artifactPath: sourcePath });
   assert.deepEqual(result.createdTarget, {
     kind: "editor.project",
     projectId: "project-2",
     sequenceId: "sequence-2",
     projectName: "Published Edit",
-    sequenceName: "Published Edit",
+    sequenceName: "Published Sequence",
   });
   assert.deepEqual(result.activeProject, {
-    before: { id: "project-2", name: "Published Edit" },
+    before: { id: "project-before", name: "Existing Project" },
     after: { id: "project-2", name: "Published Edit" },
-    changed: false,
+    changed: true,
   });
-  assert.match(scripts[0], /Import/);
-  assert.match(scripts[0], /menu item "XML…" of menu "Import" of menu item "Import"/);
+  assert.match(scripts[0], /waitForMenuItem/);
+  assert.match(scripts[0], /waitForImportSheet/);
+  assert.match(scripts[0], /menu "Import" of importMenuItem/);
+  assert.match(scripts[0], /perform action "AXPress"/);
   assert.match(scripts[0], /keystroke "g" using \{command down, shift down\}/);
-  assert.equal(scripts[0].includes("focused text field"), false);
-  assert.match(scripts[0], /first text field of sheet 1 of window "Import XML"/);
+  assert.match(scripts[0], /first text field of pathSheet/);
+  assert.match(scripts[0], /waitForImportSheetDismissal/);
+  assert.match(scripts[0], /on error/);
+  assert.match(scripts[0], /Cancel/);
+  assert.equal(scripts[0].includes("delay 0.4"), false);
+  assert.match(scripts[0], /artifact with spaces/);
   await assert.rejects(readFile(result.importedPath), /ENOENT/);
+});
+
+test("FCPXML publisher rejects a stale active project with matching names", async () => {
+  const directory = await mkdtemp(join(os.tmpdir(), "framekit-publisher-stale-"));
+  const sourcePath = join(directory, "project.fcpxml");
+  const source = '<fcpxml version="1.11"><library><event><project name="Shared Name"><sequence name="Main" /></project></event></library></fcpxml>';
+  await writeFile(sourcePath, source);
+  const staleState = {
+    project: { id: "old-project", name: "Shared Name" },
+    sequence: { id: "old-sequence", name: "Main", startTime: { value: "0", timescale: "1" }, duration: { value: "10", timescale: "1" }, frameDuration: { value: "1", timescale: "24" } },
+    revision: { id: "rev-stale", sequence: 1, timestamp: new Date(0).toISOString() },
+  };
+
+  await assert.rejects(new FinalCutProjectPublisher({
+    enabled: true,
+    sourcePath,
+    verificationTimeoutMs: 0,
+    pollIntervalMs: 0,
+    executor: async () => "imported",
+    liveState: async () => staleState,
+  }).publishNewProject({
+    sourceTransactionId: "txn-stale",
+    artifactPath: sourcePath,
+    artifactDigest: digest(source),
+    confirm: true,
+  }), /FINAL_CUT_PUBLISH_VERIFICATION_FAILED/);
+});
+
+test("FCPXML publisher requires live project and sequence verification", async () => {
+  const directory = await mkdtemp(join(os.tmpdir(), "framekit-publisher-state-"));
+  const sourcePath = join(directory, "project.fcpxml");
+  const source = '<fcpxml version="1.11"><library><event><project name="Published Edit"><sequence /></project></event></library></fcpxml>';
+  await writeFile(sourcePath, source);
+
+  await assert.rejects(new FinalCutProjectPublisher({
+    enabled: true,
+    sourcePath,
+    executor: async () => "imported",
+  }).publishNewProject({
+    sourceTransactionId: "txn-no-state",
+    artifactPath: sourcePath,
+    artifactDigest: digest(source),
+    confirm: true,
+  }), /FINAL_CUT_PUBLISH_VERIFICATION_UNAVAILABLE/);
 });
 
 test("FCPXML publisher rejects invalid artifacts before automation", async () => {

--- a/tests/integration/rough-cut.test.ts
+++ b/tests/integration/rough-cut.test.ts
@@ -487,6 +487,7 @@ test("rough-cut construction contract documents lifecycle and backend boundaries
   }
   assert.match(contract, /CAPABILITY_UNAVAILABLE/);
   assert.match(contract, /timeline\.publish\.new-project/);
-  assert.match(contract, /does not replace the active project/i);
+  assert.match(contract, /Final Cut makes the imported\s+project active/i);
+  assert.match(contract, /never modifies the previously\s+open project/i);
   assert.ok(tools.indexOf("`music.add` is the high-level") < tools.indexOf("## Rough-cut construction workflow"));
 });


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If unable to complete review within a few days, convert to draft
- [ ] Github issue: Closes: #165

## Summary

- Replace brittle FCPXML publisher timing with an Accessibility-driven import state machine.
- Verify the imported project and sequence by live identity, including stale-project rejection and bounded polling.
- Isolate publisher headed E2E coverage from native editing setup and sanitize its evidence output.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm run test` — 524 tests passed
- `pnpm run check:boundaries`
- Generated publisher AppleScript compiled successfully with `osacompile`.
- Native Xcode gates were skipped because no Swift/Xcode files changed.

## Architecture and compatibility

- [x] Runtime remains independent of MCP SDK and Final Cut adapter modules.
- [x] Public behavior and the separate publisher evidence workflow are documented.
- [x] Existing adapter and MCP tests remain covered.

## Safety

- [x] Temporary imported artifacts are cleaned up on success and failure.
- [x] Import failures cancel an open sheet before returning a precise error.
- [x] The headed publisher runner requires explicit opt-in and disposable fixtures.

## Evidence boundary

Deterministic tests, generated-script compilation, and the runner contract do not constitute headed Final Cut proof. The new headed runner is opt-in and was not executed against a live Final Cut session in this environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Final Cut publishing now verifies that both the expected project and sequence appear in the live editor.
  * Import completion uses configurable polling and verification timeouts instead of fixed delays.
  * Publishing supports XML file paths containing spaces and provides clearer timeout and cleanup errors.
  * Added a dedicated headed end-to-end publishing workflow with rollback on failure.

* **Documentation**
  * Added setup and usage guidance for the headed publishing workflow.

* **Tests**
  * Expanded coverage for identity validation, active-project transitions, polling, and stale-state rejection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->