### PR TITLE
fix: preserve routed capabilities and preflight

### DIFF
--- a/adapters/final-cut/typescript/src/fcpxml.ts
+++ b/adapters/final-cut/typescript/src/fcpxml.ts
@@ -211,7 +211,8 @@ export class FcpxmlDocumentAdapter implements EditorPort {
         }
         this.applyOperation(operation as EditOperation);
       }
-      return this.readProject();
+      const preview = await this.readProject();
+      return preview;
     } finally {
       this.xml = originalXml;
       this.sequence = originalSequence;

--- a/adapters/final-cut/typescript/src/session.ts
+++ b/adapters/final-cut/typescript/src/session.ts
@@ -14,12 +14,13 @@ import type {
   ProjectSelection,
   RuntimeCapabilities,
   ManagedArtifact,
+  WorkflowOperation,
 } from "@framekit/runtime";
 
 interface FinalCutSessionOptions {
   snapshot?: EditorPort;
   mutation?: EditorPort;
-  live?: LiveEditorStatePort & Partial<Pick<EditorPort, "readProject" | "apply" | "restore">> & {
+  live?: LiveEditorStatePort & Partial<Pick<EditorPort, "readProject" | "apply" | "restore" | "previewTransaction" | "applyTransaction">> & {
     getIdentity(): Promise<EditorIdentity>;
     getCapabilities(): Promise<RuntimeCapabilities>;
     listProjects?(): Promise<ProjectCatalog>;
@@ -73,23 +74,47 @@ export class FinalCutSessionAdapter implements EditorPort, LiveEditorStatePort {
       && this.options.live?.apply
       && this.options.live.restore
     );
-    const applyProviderCapabilities = hasExplicitDocumentPair
+    const operationRuntimeCapabilities = hasExplicitDocumentPair
       ? mutation
       : liveMutation
         ? live
         : snapshot;
+    const operationCapabilities = operationRuntimeCapabilities?.editor;
+    const operationAdapter = hasExplicitDocumentPair
+      ? this.options.mutation
+      : liveMutation
+        ? this.options.live
+        : this.options.snapshot;
+    const readCapabilities = snapshot ?? (liveSnapshot ? live : undefined);
+    const readAdapter = this.options.snapshot ?? (liveSnapshot ? this.options.live : undefined);
+    const hasTransactionMethods = Boolean(
+      operationAdapter
+      && typeof operationAdapter.previewTransaction === "function"
+      && typeof operationAdapter.applyTransaction === "function",
+    );
+    const canReadAfterWrite = Boolean(
+      readAdapter?.readProject
+      && readCapabilities?.editor.readAfterWrite
+      && operationAdapter?.restore
+      && operationCapabilities?.rollback,
+    );
+    const compositeTransactions = Boolean(
+      operationCapabilities?.compositeTransactions
+      && hasTransactionMethods
+      && canReadAfterWrite,
+    );
+    const operationFamilies = operationRuntimeCapabilities?.families;
+    const readFamilies = readCapabilities?.families;
     return withCapabilityFamilies({
       editor: {
+        ...operationCapabilities,
         projectRead: Boolean(snapshot?.editor.projectRead || (liveSnapshot && live?.editor.projectRead)),
-        timelineSnapshotRead: Boolean(snapshot?.editor.timelineSnapshotRead || liveSnapshot),
-        timelineWrite: Boolean((hasExplicitDocumentPair && mutation?.editor.timelineWrite) || liveMutation),
-        timelineArtifactWrite: Boolean(applyProviderCapabilities?.editor.timelineArtifactWrite),
-        readAfterWrite: Boolean(
-          (hasExplicitDocumentPair && snapshot?.editor.readAfterWrite && mutation?.editor.readAfterWrite)
-          || (liveMutation && live?.editor.readAfterWrite)
-        ),
+        timelineSnapshotRead: Boolean(readCapabilities?.editor.timelineSnapshotRead),
+        timelineWrite: Boolean(operationCapabilities?.timelineWrite),
+        timelineArtifactWrite: Boolean(operationCapabilities?.timelineArtifactWrite),
+        readAfterWrite: canReadAfterWrite,
         incrementalChanges: Boolean(live?.editor.incrementalChanges),
-        rollback: Boolean((hasExplicitDocumentPair && mutation?.editor.rollback) || liveMutation),
+        rollback: Boolean(operationCapabilities?.rollback && operationAdapter?.restore),
         assetDiscovery: Boolean(snapshot?.editor.assetDiscovery || this.options.assets?.listAssets),
         liveStateRead: Boolean(live?.editor.liveStateRead),
         playheadWrite: Boolean(live?.editor.playheadWrite),
@@ -97,6 +122,7 @@ export class FinalCutSessionAdapter implements EditorPort, LiveEditorStatePort {
         playbackControl: Boolean(live?.editor.playbackControl),
         projectCatalogRead: Boolean(snapshot?.editor.projectCatalogRead || (!this.options.snapshot && live?.editor.projectCatalogRead)),
         projectSelection: Boolean(snapshot?.editor.projectSelection || (!this.options.snapshot && live?.editor.projectSelection)),
+        compositeTransactions,
       },
       analyzers: {
         speechTranscribe: Boolean(snapshot?.analyzers.speechTranscribe || mutation?.analyzers.speechTranscribe || live?.analyzers.speechTranscribe),
@@ -104,7 +130,43 @@ export class FinalCutSessionAdapter implements EditorPort, LiveEditorStatePort {
         audioLoudness: Boolean(snapshot?.analyzers.audioLoudness || mutation?.analyzers.audioLoudness || live?.analyzers.audioLoudness),
         visualTrack: Boolean(snapshot?.analyzers.visualTrack || mutation?.analyzers.visualTrack || live?.analyzers.visualTrack),
       },
-    }, { backend: "final-cut-session" });
+    }, {
+      backend: "final-cut-session",
+      canonicalDocument: {
+        read: readFamilies?.canonicalDocument.read ?? Boolean(readCapabilities?.editor.timelineSnapshotRead),
+        write: operationFamilies?.canonicalDocument.write ?? Boolean(operationCapabilities?.timelineWrite),
+        artifactWrite: operationFamilies?.canonicalDocument.artifactWrite ?? Boolean(operationCapabilities?.timelineArtifactWrite),
+      },
+      editing: {
+        compositeTransactions: compositeTransactions,
+        titlePlacement: operationFamilies?.editing.titlePlacement ?? Boolean(operationCapabilities?.titlePlacement),
+        pictureInPicture: operationFamilies?.editing.pictureInPicture ?? false,
+        masking: operationFamilies?.editing.masking ?? false,
+      },
+      editingBackend: operationFamilies?.editing.compositeTransactions.backend,
+    });
+  }
+
+  public async previewTransaction(
+    operations: WorkflowOperation[],
+    expectedRevision: ContextRevision,
+  ): Promise<ProjectSnapshot> {
+    const provider = await this.routedTransactionProvider();
+    if (!provider?.previewTransaction) {
+      throw new Error("CAPABILITY_UNAVAILABLE: editor composite transaction preview");
+    }
+    return provider.previewTransaction(operations, expectedRevision);
+  }
+
+  public async applyTransaction(
+    operations: WorkflowOperation[],
+    expectedRevision: ContextRevision,
+  ): Promise<void> {
+    const provider = await this.routedTransactionProvider();
+    if (!provider?.applyTransaction) {
+      throw new Error("CAPABILITY_UNAVAILABLE: editor composite transaction execution");
+    }
+    await provider.applyTransaction(operations, expectedRevision);
   }
 
   public async read(): Promise<ProjectSnapshot> {
@@ -198,6 +260,18 @@ export class FinalCutSessionAdapter implements EditorPort, LiveEditorStatePort {
   public async liveChangesSince(revision: ContextRevision, waitMs = 0): Promise<EditorChange[]> {
     if (!this.options.live) throw new Error("CAPABILITY_UNAVAILABLE: live Final Cut editor state");
     return this.options.live.liveChangesSince(revision, waitMs);
+  }
+
+  private async routedTransactionProvider(): Promise<Partial<Pick<EditorPort, "previewTransaction" | "applyTransaction">> | undefined> {
+    if (this.options.snapshot && this.options.mutation) return this.options.mutation;
+    const liveCapabilities = await optionalCapabilities(this.options.live);
+    const liveMutation = Boolean(
+      liveCapabilities?.editor.canonicalTimelineMode === "canonical-write"
+      && this.options.live?.apply
+      && this.options.live.restore,
+    );
+    if (liveMutation && this.options.live) return this.options.live;
+    return this.options.snapshot;
   }
 }
 

--- a/adapters/final-cut/typescript/src/session.ts
+++ b/adapters/final-cut/typescript/src/session.ts
@@ -95,6 +95,7 @@ export class FinalCutSessionAdapter implements EditorPort, LiveEditorStatePort {
     const canReadAfterWrite = Boolean(
       readAdapter?.readProject
       && readCapabilities?.editor.readAfterWrite
+      && operationCapabilities?.readAfterWrite
       && operationAdapter?.restore
       && operationCapabilities?.rollback,
     );

--- a/apps/mcp-server/src/main.ts
+++ b/apps/mcp-server/src/main.ts
@@ -144,6 +144,7 @@ const videoExporter = liveMode && !headlessFinalCut && process.env.FRAMEKIT_FINA
     })
   : undefined;
 const server = createMcpServer(runtime, {
+  processMode: liveMode && !headlessFinalCut ? "headed" : "headless",
   connectionStatus: () => connection?.getStatus(),
   nativeEditor,
   disposableNative,

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -3,8 +3,10 @@ import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import {
   AgentVideoRuntime,
+  createCapabilityPreflight,
   resolveEditingIntent,
   withCapabilityFamilies,
+  type CapabilityProcessMode,
   type RuntimeCapabilities,
   type TimelineFrameCapture,
 } from "@framekit/runtime";
@@ -624,6 +626,7 @@ export interface McpConnectionStatus {
 }
 
 export interface McpServerOptions {
+  processMode?: CapabilityProcessMode;
   connectionStatus?: () => McpConnectionStatus | undefined | Promise<McpConnectionStatus | undefined>;
   nativeEditor?: NativeFinalCutEditor;
   disposableNative?: Pick<DisposableNativeEditWorkflow, "preview" | "execute" | "undo">;
@@ -1465,44 +1468,49 @@ async function inspectMcpEditor(runtime: AgentVideoRuntime, options: McpServerOp
     typeof options.projectPublisher.isAvailable !== "function" || options.projectPublisher.isAvailable()
   ));
   const exportAvailable = Boolean(options.videoExporter?.isAvailable());
+  const capabilities = withCapabilityFamilies({
+    ...inspected.capabilities,
+    editor: {
+      ...inspected.capabilities.editor,
+      artifactPublish: publishingAvailable,
+      ...(publishingAvailable ? {} : { timelinePublishNewProject: false }),
+      videoExport: exportAvailable,
+    },
+  }, {
+    backend: inspected.identity.backend,
+    nativeBackend: "final-cut-accessibility",
+    native: {
+      selectionWrite: Boolean(native?.selectionEdit),
+      undo: Boolean(native?.undo),
+      mediaLibrarySearch: Boolean(native?.mediaLibrarySearch),
+      mediaImport: Boolean(native?.mediaImport),
+      mediaSelection: Boolean(native?.mediaSelection),
+      mediaAppendSelected: Boolean(native?.mediaAppendSelected),
+      timelineOccurrenceLocate: Boolean(native?.timelineOccurrenceLocate),
+      bladeAtPlayhead: Boolean(native?.bladeAtPlayhead),
+      deleteRange: Boolean(native?.deleteRange),
+      trimToDuration: Boolean(native?.trimToDuration),
+      mediaAppend: Boolean(native?.mediaAppend),
+      mediaInsert: Boolean(native?.mediaInsert),
+      titlePlacement: Boolean(native?.titlePlacement),
+      transitionDiscovery: Boolean(native?.transitionDiscovery),
+      transitionPlacement: Boolean(native?.transitionPlacement),
+      timelineFocus: Boolean(native?.timelineFocus),
+      projectCreation: false,
+      clipInsertion: false,
+      clipMovement: false,
+    },
+    publishing: publishingAvailable,
+    publishingBackend: "fcpxml-publisher",
+    export: exportAvailable,
+    exportBackend: "final-cut-native-export",
+  });
   return {
     ...inspected,
-    capabilities: withCapabilityFamilies({
-      ...inspected.capabilities,
-      editor: {
-        ...inspected.capabilities.editor,
-        artifactPublish: publishingAvailable,
-        ...(publishingAvailable ? {} : { timelinePublishNewProject: false }),
-        videoExport: exportAvailable,
-      },
-    }, {
-      backend: inspected.identity.backend,
-      nativeBackend: "final-cut-accessibility",
-      native: {
-        selectionWrite: Boolean(native?.selectionEdit),
-        undo: Boolean(native?.undo),
-        mediaLibrarySearch: Boolean(native?.mediaLibrarySearch),
-        mediaImport: Boolean(native?.mediaImport),
-        mediaSelection: Boolean(native?.mediaSelection),
-        mediaAppendSelected: Boolean(native?.mediaAppendSelected),
-        timelineOccurrenceLocate: Boolean(native?.timelineOccurrenceLocate),
-        bladeAtPlayhead: Boolean(native?.bladeAtPlayhead),
-        deleteRange: Boolean(native?.deleteRange),
-        trimToDuration: Boolean(native?.trimToDuration),
-        mediaAppend: Boolean(native?.mediaAppend),
-        mediaInsert: Boolean(native?.mediaInsert),
-        titlePlacement: Boolean(native?.titlePlacement),
-        transitionDiscovery: Boolean(native?.transitionDiscovery),
-        transitionPlacement: Boolean(native?.transitionPlacement),
-        timelineFocus: Boolean(native?.timelineFocus),
-        projectCreation: false,
-        clipInsertion: false,
-        clipMovement: false,
-      },
-      publishing: publishingAvailable,
-      publishingBackend: "fcpxml-publisher",
-      export: exportAvailable,
-      exportBackend: "final-cut-native-export",
+    capabilities,
+    preflight: createCapabilityPreflight(inspected.identity, capabilities, {
+      processMode: options.processMode ?? (native ? "headed" : "headless"),
+      nativeWrite: Boolean(native?.selectionEdit),
     }),
     ...(native ? { native } : {}),
   };

--- a/docs/architecture/capability-model.md
+++ b/docs/architecture/capability-model.md
@@ -18,8 +18,8 @@ properties:
 - `unavailableReason` is required when `available` is false and explains why
   the operation must fail closed.
 
-The families are `connection`, `observation`, `canonicalDocument`, `native`,
-`publishing`, `export`, and `analyzers`. The shape is intentionally additive so
+The families are `connection`, `observation`, `canonicalDocument`, `editing`,
+`native`, `publishing`, `export`, and `analyzers`. The shape is intentionally additive so
 older clients can continue reading the legacy booleans while new agents choose
 one operation at a time:
 
@@ -36,6 +36,12 @@ one operation at a time:
       "read": { "available": false, "backend": "workflow-extension-ipc", "guarantee": "none", "unavailableReason": "canonical timeline reads are unavailable" },
       "write": { "available": false, "backend": "workflow-extension-ipc", "guarantee": "none", "unavailableReason": "canonical timeline writes are unavailable" },
       "artifactWrite": { "available": false, "backend": "workflow-extension-ipc", "guarantee": "none", "unavailableReason": "canonical artifact writes are unavailable" }
+    },
+    "editing": {
+      "compositeTransactions": { "available": false, "backend": "workflow-extension-ipc", "guarantee": "none", "unavailableReason": "composite editing transactions are unavailable" },
+      "titlePlacement": { "available": false, "backend": "workflow-extension-ipc", "guarantee": "none", "unavailableReason": "title placement is unavailable" },
+      "pictureInPicture": { "available": false, "backend": "workflow-extension-ipc", "guarantee": "none", "unavailableReason": "picture-in-picture editing is unavailable" },
+      "masking": { "available": false, "backend": "workflow-extension-ipc", "guarantee": "none", "unavailableReason": "masking is unavailable" }
     },
     "native": {
       "selectionWrite": { "available": false, "backend": "final-cut-accessibility", "guarantee": "none", "unavailableReason": "native selection write is unavailable" },
@@ -76,3 +82,26 @@ expected revision, so stale or mismatched targets fail before mutation. A
 successful `apply` response returns the resulting revision so Framekit can
 perform compensating rollback even when the subsequent snapshot read fails. Native
 Accessibility operations remain a separate capability surface.
+
+## Inspect-time preflight
+
+`editor.inspect` adds a top-level `preflight` report. It describes the effective
+routed capabilities rather than only the identity of the composed editor:
+
+```json
+{
+  "mode": "fcpxml-artifact",
+  "documentMode": "fcpxml-artifact",
+  "processMode": "headless",
+  "backend": "final-cut-session",
+  "capabilities": { "...": "the same operation-level family descriptors" }
+}
+```
+
+`documentMode` distinguishes `fixture`, `fcpxml-artifact`, `metadata-only`, and
+`canonical-live`. `mode` becomes `native-write` only for an explicitly headed
+process with an available native write capability. A native-write report does not
+promote metadata-only or artifact results to canonical evidence. Each operation
+under `capabilities` retains its provider `backend`, `guarantee`, and, when
+unavailable, `unavailableReason`. PIP and masking remain explicit unavailable
+operations until a provider implements and verifies them.

--- a/docs/final-cut/installation.md
+++ b/docs/final-cut/installation.md
@@ -54,6 +54,13 @@ successful connections. Live metadata access also does not imply canonical
 timeline snapshot or write capability: inspect the active backend's capability
 flags before using project, timeline, or edit tools.
 
+Call `editor.inspect` after connecting to read the actionable `preflight` report.
+It identifies the active `mode`, `documentMode`, headed/headless `processMode`,
+and the provider backend, guarantee, or unavailable reason for each operation.
+An FCPXML artifact, metadata-only bridge, canonical-live bridge, and headed
+native-write session are distinct modes; one must not be used as evidence for
+another.
+
 Accessibility and Automation permission are required only for an explicit
 headed native-write setup. Native destructive edits retain their preview,
 execute, frontmost, focus, post-command verification, and undo requirements.

--- a/docs/mcp/capabilities-and-errors.md
+++ b/docs/mcp/capabilities-and-errors.md
@@ -65,6 +65,7 @@ The families are:
 | `connection` | `status` | Bridge connection availability only |
 | `observation` | `timeline`, `media` | Live metadata or canonical observation |
 | `canonicalDocument` | `read`, `write`, `artifactWrite` | Canonical timeline guarantees |
+| `editing` | `compositeTransactions`, `titlePlacement`, `pictureInPicture`, `masking` | Routed editing operations and explicit unsupported boundaries |
 | `native` | `selectionWrite`, `projectCreation`, `clipInsertion`, `clipMovement`, `titlePlacement` | Individual Final Cut Accessibility operations |
 | `publishing` | `projectCreation` | Importing a verified artifact as a new project |
 | `export` | `timeline` | Verified local video export |
@@ -76,6 +77,17 @@ project creation, clip insertion, or clip movement remains present with
 media insertion operation does not imply that any other native operation is
 available. `ready` is only a connection state and never implies arbitrary
 editability.
+
+`editor.inspect` also returns an inspect-time `preflight` report. Its `mode` is
+`fixture`, `fcpxml-artifact`, `metadata-only`, `canonical-live`, or
+`native-write`; `documentMode` preserves the underlying document mode when a
+headed native-write surface is active. `processMode` is `headed` or `headless`.
+The report repeats the effective `capabilities` families so agents can see the
+backend, guarantee, and unavailable reason for connection, canonical reads and
+writes, composite editing, speech, audio, visual analysis, title placement, PIP,
+and masking in one response. `native-write` is only reported for an explicitly
+headed process with a native write capability; deterministic, metadata-only, and
+FCPXML artifact results remain separate evidence tiers.
 
 ```json
 {

--- a/docs/tests/final-cut-live-e2e.md
+++ b/docs/tests/final-cut-live-e2e.md
@@ -55,6 +55,11 @@ The live MCP client should observe:
 - a valid sequence time range;
 - revisions for active sequence, sequence range, and playhead changes.
 
+The initial `editor.inspect` response should also include a preflight report with
+`processMode: "headless"` for the default live setup, the effective document
+mode, and operation-level backend, guarantee, and unavailable reasons. A bridge
+that only reports metadata must remain `mode: "metadata-only"`.
+
 For canonical MCP coverage, start the server with:
 
 ```sh
@@ -152,6 +157,18 @@ proves that the open canonical timeline changed through the verified target
 diff and advancing revision, then proves restoration through the matching
 canonical digest. If the bridge is metadata-only or canonical-read, it fails
 before calling `editor.timeline.edit`.
+
+For headed native-write evidence, use the disposable native runner separately:
+
+```sh
+FRAMEKIT_FINAL_CUT_E2E_PROJECT="Framekit Disposable E2E" \
+FRAMEKIT_FINAL_CUT_E2E_CLIP_ID="final-cut:occurrence:example" \
+pnpm run test:final-cut-disposable-headed
+```
+
+That run must report `preflight.mode: "native-write"` and is evidence for the
+headed native surface only; fixture, metadata-only, FCPXML, and canonical-live
+results remain separate.
 
 Before attaching the JSON to a release or pull request, review that it contains
 no private media paths, raw snapshots, transaction identifiers, credentials,

--- a/packages/runtime/src/capabilities.ts
+++ b/packages/runtime/src/capabilities.ts
@@ -107,8 +107,14 @@ export function withCapabilityFamilies(
     ...nativeAvailability(previous?.native),
     ...options.native,
   };
-  const canonicalDocument = options.canonicalDocument ?? {};
-  const editing = options.editing ?? {};
+  const canonicalDocument = {
+    ...previous?.canonicalDocument,
+    ...options.canonicalDocument,
+  };
+  const editing = {
+    ...previous?.editing,
+    ...options.editing,
+  };
   const families: CapabilityFamilies = {
     connection: {
       status: descriptorFrom(
@@ -153,7 +159,11 @@ export function withCapabilityFamilies(
         "canonical artifact writes are unavailable",
       ),
     },
-    editing: editingFamily(editor, editing, options.editingBackend ?? backend),
+    editing: editingFamily(
+      editor,
+      editing,
+      options.editingBackend ?? previous?.editing?.compositeTransactions.backend ?? backend,
+    ),
     native: nativeFamily(native, options.nativeBackend ?? previous?.native.selectionWrite.backend ?? backend),
     publishing: {
       projectCreation: descriptorFrom(

--- a/packages/runtime/src/capabilities.ts
+++ b/packages/runtime/src/capabilities.ts
@@ -53,6 +53,16 @@ export function withCanonicalTimelineMode(capabilities: RuntimeCapabilities): Ru
   };
   const previous = capabilities.families;
   if (!previous) return normalized;
+  const canonicalRead = normalized.editor.canonicalTimelineMode === "canonical-read"
+    || normalized.editor.canonicalTimelineMode === "canonical-write";
+  const canonicalWrite = normalized.editor.canonicalTimelineMode === "canonical-write";
+  const compositeTransactions = Boolean(
+    normalized.editor.compositeTransactions
+    && normalized.editor.timelineSnapshotRead
+    && normalized.editor.readAfterWrite
+    && normalized.editor.rollback
+    && (normalized.editor.timelineArtifactWrite || canonicalWrite),
+  );
   return withCapabilityFamilies(normalized, {
     backend: previous.connection.status.backend,
     nativeBackend: previous.native.selectionWrite.backend,
@@ -60,12 +70,31 @@ export function withCanonicalTimelineMode(capabilities: RuntimeCapabilities): Ru
     exportBackend: previous.export.timeline.backend,
     analyzerBackend: previous.analyzers.speechTranscribe.backend,
     connection: previous.connection.status,
-    canonicalDocument: previous.canonicalDocument,
-    editing: previous.editing,
+    canonicalDocument: {
+      read: refreshDescriptor(canonicalRead, previous.canonicalDocument.read, "canonical-read", "canonical timeline reads are unavailable"),
+      write: refreshDescriptor(canonicalWrite, previous.canonicalDocument.write, "canonical-write", "canonical timeline writes are unavailable"),
+      artifactWrite: refreshDescriptor(normalized.editor.timelineArtifactWrite, previous.canonicalDocument.artifactWrite, "artifact-write", "canonical artifact writes are unavailable"),
+    },
+    editing: {
+      compositeTransactions: refreshDescriptor(compositeTransactions, previous.editing.compositeTransactions, "verified", "composite editing transactions are unavailable"),
+      titlePlacement: refreshDescriptor(Boolean(normalized.editor.titlePlacement), previous.editing.titlePlacement, "verified", "title placement is unavailable"),
+      pictureInPicture: previous.editing.pictureInPicture,
+      masking: previous.editing.masking,
+    },
     native: nativeAvailability(previous.native),
     publishing: previous.publishing.projectCreation,
     export: previous.export.timeline,
   });
+}
+
+function refreshDescriptor(
+  available: boolean,
+  previous: CapabilityDescriptor,
+  guarantee: Exclude<CapabilityDescriptor["guarantee"], "none">,
+  unavailableReason: string,
+): CapabilityDescriptor {
+  if (available && previous.available) return previous;
+  return descriptorFrom(available, previous.backend, guarantee, unavailableReason);
 }
 
 export interface CapabilityFamilyOptions {

--- a/packages/runtime/src/capabilities.ts
+++ b/packages/runtime/src/capabilities.ts
@@ -2,12 +2,29 @@ import { CAPABILITY_SCHEMA_VERSION } from "./domain/capabilities.js";
 import type {
   CapabilityDescriptor,
   CapabilityFamilies,
+  EditingCapabilityOperation,
+  EditorIdentity,
   NativeCapabilityOperation,
   RuntimeCapabilities,
   VersionedRuntimeCapabilities,
 } from "./domain/capabilities.js";
 
 export type CanonicalTimelineMode = "metadata-only" | "canonical-read" | "canonical-write";
+export type CapabilityProcessMode = "headless" | "headed";
+export type CapabilityPreflightMode =
+  | "fixture"
+  | "fcpxml-artifact"
+  | "metadata-only"
+  | "canonical-live"
+  | "native-write";
+
+export interface CapabilityPreflight {
+  mode: CapabilityPreflightMode;
+  documentMode: Exclude<CapabilityPreflightMode, "native-write">;
+  processMode: CapabilityProcessMode;
+  backend: string;
+  capabilities: CapabilityFamilies;
+}
 
 export function canonicalTimelineMode(capabilities: RuntimeCapabilities): CanonicalTimelineMode {
   const editor = capabilities.editor;
@@ -43,6 +60,8 @@ export function withCanonicalTimelineMode(capabilities: RuntimeCapabilities): Ru
     exportBackend: previous.export.timeline.backend,
     analyzerBackend: previous.analyzers.speechTranscribe.backend,
     connection: previous.connection.status,
+    canonicalDocument: previous.canonicalDocument,
+    editing: previous.editing,
     native: nativeAvailability(previous.native),
     publishing: previous.publishing.projectCreation,
     export: previous.export.timeline,
@@ -56,6 +75,9 @@ export interface CapabilityFamilyOptions {
   publishingBackend?: string;
   exportBackend?: string;
   analyzerBackend?: string;
+  canonicalDocument?: Partial<Record<"read" | "write" | "artifactWrite", boolean | CapabilityDescriptor>>;
+  editing?: Partial<Record<EditingCapabilityOperation, boolean | CapabilityDescriptor>>;
+  editingBackend?: string;
   connection?: boolean | CapabilityDescriptor;
   native?: Partial<Record<NativeCapabilityOperation, boolean>>;
   publishing?: boolean | CapabilityDescriptor;
@@ -85,6 +107,8 @@ export function withCapabilityFamilies(
     ...nativeAvailability(previous?.native),
     ...options.native,
   };
+  const canonicalDocument = options.canonicalDocument ?? {};
+  const editing = options.editing ?? {};
   const families: CapabilityFamilies = {
     connection: {
       status: descriptorFrom(
@@ -110,25 +134,26 @@ export function withCapabilityFamilies(
     },
     canonicalDocument: {
       read: descriptorFrom(
-        editor.canonicalTimelineMode === "canonical-read"
-          || editor.canonicalTimelineMode === "canonical-write",
+        canonicalDocument.read ?? (editor.canonicalTimelineMode === "canonical-read"
+          || editor.canonicalTimelineMode === "canonical-write"),
         backend,
         "canonical-read",
         "canonical timeline reads are unavailable",
       ),
       write: descriptorFrom(
-        editor.canonicalTimelineMode === "canonical-write",
+        canonicalDocument.write ?? (editor.canonicalTimelineMode === "canonical-write"),
         backend,
         "canonical-write",
         "canonical timeline writes are unavailable",
       ),
       artifactWrite: descriptorFrom(
-        editor.timelineArtifactWrite,
+        canonicalDocument.artifactWrite ?? editor.timelineArtifactWrite,
         backend,
         "artifact-write",
         "canonical artifact writes are unavailable",
       ),
     },
+    editing: editingFamily(editor, editing, options.editingBackend ?? backend),
     native: nativeFamily(native, options.nativeBackend ?? previous?.native.selectionWrite.backend ?? backend),
     publishing: {
       projectCreation: descriptorFrom(
@@ -155,6 +180,71 @@ export function withCapabilityFamilies(
     },
   };
   return { ...normalized, families };
+}
+
+function editingFamily(
+  editor: RuntimeCapabilities["editor"],
+  overrides: Partial<Record<EditingCapabilityOperation, boolean | CapabilityDescriptor>>,
+  backend: string,
+): Record<EditingCapabilityOperation, CapabilityDescriptor> {
+  return {
+    compositeTransactions: descriptorFrom(
+      overrides.compositeTransactions ?? Boolean(editor.compositeTransactions),
+      backend,
+      "verified",
+      "composite editing transactions are unavailable",
+    ),
+    titlePlacement: descriptorFrom(
+      overrides.titlePlacement ?? Boolean(editor.titlePlacement),
+      backend,
+      "verified",
+      "title placement is unavailable",
+    ),
+    pictureInPicture: descriptorFrom(
+      overrides.pictureInPicture ?? false,
+      backend,
+      "verified",
+      "picture-in-picture editing is unavailable",
+    ),
+    masking: descriptorFrom(
+      overrides.masking ?? false,
+      backend,
+      "verified",
+      "masking is unavailable",
+    ),
+  };
+}
+
+export function createCapabilityPreflight(
+  identity: EditorIdentity,
+  capabilities: RuntimeCapabilities,
+  options: {
+    processMode?: CapabilityProcessMode;
+    nativeWrite?: boolean;
+  } = {},
+): CapabilityPreflight {
+  const normalized = capabilities.families
+    ? capabilities as VersionedRuntimeCapabilities
+    : withCapabilityFamilies(capabilities, { backend: identity.backend });
+  const editor = normalized.editor;
+  const documentMode: CapabilityPreflight["documentMode"] = identity.backend === "fixture"
+    ? "fixture"
+    : editor.timelineArtifactWrite && !editor.timelineWrite
+      ? "fcpxml-artifact"
+      : editor.canonicalTimelineMode === "metadata-only"
+        ? "metadata-only"
+        : "canonical-live";
+  const processMode = options.processMode ?? "headless";
+  const mode: CapabilityPreflightMode = options.nativeWrite && processMode === "headed"
+    ? "native-write"
+    : documentMode;
+  return {
+    mode,
+    documentMode,
+    processMode,
+    backend: identity.backend,
+    capabilities: normalized.families,
+  };
 }
 
 function descriptorFrom(

--- a/packages/runtime/src/domain/capabilities.ts
+++ b/packages/runtime/src/domain/capabilities.ts
@@ -77,6 +77,12 @@ export interface CapabilityDescriptor {
   unavailableReason?: string;
 }
 
+export type EditingCapabilityOperation =
+  | "compositeTransactions"
+  | "titlePlacement"
+  | "pictureInPicture"
+  | "masking";
+
 export type NativeCapabilityOperation =
   | "selectionWrite"
   | "undo"
@@ -111,6 +117,7 @@ export interface CapabilityFamilies {
     write: CapabilityDescriptor;
     artifactWrite: CapabilityDescriptor;
   };
+  editing: Record<EditingCapabilityOperation, CapabilityDescriptor>;
   native: Record<NativeCapabilityOperation, CapabilityDescriptor>;
   publishing: {
     projectCreation: CapabilityDescriptor;

--- a/tests/integration/capabilities.test.ts
+++ b/tests/integration/capabilities.test.ts
@@ -106,6 +106,7 @@ test("capability normalization invalidates stale descriptors after a downgrade",
     editor: {
       ...artifactCapabilities.editor,
       timelineWrite: true,
+      timelineArtifactWrite: false,
       readAfterWrite: true,
       rollback: true,
       projectRead: true,

--- a/tests/integration/capabilities.test.ts
+++ b/tests/integration/capabilities.test.ts
@@ -10,7 +10,7 @@ import {
   FinalCutSessionAdapter,
 } from "@framekit/final-cut";
 import type { NativeFinalCutEditor } from "@framekit/final-cut";
-import { AgentVideoRuntime, withCapabilityFamilies } from "@framekit/runtime";
+import { AgentVideoRuntime, withCanonicalTimelineMode, withCapabilityFamilies } from "@framekit/runtime";
 import { InMemoryEditorAdapter } from "@framekit/testkit";
 import { createMcpServer } from "../../apps/mcp-server/src/server.js";
 import { join } from "node:path";
@@ -99,6 +99,38 @@ test("canonical writes retain canonical-read guarantees and asset discovery is n
   assert.equal(canonicalWrite.families.canonicalDocument.read.guarantee, "canonical-read");
   assert.equal(canonicalWrite.families.canonicalDocument.write.available, true);
   assert.equal(assetOnly.families.observation.media.available, false);
+});
+
+test("capability normalization invalidates stale descriptors after a downgrade", () => {
+  const canonicalWrite = withCapabilityFamilies({
+    editor: {
+      ...artifactCapabilities.editor,
+      timelineWrite: true,
+      readAfterWrite: true,
+      rollback: true,
+      projectRead: true,
+      projectCatalogRead: true,
+      projectSelection: true,
+      compositeTransactions: true,
+    },
+    analyzers: artifactCapabilities.analyzers,
+  }, { backend: "canonical-live-ipc" });
+
+  const downgraded = withCanonicalTimelineMode({
+    ...canonicalWrite,
+    editor: {
+      ...canonicalWrite.editor,
+      timelineWrite: false,
+      projectCatalogRead: false,
+      projectSelection: false,
+    },
+  });
+
+  assert.equal(downgraded.editor.canonicalTimelineMode, "metadata-only");
+  assert.equal(downgraded.families?.canonicalDocument.write.available, false);
+  assert.equal(downgraded.families?.canonicalDocument.write.backend, "canonical-live-ipc");
+  assert.equal(downgraded.families?.editing.compositeTransactions.available, false);
+  assert.equal(downgraded.families?.editing.compositeTransactions.backend, "canonical-live-ipc");
 });
 
 test("unavailable capability operations explain their fail-closed reason", () => {

--- a/tests/integration/capabilities.test.ts
+++ b/tests/integration/capabilities.test.ts
@@ -292,6 +292,13 @@ test("capability documentation describes the versioned operation contract", asyn
   assert.match(documentation, /families/);
   assert.match(documentation, /unavailableReason/);
   assert.match(documentation, /canonicalDocument/);
+  assert.match(documentation, /editing/);
+  assert.match(documentation, /pictureInPicture/);
+  assert.match(documentation, /masking/);
+  assert.match(documentation, /preflight/);
+  assert.match(documentation, /documentMode/);
+  assert.match(documentation, /processMode/);
+  assert.match(documentation, /native-write/);
   assert.match(documentation, /projectCreation/);
   assert.match(documentation, /clipInsertion/);
   assert.match(documentation, /clipMovement/);

--- a/tests/integration/finalcut-routing.test.ts
+++ b/tests/integration/finalcut-routing.test.ts
@@ -61,10 +61,10 @@ test("Final Cut sessions route artifact composite transactions to the mutation p
 
     const preview = await runtime.previewArtifactEdit(artifactPath, {
       baseRevision: before.revision,
-      operations: [{ type: "rename-clip", clipId: "clip-routing", name: "Renamed" }],
+      operations: [{ type: "rename-clip", clipId: before.timeline.clips[0]!.id, name: "Renamed" }],
     });
     assert.equal(mutation.previewCalls, 1);
-    assert.equal(preview.expectedDiff.modified[0]?.after.name, "Renamed");
+    assert.equal(preview.expectedDiff.modified[0]?.after?.name, "Renamed");
 
     const transaction = await runtime.executeEdit(preview.previewToken);
     assert.equal(mutation.applyCalls, 1);

--- a/tests/integration/finalcut-routing.test.ts
+++ b/tests/integration/finalcut-routing.test.ts
@@ -46,6 +46,19 @@ class TrackingFcpxmlAdapter extends FcpxmlDocumentAdapter {
   }
 }
 
+class UnsynchronizedFcpxmlAdapter extends FcpxmlDocumentAdapter {
+  public override async getCapabilities() {
+    const capabilities = await super.getCapabilities();
+    return {
+      ...capabilities,
+      editor: {
+        ...capabilities.editor,
+        readAfterWrite: false,
+      },
+    };
+  }
+}
+
 function textFrom(result: unknown): string {
   const content = (result as { content?: unknown }).content;
   assert.ok(Array.isArray(content));
@@ -100,6 +113,26 @@ test("Final Cut sessions route artifact composite transactions to the mutation p
     assert.equal(transaction.status, "VERIFIED");
     assert.equal(transaction.after.timeline.clips[0]?.name, "Renamed");
     assert.equal(transaction.verification?.passed, true);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("split-provider sessions require mutation read-after-write guarantees", async () => {
+  const directory = await mkdtemp(join(os.tmpdir(), "framekit-finalcut-routing-guarantee-"));
+  const artifactPath = join(directory, "project.fcpxml");
+
+  try {
+    await writeFile(artifactPath, FCPXML);
+    const session = new FinalCutSessionAdapter({
+      snapshot: new FcpxmlDocumentAdapter(artifactPath),
+      mutation: new UnsynchronizedFcpxmlAdapter(artifactPath),
+    });
+    const capabilities = await session.getCapabilities();
+
+    assert.equal(capabilities.editor.readAfterWrite, false);
+    assert.equal(capabilities.editor.compositeTransactions, false);
+    assert.equal(capabilities.families?.editing.compositeTransactions.available, false);
   } finally {
     await rm(directory, { recursive: true, force: true });
   }

--- a/tests/integration/finalcut-routing.test.ts
+++ b/tests/integration/finalcut-routing.test.ts
@@ -3,12 +3,17 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import {
   FcpxmlDocumentAdapter,
+  FinalCutLiveAdapter,
   FinalCutSessionAdapter,
 } from "@framekit/final-cut";
 import type { ContextRevision, ProjectSnapshot, WorkflowOperation } from "@framekit/runtime";
 import { AgentVideoRuntime } from "@framekit/runtime";
+import { InMemoryEditorAdapter } from "@framekit/testkit";
+import { createMcpServer } from "../../apps/mcp-server/src/server.js";
 
 const FCPXML = `<?xml version="1.0"?>
 <fcpxml version="1.11">
@@ -38,6 +43,30 @@ class TrackingFcpxmlAdapter extends FcpxmlDocumentAdapter {
   ): Promise<void> {
     this.applyCalls += 1;
     return super.applyTransaction(operations, expectedRevision);
+  }
+}
+
+function textFrom(result: unknown): string {
+  const content = (result as { content?: unknown }).content;
+  assert.ok(Array.isArray(content));
+  const first = content[0] as { text?: unknown } | undefined;
+  assert.equal(typeof first?.text, "string");
+  return first?.text as string;
+}
+
+async function inspectWithMcp(
+  runtime: AgentVideoRuntime,
+  options: Parameters<typeof createMcpServer>[1] = {},
+): Promise<any> {
+  const server = createMcpServer(runtime, options);
+  const client = new Client({ name: "preflight-test", version: "0.1.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  try {
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+    return JSON.parse(textFrom(await client.callTool({ name: "editor.inspect", arguments: {} })));
+  } finally {
+    await client.close();
+    await server.close();
   }
 }
 
@@ -74,4 +103,146 @@ test("Final Cut sessions route artifact composite transactions to the mutation p
   } finally {
     await rm(directory, { recursive: true, force: true });
   }
+});
+
+test("editor inspection exposes actionable artifact preflight provenance", async () => {
+  const directory = await mkdtemp(join(os.tmpdir(), "framekit-finalcut-preflight-"));
+  const artifactPath = join(directory, "project.fcpxml");
+
+  try {
+    await writeFile(artifactPath, FCPXML);
+    const document = new FcpxmlDocumentAdapter(artifactPath);
+    const payload = await inspectWithMcp(new AgentVideoRuntime(new FinalCutSessionAdapter({
+      snapshot: document,
+      mutation: document,
+    })));
+
+    assert.equal(payload.preflight.mode, "fcpxml-artifact");
+    assert.equal(payload.preflight.documentMode, "fcpxml-artifact");
+    assert.equal(payload.preflight.processMode, "headless");
+    assert.equal(payload.preflight.backend, "final-cut-session");
+    assert.equal(payload.preflight.capabilities.canonicalDocument.artifactWrite.backend, "fcpxml-document");
+    assert.equal(payload.preflight.capabilities.editing.compositeTransactions.available, true);
+    assert.equal(payload.preflight.capabilities.editing.compositeTransactions.backend, "fcpxml-document");
+    assert.equal(payload.preflight.capabilities.editing.compositeTransactions.guarantee, "verified");
+    assert.equal(payload.preflight.capabilities.editing.titlePlacement.available, false);
+    assert.match(payload.preflight.capabilities.editing.pictureInPicture.unavailableReason, /unavailable/);
+    assert.match(payload.preflight.capabilities.editing.masking.unavailableReason, /unavailable/);
+    assert.equal(payload.preflight.capabilities.analyzers.speechTranscribe.available, false);
+    assert.match(payload.preflight.capabilities.analyzers.audioLoudness.unavailableReason, /unavailable/);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("editor inspection distinguishes fixture, metadata-only, canonical-live, and native-write modes", async () => {
+  const fixture = await inspectWithMcp(new AgentVideoRuntime(new InMemoryEditorAdapter({
+    projectId: "project-fixture",
+    projectName: "Fixture",
+    timelineId: "sequence-fixture",
+    timelineName: "Main",
+    clips: [],
+  })));
+  assert.equal(fixture.preflight.mode, "fixture");
+  assert.equal(fixture.preflight.documentMode, "fixture");
+
+  const metadataCapabilities = {
+    editor: {
+      projectRead: true,
+      timelineSnapshotRead: false,
+      timelineWrite: false,
+      timelineArtifactWrite: false,
+      readAfterWrite: false,
+      incrementalChanges: true,
+      rollback: false,
+      assetDiscovery: false,
+      liveStateRead: true,
+      playheadWrite: false,
+      frameCapture: false,
+    },
+    analyzers: {
+      speechTranscribe: false,
+      speechVad: false,
+      audioLoudness: false,
+      visualTrack: false,
+    },
+  };
+  const metadataLive = new FinalCutLiveAdapter({
+    request: async (request) => ({
+      version: 1,
+      id: request.id,
+      ok: true,
+      result: {
+        identity: { name: "Final Cut Pro", version: "test", backend: "workflow-extension-ipc" },
+        capabilities: metadataCapabilities,
+      },
+    }),
+  });
+  const metadata = await inspectWithMcp(new AgentVideoRuntime(metadataLive), { processMode: "headless" });
+  assert.equal(metadata.preflight.mode, "metadata-only");
+  assert.equal(metadata.preflight.documentMode, "metadata-only");
+  assert.equal(metadata.preflight.processMode, "headless");
+  assert.equal(metadata.preflight.capabilities.connection.status.backend, "workflow-extension-ipc");
+
+  const canonicalLive = await inspectWithMcp(new AgentVideoRuntime(new FinalCutLiveAdapter({
+    request: async (request) => ({
+      version: 1,
+      id: request.id,
+      ok: true,
+      result: {
+        identity: { name: "Final Cut Pro", version: "test", backend: "canonical-live-ipc" },
+        capabilities: {
+          ...metadataCapabilities,
+          editor: {
+            ...metadataCapabilities.editor,
+            projectRead: true,
+            timelineSnapshotRead: true,
+            projectCatalogRead: true,
+            projectSelection: true,
+          },
+        },
+      },
+    }),
+  })));
+  assert.equal(canonicalLive.preflight.mode, "canonical-live");
+  assert.equal(canonicalLive.preflight.documentMode, "canonical-live");
+
+  const native = await inspectWithMcp(new AgentVideoRuntime(new FinalCutLiveAdapter({
+    request: async (request) => ({
+      version: 1,
+      id: request.id,
+      ok: true,
+      result: {
+        identity: { name: "Final Cut Pro", version: "test", backend: "workflow-extension-ipc" },
+        capabilities: metadataCapabilities,
+      },
+    }),
+  })), {
+    processMode: "headed",
+    nativeEditor: {
+      capabilities: () => ({
+        selectionEdit: true,
+        undo: true,
+        mediaLibrarySearch: false,
+        mediaImport: false,
+        mediaSelection: false,
+        mediaAppendSelected: false,
+        timelineOccurrenceLocate: false,
+        bladeAtPlayhead: false,
+        deleteRange: false,
+        trimToDuration: false,
+        mediaAppend: false,
+        mediaInsert: false,
+        titlePlacement: false,
+        timelineFocus: false,
+        requiresAccessibility: true,
+        requiresFinalCutFrontmost: true,
+      }),
+    } as never,
+  });
+  assert.equal(native.preflight.mode, "native-write");
+  assert.equal(native.preflight.documentMode, "metadata-only");
+  assert.equal(native.preflight.processMode, "headed");
+  assert.equal(native.preflight.capabilities.native.selectionWrite.backend, "final-cut-accessibility");
+  assert.equal(native.preflight.capabilities.native.selectionWrite.guarantee, "native-verified");
 });

--- a/tests/integration/finalcut-routing.test.ts
+++ b/tests/integration/finalcut-routing.test.ts
@@ -120,7 +120,7 @@ test("editor inspection exposes actionable artifact preflight provenance", async
     assert.equal(payload.preflight.mode, "fcpxml-artifact");
     assert.equal(payload.preflight.documentMode, "fcpxml-artifact");
     assert.equal(payload.preflight.processMode, "headless");
-    assert.equal(payload.preflight.backend, "final-cut-session");
+    assert.equal(payload.preflight.backend, "fcpxml-document");
     assert.equal(payload.preflight.capabilities.canonicalDocument.artifactWrite.backend, "fcpxml-document");
     assert.equal(payload.preflight.capabilities.editing.compositeTransactions.available, true);
     assert.equal(payload.preflight.capabilities.editing.compositeTransactions.backend, "fcpxml-document");

--- a/tests/integration/finalcut-routing.test.ts
+++ b/tests/integration/finalcut-routing.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  FcpxmlDocumentAdapter,
+  FinalCutSessionAdapter,
+} from "@framekit/final-cut";
+import type { ContextRevision, ProjectSnapshot, WorkflowOperation } from "@framekit/runtime";
+import { AgentVideoRuntime } from "@framekit/runtime";
+
+const FCPXML = `<?xml version="1.0"?>
+<fcpxml version="1.11">
+  <resources />
+  <library><event name="Event"><project uid="project-routing" name="Routing Project">
+    <sequence uid="sequence-routing" duration="1s"><spine>
+      <asset-clip id="clip-routing" name="Original" offset="0s" duration="1s" />
+    </spine></sequence>
+  </project></event></library>
+</fcpxml>`;
+
+class TrackingFcpxmlAdapter extends FcpxmlDocumentAdapter {
+  public previewCalls = 0;
+  public applyCalls = 0;
+
+  public override async previewTransaction(
+    operations: WorkflowOperation[],
+    expectedRevision: ContextRevision,
+  ): Promise<ProjectSnapshot> {
+    this.previewCalls += 1;
+    return super.previewTransaction(operations, expectedRevision);
+  }
+
+  public override async applyTransaction(
+    operations: WorkflowOperation[],
+    expectedRevision: ContextRevision,
+  ): Promise<void> {
+    this.applyCalls += 1;
+    return super.applyTransaction(operations, expectedRevision);
+  }
+}
+
+test("Final Cut sessions route artifact composite transactions to the mutation provider", async () => {
+  const directory = await mkdtemp(join(os.tmpdir(), "framekit-finalcut-routing-"));
+  const artifactPath = join(directory, "project.fcpxml");
+
+  try {
+    await writeFile(artifactPath, FCPXML);
+    const mutation = new TrackingFcpxmlAdapter(artifactPath);
+    const runtime = new AgentVideoRuntime(new FinalCutSessionAdapter({
+      snapshot: new FcpxmlDocumentAdapter(artifactPath),
+      mutation,
+    }));
+    const before = await runtime.inspectProject();
+    const inspected = await runtime.inspectEditor();
+
+    assert.equal(inspected.capabilities.editor.compositeTransactions, true);
+    assert.equal(inspected.capabilities.families?.editing.compositeTransactions.available, true);
+    assert.equal(inspected.capabilities.families?.editing.compositeTransactions.backend, "fcpxml-document");
+
+    const preview = await runtime.previewArtifactEdit(artifactPath, {
+      baseRevision: before.revision,
+      operations: [{ type: "rename-clip", clipId: "clip-routing", name: "Renamed" }],
+    });
+    assert.equal(mutation.previewCalls, 1);
+    assert.equal(preview.expectedDiff.modified[0]?.after.name, "Renamed");
+
+    const transaction = await runtime.executeEdit(preview.previewToken);
+    assert.equal(mutation.applyCalls, 1);
+    assert.equal(transaction.status, "VERIFIED");
+    assert.equal(transaction.after.timeline.clips[0]?.name, "Renamed");
+    assert.equal(transaction.verification?.passed, true);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
<!-- Title naming policy -->

- [x] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [x] Github issue: Closes: #164

## Summary

Preserve capabilities from the provider responsible for routed Final Cut
operations, and route composite transaction preview/execute through that
provider. FCPXML previews now capture the temporary snapshot before restoring
the document state.

Add an additive `editing` capability family and an `editor.inspect` `preflight`
report covering backend, guarantee, unavailable reason, document mode, and
headed/headless process mode. The report keeps fixture, FCPXML artifact,
metadata-only, canonical-live, and native-write evidence distinct.

## Validation

```bash
pnpm install --frozen-lockfile
pnpm run build
pnpm run test
pnpm run check:boundaries
```

All passed locally: 525 tests and the package boundary check. No native files
changed, so Xcode validation was not required. The headed native Final Cut
runner remains an opt-in separate evidence path and was not claimed here.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Public MCP behavior or package interfaces are documented if changed.
- [x] Existing adapters and test fixtures remain compatible, or the migration is explained above.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [x] Documentation reflects the changed capability and evidence contract.
