### PR TITLE
Release for v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [v0.1.6](https://github.com/morshoto/framekit/compare/v0.1.5...v0.1.6) - 2026-09-11
+
+- fix: make tagged release retries idempotent by @morshoto in https://github.com/morshoto/framekit/pull/163
+- Implement dialogue-normalization Skill by @morshoto in https://github.com/morshoto/framekit/pull/188
+- feat: implement filler-removal Skill by @morshoto in https://github.com/morshoto/framekit/pull/189
+- Discover built-in Final Cut Motion titles by @morshoto in https://github.com/morshoto/framekit/pull/190
+- feat: add native masking capability by @morshoto in https://github.com/morshoto/framekit/pull/191
+- feat: add native picture-in-picture by @morshoto in https://github.com/morshoto/framekit/pull/192
+- [Improvement] Add the v0.1.6 native-editing release gate by @morshoto in https://github.com/morshoto/framekit/pull/193
+- feat: produce sanitized headed-native evidence by @morshoto in https://github.com/morshoto/framekit/pull/196
+- fix: sanitize staged commits and repair release gate by @morshoto in https://github.com/morshoto/framekit/pull/198
+- feat: Enable headed canonical Final Cut provider by @morshoto in https://github.com/morshoto/framekit/pull/197
+- fix: reject out-of-bounds ripple-delete ranges (#199) by @morshoto in https://github.com/morshoto/framekit/pull/201
+- test: cover canonical live MCP boundary (#194) by @morshoto in https://github.com/morshoto/framekit/pull/200
+
 ## [v0.1.5](https://github.com/morshoto/framekit/compare/v0.1.4...v0.1.5) - 2026-09-11
 
 - test: align pnpm lockfile assertion by @morshoto in https://github.com/morshoto/framekit/pull/174

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@morshoto/framekit",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "packageManager": "pnpm@12.3.4",
   "private": false,
   "type": "module",

--- a/plugins/framekit/.codex-plugin/plugin.json
+++ b/plugins/framekit/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "framekit",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Connect Codex to Framekit's MCP tools for Final Cut Pro",
   "author": {
     "name": "Framekit Contributors",


### PR DESCRIPTION
This pull request is for the next release as v0.1.6 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.6 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.5" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* fix: make tagged release retries idempotent by @morshoto in https://github.com/morshoto/framekit/pull/163
* Implement dialogue-normalization Skill by @morshoto in https://github.com/morshoto/framekit/pull/188
* feat: implement filler-removal Skill by @morshoto in https://github.com/morshoto/framekit/pull/189
* Discover built-in Final Cut Motion titles by @morshoto in https://github.com/morshoto/framekit/pull/190
* feat: add native masking capability by @morshoto in https://github.com/morshoto/framekit/pull/191
* feat: add native picture-in-picture by @morshoto in https://github.com/morshoto/framekit/pull/192
* [Improvement] Add the v0.1.6 native-editing release gate by @morshoto in https://github.com/morshoto/framekit/pull/193
* feat: produce sanitized headed-native evidence by @morshoto in https://github.com/morshoto/framekit/pull/196
* fix: sanitize staged commits and repair release gate by @morshoto in https://github.com/morshoto/framekit/pull/198
* feat: Enable headed canonical Final Cut provider by @morshoto in https://github.com/morshoto/framekit/pull/197
* fix: reject out-of-bounds ripple-delete ranges (#199) by @morshoto in https://github.com/morshoto/framekit/pull/201
* test: cover canonical live MCP boundary (#194) by @morshoto in https://github.com/morshoto/framekit/pull/200


**Full Changelog**: https://github.com/morshoto/framekit/compare/v0.1.5...tagpr-from-v0.1.5