### PR TITLE
Implement dialogue-normalization Skill

### DIFF
--- a/adapters/final-cut/typescript/src/fcpxml.ts
+++ b/adapters/final-cut/typescript/src/fcpxml.ts
@@ -98,7 +98,7 @@ export class FcpxmlDocumentAdapter implements EditorPort {
         projectCatalogRead: true,
         projectSelection: true,
         compositeTransactions: true,
-        semanticOperations: { "add-marker": true },
+        semanticOperations: { "add-marker": true, "set-gain": true },
       },
       analyzers: emptyAnalyzerCapabilities(),
     }, { backend: "fcpxml-document" });

--- a/docs/adr/0008-skill-contract.md
+++ b/docs/adr/0008-skill-contract.md
@@ -15,7 +15,7 @@ can be inspected and planned without importing MCP or Final Cut code.
 
 `@framekit/runtime` owns the versioned Skill contract. A `SkillManifest` is
 metadata: a stable ID, semantic version, title, description, transport-neutral
-input schema, capability requirements, and optional verification defaults.
+input schema, capability requirements, and optional input or verification defaults.
 
 The executable `SkillHandler` is kept separate from the manifest. It receives a
 read-only `SkillPlanningContext` containing a project snapshot, runtime

--- a/docs/mcp/skill-authoring.md
+++ b/docs/mcp/skill-authoring.md
@@ -23,6 +23,8 @@ const manifest: SkillManifest = {
     required: ["name", "start"],
     additionalProperties: false,
   },
+  // Optional values resolved by the version-pinned handler.
+  defaults: { start: 0 },
   requirements: {
     type: "operation",
     operation: "add-marker",
@@ -31,9 +33,11 @@ const manifest: SkillManifest = {
 ```
 
 The ID is stable across releases. The version is semantic and is pinned by
-preview tokens. Input schemas reject missing, unknown, or incorrectly typed
-values before planning. Requirements use `allOf` and `anyOf` trees over editor
-capabilities, analyzer capabilities, and explicit semantic operations.
+preview tokens. Optional manifest defaults are part of that version and are
+copied into `plan.normalizedInput` before planning. Input schemas reject
+missing, unknown, or incorrectly typed values before planning. Requirements use
+`allOf` and `anyOf` trees over editor capabilities, analyzer capabilities, and
+explicit semantic operations.
 
 ## Handler, plan, preview, and execution
 

--- a/docs/mcp/skills.md
+++ b/docs/mcp/skills.md
@@ -53,6 +53,44 @@ inside tolerance, and returns `SKIP` for silence, missing dialogue, invalid
 measurements, clamp violations, or peak risk. Verification uses a new
 post-write measurement rather than the estimate.
 
+### Dialogue normalization inputs
+
+`dialogue-normalization@1.0.0` requires `mediaId` and `occurrenceId`. The
+remaining safety policy is versioned by the manifest and resolved into
+`plan.normalizedInput` when omitted:
+
+| Input | Default |
+| --- | ---: |
+| `targetLufs` | -16 |
+| `toleranceDb` | 0.5 |
+| `maxTruePeakDb` | -1 |
+| `minGainDb` | -6 |
+| `maxGainDb` | 6 |
+| `minDialogueDurationSeconds` | 1 |
+
+After `project.inspect`, preview one complete occurrence through the generic
+MCP surface:
+
+```json
+{
+  "skill": "dialogue-normalization",
+  "version": "1.0.0",
+  "arguments": {
+    "baseRevision": { "id": "rev-7", "sequence": 7, "timestamp": "..." },
+    "mediaId": "dialogue-media",
+    "occurrenceId": "dialogue-occurrence"
+  }
+}
+```
+
+Pass the returned token unchanged to `skill.execute`. An `APPLY` preview
+contains the measured occurrence, LUFS, true peak, target, tolerance, bounded
+gain, estimated peak, decision, warnings, expected diff, and token. A clip
+already inside tolerance executes as a verified no-op; unsafe decisions remain
+non-mutating `SKIP` results. Execution re-measures the selected range and rolls
+back the complete transaction if measurement, verification, or the authorized
+canonical diff fails.
+
 `audio-noise-reduction` requires an explicitly configured noise analyzer and an
 editor-native noise-reduction capability. It reports revision-bound noise
 measurements, affected ranges, and a bounded reduction adjustment. The runtime

--- a/docs/tests/release-gate.md
+++ b/docs/tests/release-gate.md
@@ -37,12 +37,14 @@ the original canonical digest.
 ## Capability evidence
 
 The deterministic fixture result is separate from adapter and live evidence.
-The current report marks the FCPXML closed-loop path unsupported because the
-adapter does not advertise both Skill write guarantees. It also marks live
-Final Cut unsupported unless a documented opt-in headed run is requested; the
-bundled Workflow Extension is metadata-only and never supplies fixture data.
-An unsupported capability is not a passing proof of autonomous open-project
-Final Cut support.
+The combined v0.0.3 report still marks the FCPXML speech-editing family
+unsupported because filler-removal requires timeline write guarantees. The
+dialogue-normalization Skill has separate deterministic artifact coverage for
+clip-level `set-gain`; that result is FCPXML evidence, not proof of a headed
+open-project Final Cut edit. Live Final Cut remains unsupported unless a
+documented opt-in headed run is requested; the bundled Workflow Extension is
+metadata-only and never supplies fixture data. An unsupported capability is not
+a passing proof of autonomous open-project Final Cut support.
 
 The CI report keeps deterministic correctness, adapter coverage, live Final Cut
 evidence, and unsupported capabilities in separate fields.

--- a/packages/runtime/src/application/media-analysis-service.ts
+++ b/packages/runtime/src/application/media-analysis-service.ts
@@ -73,7 +73,8 @@ export class MediaAnalysisService {
       throw new Error(`TARGET_MISMATCH: occurrence ${occurrenceId} does not reference media ${mediaId}`);
     }
     const media = findMedia(project, mediaId);
-    const requestedRange = { start: 0, end: clip.duration };
+    const sourceStart = clip.sourceStart ?? 0;
+    const requestedRange = { start: sourceStart, end: sourceStart + clip.duration };
     const analysis = await this.options.audioAnalyzer.analyze({ project, media }, requestedRange);
     const analyzedDurationSeconds = analysis.analyzedDurationSeconds ?? clip.duration;
     const valid = analysis.valid !== false

--- a/packages/runtime/src/audio/dialogue-normalization.ts
+++ b/packages/runtime/src/audio/dialogue-normalization.ts
@@ -49,6 +49,16 @@ export interface DialogueNormalizationPreview {
   expiresAt?: string;
 }
 
+/** Defaults for the version 1.0.0 dialogue-normalization Skill. */
+export const DIALOGUE_NORMALIZATION_DEFAULTS = {
+  targetLufs: -16,
+  toleranceDb: 0.5,
+  maxTruePeakDb: -1,
+  minGainDb: -6,
+  maxGainDb: 6,
+  minDialogueDurationSeconds: 1,
+} as const satisfies DialogueGainPlanningOptions;
+
 /** Plan a bounded clip-level gain change without mutating an editor. */
 export function planDialogueGain(
   measurement: AudioMeasurement,

--- a/packages/runtime/src/domain/skills.ts
+++ b/packages/runtime/src/domain/skills.ts
@@ -112,9 +112,13 @@ export interface SkillManifest {
   title: string;
   description: string;
   inputSchema: SkillInputSchema;
+  /** Version-pinned values used when the input omits optional policy fields. */
+  defaults?: Record<string, unknown>;
   requirements: SkillRequirement;
   verification?: VerificationPolicy;
 }
+
+export type SkillPlanDecision = "APPLY" | "NO_OP" | "SKIP";
 
 export interface SkillPlanningContext {
   /** The snapshot is read-only input to a handler; it is not an adapter. */
@@ -135,6 +139,7 @@ export interface SkillPlan {
   operations: WorkflowOperation[];
   affectedRanges: TimeRange[];
   warnings: string[];
+  decision?: SkillPlanDecision;
   verification?: VerificationPolicy;
   details?: Record<string, unknown>;
 }

--- a/packages/runtime/src/domain/verification.ts
+++ b/packages/runtime/src/domain/verification.ts
@@ -20,6 +20,7 @@ export interface AudioCoverageAssertion {
 export interface AudioLoudnessAssertion {
   type: "audio-loudness";
   mediaId: string;
+  occurrenceId?: string;
   targetLufs: number;
   toleranceDb?: number;
 }

--- a/packages/runtime/src/editing/edit-service.ts
+++ b/packages/runtime/src/editing/edit-service.ts
@@ -17,7 +17,7 @@ import type {
 } from "../domain/editing.js";
 import type { ProjectSnapshot } from "../domain/project.js";
 import type { TimelineDiff } from "../domain/diff.js";
-import type { VerificationEngine, VerificationPolicy } from "../domain/verification.js";
+import type { VerificationCheck, VerificationEngine, VerificationPolicy } from "../domain/verification.js";
 import { sameRevision } from "../context/revision.js";
 import { MediaAnalysisService, type PostWriteAnalysisRequirements } from "../application/media-analysis-service.js";
 import { ProjectService } from "../application/project-service.js";
@@ -273,6 +273,28 @@ export class EditService {
       verificationPolicy,
       status: "APPLIED",
     };
+    if (!sameDiffContent(transaction.diff, preview.expectedDiff)) {
+      const check: VerificationCheck = {
+        name: "authorized-diff",
+        passed: false,
+        status: "failed",
+        reason: "UNAUTHORIZED_DIFF",
+        expected: structuredClone(preview.expectedDiff),
+        observed: structuredClone(transaction.diff),
+        detail: "canonical diff contains changes outside the preview-authorized operations",
+      };
+      await this.adapter.restore(before, attemptedAfter.revision);
+      transaction.after = await this.project.inspectProject();
+      this.assertRestored(before, transaction.after);
+      transaction.verification = {
+        passed: false,
+        checks: [check],
+        target: structuredClone(preview.target),
+      };
+      transaction.status = "ROLLED_BACK";
+      this.transactions.set(transaction);
+      return transaction;
+    }
     try {
       await this.reanalyzeForVerification(transaction, verificationPolicy);
     } catch (error) {
@@ -498,6 +520,14 @@ function postWriteAnalysisRequirements(policy: VerificationPolicy): PostWriteAna
     noise: assertions.some((assertion) => assertion.type === "audio-noise"),
     visual: assertions.some((assertion) => assertion.type === "visual-content"),
   };
+}
+
+function sameDiffContent(left: TimelineDiff, right: TimelineDiff): boolean {
+  const comparable = (diff: TimelineDiff) => {
+    const { from: _from, to: _to, ...content } = diff;
+    return content;
+  };
+  return JSON.stringify(comparable(left)) === JSON.stringify(comparable(right));
 }
 
 function assertValidWorkflowOperation(operation: WorkflowOperation): void {

--- a/packages/runtime/src/editing/edit-service.ts
+++ b/packages/runtime/src/editing/edit-service.ts
@@ -273,8 +273,9 @@ export class EditService {
       verificationPolicy,
       status: "APPLIED",
     };
-    if (!sameDiffContent(transaction.diff, preview.expectedDiff)) {
-      const check: VerificationCheck = {
+    const authorizedDiffCheck = sameDiffContent(transaction.diff, preview.expectedDiff)
+      ? undefined
+      : {
         name: "authorized-diff",
         passed: false,
         status: "failed",
@@ -283,18 +284,6 @@ export class EditService {
         observed: structuredClone(transaction.diff),
         detail: "canonical diff contains changes outside the preview-authorized operations",
       };
-      await this.adapter.restore(before, attemptedAfter.revision);
-      transaction.after = await this.project.inspectProject();
-      this.assertRestored(before, transaction.after);
-      transaction.verification = {
-        passed: false,
-        checks: [check],
-        target: structuredClone(preview.target),
-      };
-      transaction.status = "ROLLED_BACK";
-      this.transactions.set(transaction);
-      return transaction;
-    }
     try {
       await this.reanalyzeForVerification(transaction, verificationPolicy);
     } catch (error) {
@@ -315,6 +304,13 @@ export class EditService {
         throw new Error(`VERIFICATION_FAILED: compensating rollback failed (${String(verificationError)}; ${String(rollbackError)})`);
       }
       throw new Error(`VERIFICATION_FAILED: canonical state was restored (${String(verificationError)})`);
+    }
+    if (authorizedDiffCheck) {
+      transaction.verification = {
+        ...transaction.verification,
+        passed: false,
+        checks: [...transaction.verification.checks, authorizedDiffCheck],
+      };
     }
     if (transaction.verification.passed) {
       transaction.status = "VERIFIED";

--- a/packages/runtime/src/editing/edit-service.ts
+++ b/packages/runtime/src/editing/edit-service.ts
@@ -273,7 +273,7 @@ export class EditService {
       verificationPolicy,
       status: "APPLIED",
     };
-    const authorizedDiffCheck = sameDiffContent(transaction.diff, preview.expectedDiff)
+    const authorizedDiffCheck: VerificationCheck | undefined = sameDiffContent(transaction.diff, preview.expectedDiff)
       ? undefined
       : {
         name: "authorized-diff",
@@ -305,7 +305,7 @@ export class EditService {
       }
       throw new Error(`VERIFICATION_FAILED: canonical state was restored (${String(verificationError)})`);
     }
-    if (authorizedDiffCheck) {
+    if (authorizedDiffCheck && transaction.verification) {
       transaction.verification = {
         ...transaction.verification,
         passed: false,

--- a/packages/runtime/src/skills/builtin.ts
+++ b/packages/runtime/src/skills/builtin.ts
@@ -2,7 +2,11 @@ import type { SkillDefinition, SkillPlanningContext } from "../domain/skills.js"
 import type { TimeRange } from "../domain/primitives.js";
 import { planFillerRemoval } from "../speech/filler-removal.js";
 import { translateRationalRange } from "../timeline/rational-time.js";
-import { planDialogueGain, type DialogueNormalizationRequest } from "../audio/dialogue-normalization.js";
+import {
+  DIALOGUE_NORMALIZATION_DEFAULTS,
+  planDialogueGain,
+  type DialogueNormalizationRequest,
+} from "../audio/dialogue-normalization.js";
 import { planNoiseReduction, type NoiseReductionRequest } from "../audio/noise-reduction.js";
 import { planColorCorrection, type ColorCorrectionRequest } from "../color-correction.js";
 import type { FillerRemovalTarget } from "../speech/filler-removal.js";
@@ -118,6 +122,7 @@ function dialogueNormalizationSkill(): SkillDefinition {
       version: "1.0.0",
       title: "Dialogue normalization",
       description: "Normalize one complete dialogue clip occurrence with measured loudness and peak verification.",
+      defaults: { ...DIALOGUE_NORMALIZATION_DEFAULTS },
       inputSchema: {
         type: "object",
         properties: {
@@ -130,23 +135,30 @@ function dialogueNormalizationSkill(): SkillDefinition {
           maxGainDb: { type: "number" },
           minDialogueDurationSeconds: { type: "number", minimum: 0 },
         },
-        required: ["mediaId", "occurrenceId", "targetLufs", "toleranceDb", "maxTruePeakDb", "minGainDb", "maxGainDb", "minDialogueDurationSeconds"],
+        required: ["mediaId", "occurrenceId"],
         additionalProperties: false,
       },
       requirements: {
         type: "allOf",
         requirements: [
           { type: "editor", capability: "timelineSnapshotRead" },
-          { type: "editor", capability: "timelineWrite" },
+          {
+            type: "anyOf",
+            requirements: [
+              { type: "editor", capability: "timelineWrite" },
+              { type: "editor", capability: "timelineArtifactWrite" },
+            ],
+          },
           { type: "editor", capability: "readAfterWrite" },
           { type: "editor", capability: "rollback" },
+          { type: "editor", capability: "compositeTransactions" },
           { type: "analyzer", capability: "audioLoudness" },
           { type: "operation", operation: "set-gain" },
         ],
       },
     },
     handler: {
-      normalize: (input) => input as Record<string, unknown>,
+      normalize: (input) => ({ ...DIALOGUE_NORMALIZATION_DEFAULTS, ...(input as Record<string, unknown>) }),
       plan: async (context, input) => planDialogueSkill(context, input),
     },
   };
@@ -315,6 +327,11 @@ async function planColorSkill(context: SkillPlanningContext, input: Record<strin
 async function planDialogueSkill(context: SkillPlanningContext, input: Record<string, unknown>) {
   if (!context.measureAudio) throw new Error("CAPABILITY_UNAVAILABLE: audio analysis");
   const request = input as unknown as DialogueNormalizationRequest;
+  const clip = context.project.timeline.clips.find((candidate) => candidate.id === request.occurrenceId);
+  if (!clip) throw new Error(`OCCURRENCE_NOT_FOUND: ${request.occurrenceId}`);
+  if (clip.mediaId !== request.mediaId) {
+    throw new Error(`TARGET_MISMATCH: occurrence ${request.occurrenceId} does not reference media ${request.mediaId}`);
+  }
   const measurement = await context.measureAudio(request.mediaId, request.occurrenceId);
   const plan = planDialogueGain(measurement, request);
   const verification = plan.decision === "APPLY" ? {
@@ -323,6 +340,7 @@ async function planDialogueSkill(context: SkillPlanningContext, input: Record<st
     assertions: [{
       type: "audio-loudness" as const,
       mediaId: request.mediaId,
+      occurrenceId: request.occurrenceId,
       targetLufs: request.targetLufs,
       toleranceDb: request.toleranceDb,
     }],
@@ -334,13 +352,19 @@ async function planDialogueSkill(context: SkillPlanningContext, input: Record<st
       gainDb: plan.clampedGainDb,
       baseRevision: context.baseRevision,
     }] : [],
+    decision: plan.decision,
     affectedRanges: plan.decision === "APPLY" ? [{
-      start: context.project.timeline.clips.find((clip) => clip.id === request.occurrenceId)?.start ?? 0,
-      end: (context.project.timeline.clips.find((clip) => clip.id === request.occurrenceId)?.start ?? 0)
-        + (context.project.timeline.clips.find((clip) => clip.id === request.occurrenceId)?.duration ?? 0),
+      start: clip.start,
+      end: clip.start + clip.duration,
     }] : [],
     warnings: plan.decision === "SKIP" ? [...plan.reasonCodes] : [],
     ...(verification ? { verification } : {}),
-    details: { measurement: structuredClone(measurement), ...structuredClone(plan) },
+    details: {
+      occurrenceId: request.occurrenceId,
+      mediaId: request.mediaId,
+      measurement: structuredClone(measurement),
+      truePeakDb: measurement.truePeakDb,
+      ...structuredClone(plan),
+    },
   };
 }

--- a/packages/runtime/src/skills/builtin.ts
+++ b/packages/runtime/src/skills/builtin.ts
@@ -332,8 +332,11 @@ async function planDialogueSkill(context: SkillPlanningContext, input: Record<st
   if (clip.mediaId !== request.mediaId) {
     throw new Error(`TARGET_MISMATCH: occurrence ${request.occurrenceId} does not reference media ${request.mediaId}`);
   }
+  const existingGainDb = clip.gainDb ?? 0;
+  if (!Number.isFinite(existingGainDb)) throw new Error(`INVALID_OPERATION: occurrence ${request.occurrenceId} has an invalid gain`);
   const measurement = await context.measureAudio(request.mediaId, request.occurrenceId);
   const plan = planDialogueGain(measurement, request);
+  const targetGainDb = Number((existingGainDb + plan.clampedGainDb).toFixed(6));
   const verification = plan.decision === "APPLY" ? {
     requireExpectedChange: true,
     maxTruePeakDb: request.maxTruePeakDb,
@@ -349,7 +352,7 @@ async function planDialogueSkill(context: SkillPlanningContext, input: Record<st
     operations: plan.decision === "APPLY" ? [{
       type: "set-gain" as const,
       clipId: request.occurrenceId,
-      gainDb: plan.clampedGainDb,
+      gainDb: targetGainDb,
       baseRevision: context.baseRevision,
     }] : [],
     decision: plan.decision,
@@ -362,6 +365,8 @@ async function planDialogueSkill(context: SkillPlanningContext, input: Record<st
     details: {
       occurrenceId: request.occurrenceId,
       mediaId: request.mediaId,
+      existingGainDb,
+      targetGainDb,
       measurement: structuredClone(measurement),
       truePeakDb: measurement.truePeakDb,
       ...structuredClone(plan),

--- a/packages/runtime/src/skills/runtime.ts
+++ b/packages/runtime/src/skills/runtime.ts
@@ -112,6 +112,7 @@ export class SkillRuntime {
       operations: structuredClone(planned.operations),
       affectedRanges: structuredClone(planned.affectedRanges),
       warnings: [...planned.warnings],
+      ...(planned.decision ? { decision: planned.decision } : {}),
       ...(planned.verification ? { verification: structuredClone(planned.verification) } : {}),
       ...(planned.details ? { details: structuredClone(planned.details) } : {}),
     };
@@ -154,7 +155,7 @@ export class SkillRuntime {
     });
     if (!session.editPreviewToken) {
       return {
-        status: "SKIPPED",
+        status: session.preview.plan.decision === "NO_OP" ? "VERIFIED" : "SKIPPED",
         plan: {
           id: session.preview.plan.id,
           skillId: session.preview.plan.skillId,

--- a/packages/runtime/src/verification/verification.ts
+++ b/packages/runtime/src/verification/verification.ts
@@ -159,8 +159,9 @@ export class DefaultVerificationEngine implements VerificationEngine {
 
     if (policy.maxTruePeakDb !== undefined) {
       const peaks = transaction.attemptedAfter.media
+        .filter((media) => media.audio?.valid !== false)
         .map((media) => media.audio?.truePeakDb)
-        .filter((peak): peak is number => peak !== undefined);
+        .filter((peak): peak is number => peak !== undefined && Number.isFinite(peak));
       const passed = peaks.length > 0 && peaks.every((peak) => peak <= policy.maxTruePeakDb!);
       checks.push({
         name: "true-peak-limit",
@@ -174,8 +175,9 @@ export class DefaultVerificationEngine implements VerificationEngine {
     if (policy.targetLufs !== undefined) {
       const tolerance = policy.loudnessToleranceDb ?? 0.5;
       const loudness = transaction.attemptedAfter.media
+        .filter((media) => media.audio?.valid !== false)
         .map((media) => media.audio?.integratedLufs)
-        .filter((value): value is number => value !== undefined);
+        .filter((value): value is number => value !== undefined && Number.isFinite(value));
       const passed = loudness.length > 0 && loudness.every((value) => Math.abs(value - policy.targetLufs!) <= tolerance);
       checks.push({
         name: "integrated-loudness-target",
@@ -391,6 +393,19 @@ function verifyAudioLoudness(transaction: EditTransaction, assertion: AudioLoudn
       observed: { mediaId: assertion.mediaId },
       reason: "AUDIO_ANALYZER_UNAVAILABLE",
       detail: `audio analysis is unavailable for media ${assertion.mediaId}`,
+    };
+  }
+  if (media.audio.valid === false
+    || !Number.isFinite(media.audio.integratedLufs)
+    || !Number.isFinite(media.audio.truePeakDb)) {
+    return {
+      name: assertion.type,
+      passed: false,
+      status: "failed",
+      expected,
+      observed: media.audio,
+      reason: "AUDIO_MEASUREMENT_INVALID",
+      detail: `audio measurement for media ${assertion.mediaId} is invalid`,
     };
   }
   const observed = media.audio.integratedLufs;

--- a/packages/runtime/src/verification/verification.ts
+++ b/packages/runtime/src/verification/verification.ts
@@ -61,7 +61,8 @@ function validateAssertion(assertion: VerificationAssertion, index: number): voi
     return;
   }
   if (assertion.type === "audio-loudness") {
-    if (!Number.isFinite(assertion.targetLufs)
+    if ((assertion.occurrenceId !== undefined && !assertion.occurrenceId.trim())
+      || !Number.isFinite(assertion.targetLufs)
       || assertion.toleranceDb !== undefined
       && (!Number.isFinite(assertion.toleranceDb) || assertion.toleranceDb < 0)) {
       throw new Error(`INVALID_VERIFICATION_POLICY: ${path} has invalid loudness values`);
@@ -349,9 +350,26 @@ function verifyAudioLoudness(transaction: EditTransaction, assertion: AudioLoudn
   const toleranceDb = assertion.toleranceDb ?? 0.5;
   const expected = {
     mediaId: assertion.mediaId,
+    ...(assertion.occurrenceId ? { occurrenceId: assertion.occurrenceId } : {}),
     targetLufs: assertion.targetLufs,
     toleranceDb,
   };
+  const occurrence = assertion.occurrenceId
+    ? transaction.attemptedAfter.timeline.clips.find((clip) => clip.id === assertion.occurrenceId)
+    : undefined;
+  if (assertion.occurrenceId && (!occurrence || occurrence.mediaId !== assertion.mediaId)) {
+    return {
+      name: assertion.type,
+      passed: false,
+      status: "failed",
+      expected,
+      observed: { mediaId: assertion.mediaId, occurrenceId: assertion.occurrenceId },
+      reason: !occurrence ? "OCCURRENCE_NOT_FOUND" : "TARGET_MISMATCH",
+      detail: !occurrence
+        ? `expected occurrence ${assertion.occurrenceId}, but it was not observed`
+        : `occurrence ${assertion.occurrenceId} does not reference media ${assertion.mediaId}`,
+    };
+  }
   const media = transaction.attemptedAfter.media.find((candidate) => candidate.mediaId === assertion.mediaId);
   if (!media) {
     return {

--- a/tests/integration/dialogue-normalization-skill.test.ts
+++ b/tests/integration/dialogue-normalization-skill.test.ts
@@ -28,7 +28,7 @@ function createFixture(options: {
   analyzedDurationSeconds?: number;
   sourceStart?: number;
   duration?: number;
-  clips?: Array<{ id: string; mediaId: string; start: number; duration: number; sourceStart?: number }>;
+  clips?: Array<{ id: string; mediaId: string; start: number; duration: number; sourceStart?: number; gainDb?: number }>;
   analyze?: AudioAnalyzer["analyze"];
 } = {}) {
   const clips = options.clips ?? [{
@@ -142,6 +142,26 @@ test("dialogue preview resolves defaults and targets one complete occurrence ran
   assert.equal(preview.previewToken.startsWith("skill-preview-"), true);
   assert.equal(canonicalSnapshotDigest(await adapter.readProject()), canonicalSnapshotDigest(before));
   assert.equal(analyzer.descriptor?.provider, "fixture");
+});
+
+test("dialogue normalization converts the planned delta to an absolute gain", async () => {
+  const { runtime, adapter } = createFixture({
+    clips: [{ id: "dialogue-occurrence", mediaId: "dialogue-media", start: 0, duration: 10, gainDb: 2 }],
+  });
+  runtime.registerBuiltinSkills();
+
+  const { preview } = await previewDialogue(runtime);
+  const operation = preview.plan.operations[0];
+
+  assert.equal(preview.plan.details?.currentLufs, -18);
+  assert.equal(preview.plan.details?.clampedGainDb, 2);
+  assert.equal(operation?.type, "set-gain");
+  assert.equal(operation?.type === "set-gain" ? operation.gainDb : undefined, 4);
+
+  const result = await runtime.executeSkill(preview.previewToken);
+
+  assert.equal(result.status, "VERIFIED");
+  assert.equal((await adapter.readProject()).timeline.clips[0]?.gainDb, 4);
 });
 
 test("already-normalized dialogue executes as a verified no-op", async () => {

--- a/tests/integration/dialogue-normalization-skill.test.ts
+++ b/tests/integration/dialogue-normalization-skill.test.ts
@@ -1,0 +1,242 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  AgentVideoRuntime,
+  canonicalSnapshotDigest,
+  type AudioAnalyzer,
+} from "@framekit/runtime";
+import { FcpxmlDocumentAdapter } from "@framekit/final-cut";
+import { InMemoryEditorAdapter } from "@framekit/testkit";
+
+const defaults = {
+  targetLufs: -16,
+  toleranceDb: 0.5,
+  maxTruePeakDb: -1,
+  minGainDb: -6,
+  maxGainDb: 6,
+  minDialogueDurationSeconds: 1,
+};
+
+function createFixture(options: {
+  integratedLufs?: number;
+  truePeakDb?: number;
+  silenceMs?: number;
+  dialoguePresent?: boolean;
+  analyzedDurationSeconds?: number;
+  sourceStart?: number;
+  duration?: number;
+  clips?: Array<{ id: string; mediaId: string; start: number; duration: number; sourceStart?: number }>;
+  analyze?: AudioAnalyzer["analyze"];
+} = {}) {
+  const clips = options.clips ?? [{
+    id: "dialogue-occurrence",
+    mediaId: "dialogue-media",
+    start: 0,
+    duration: options.duration ?? 10,
+    ...(options.sourceStart === undefined ? {} : { sourceStart: options.sourceStart }),
+  }];
+  const adapter = new InMemoryEditorAdapter({
+    projectId: "dialogue-skill-project",
+    projectName: "Dialogue Skill",
+    timelineId: "dialogue-skill-timeline",
+    timelineName: "Main Edit",
+    clips: clips.map((clip, index) => ({ ...clip, name: `Dialogue ${index + 1}`, track: 1 })),
+    media: [{
+      mediaId: "dialogue-media",
+      source: "fixtures/dialogue.wav",
+      mediaKind: "video",
+      duration: 20,
+      speech: { words: [{ text: "hello", start: 0, end: 2, confidence: 0.99 }] },
+    }],
+  });
+  const analyzer: AudioAnalyzer = {
+    descriptor: { id: "fixture.dialogue", provider: "fixture", version: "1" },
+    analyze: options.analyze ?? (async ({ project }) => {
+      const gain = project.timeline.clips.find((clip) => clip.id === "dialogue-occurrence")?.gainDb ?? 0;
+      return {
+        integratedLufs: (options.integratedLufs ?? -20) + gain,
+        truePeakDb: (options.truePeakDb ?? -6) + gain,
+        silenceMs: options.silenceMs ?? 100,
+        analyzedDurationSeconds: options.analyzedDurationSeconds ?? 10,
+        dialoguePresent: options.dialoguePresent ?? true,
+      };
+    }),
+  };
+  return { adapter, analyzer, runtime: new AgentVideoRuntime(adapter, { audioAnalyzer: analyzer }) };
+}
+
+async function previewDialogue(runtime: AgentVideoRuntime, input: Record<string, unknown> = {}) {
+  const before = await runtime.inspectProject();
+  const preview = await runtime.previewSkill({
+    skillId: "dialogue-normalization",
+    baseRevision: before.revision,
+    input: {
+      mediaId: "dialogue-media",
+      occurrenceId: "dialogue-occurrence",
+      ...input,
+    },
+  });
+  return { before, preview };
+}
+
+test("dialogue Skill exposes versioned defaults and composite capability", async () => {
+  const { runtime } = createFixture();
+  runtime.registerBuiltinSkills();
+
+  const manifest = runtime.inspectSkill("dialogue-normalization");
+  assert.deepEqual(manifest.defaults, defaults);
+  assert.match(JSON.stringify(manifest.requirements), /compositeTransactions/);
+
+  const { adapter, runtime: unavailableRuntime } = createFixture();
+  const getCapabilities = adapter.getCapabilities.bind(adapter);
+  adapter.getCapabilities = async () => {
+    const capabilities = await getCapabilities();
+    return { ...capabilities, editor: { ...capabilities.editor, compositeTransactions: false } };
+  };
+  unavailableRuntime.registerBuiltinSkills();
+  const inspection = await unavailableRuntime.inspectSkillAvailability("dialogue-normalization");
+  assert.equal(inspection.availability.available, false);
+  assert.ok(inspection.availability.missingRequirements.some((item) => item.name === "compositeTransactions"));
+});
+
+test("dialogue preview resolves defaults and targets one complete occurrence range", async () => {
+  const ranges: Array<{ start: number; end: number } | undefined> = [];
+  const { runtime, analyzer, adapter } = createFixture({
+    sourceStart: 5,
+    duration: 3,
+    analyze: async ({ project }, range) => {
+      ranges.push(range);
+      const gain = project.timeline.clips.find((clip) => clip.id === "dialogue-occurrence")?.gainDb ?? 0;
+      return {
+        integratedLufs: -20 + gain,
+        truePeakDb: -6 + gain,
+        silenceMs: 100,
+        analyzedDurationSeconds: 3,
+        dialoguePresent: true,
+      };
+    },
+  });
+  runtime.registerBuiltinSkills();
+
+  const { before, preview } = await previewDialogue(runtime);
+
+  assert.deepEqual(preview.plan.normalizedInput, {
+    mediaId: "dialogue-media",
+    occurrenceId: "dialogue-occurrence",
+    ...defaults,
+  });
+  assert.equal(preview.plan.decision, "APPLY");
+  assert.equal(preview.plan.details?.occurrenceId, "dialogue-occurrence");
+  assert.equal(preview.plan.details?.currentLufs, -20);
+  assert.equal(preview.plan.details?.truePeakDb, -6);
+  assert.equal(preview.plan.details?.targetLufs, -16);
+  assert.equal(preview.plan.details?.toleranceDb, 0.5);
+  assert.equal(preview.plan.details?.clampedGainDb, 4);
+  assert.equal(preview.plan.details?.estimatedPeakDb, -2);
+  assert.equal(preview.plan.operations[0]?.clipId, "dialogue-occurrence");
+  assert.deepEqual(ranges, [{ start: 5, end: 8 }]);
+  assert.equal(preview.previewToken.startsWith("skill-preview-"), true);
+  assert.equal(canonicalSnapshotDigest(await adapter.readProject()), canonicalSnapshotDigest(before));
+  assert.equal(analyzer.descriptor?.provider, "fixture");
+});
+
+test("already-normalized dialogue executes as a verified no-op", async () => {
+  const { runtime, adapter } = createFixture({ integratedLufs: -16, truePeakDb: -3 });
+  runtime.registerBuiltinSkills();
+  const { before, preview } = await previewDialogue(runtime);
+
+  assert.equal(preview.plan.decision, "NO_OP");
+  const result = await runtime.executeSkill(preview.previewToken);
+
+  assert.equal(result.status, "VERIFIED");
+  assert.deepEqual(result.transactionIds, []);
+  assert.equal(result.rollback.attempted, false);
+  assert.equal(canonicalSnapshotDigest(await adapter.readProject()), canonicalSnapshotDigest(before));
+});
+
+test("dialogue execution remeasures after writing and verifies the new result", async () => {
+  let calls = 0;
+  const { runtime, adapter } = createFixture({
+    analyze: async ({ project }) => {
+      calls += 1;
+      const gain = project.timeline.clips.find((clip) => clip.id === "dialogue-occurrence")?.gainDb ?? 0;
+      return {
+        integratedLufs: calls === 1 ? -20 : -19,
+        truePeakDb: -6 + gain,
+        silenceMs: 100,
+        analyzedDurationSeconds: 10,
+        dialoguePresent: true,
+      };
+    },
+  });
+  runtime.registerBuiltinSkills();
+  const { before, preview } = await previewDialogue(runtime);
+
+  const result = await runtime.executeSkill(preview.previewToken);
+
+  assert.equal(calls, 2);
+  assert.equal(result.status, "ROLLED_BACK");
+  assert.equal(result.rollback.succeeded, true);
+  assert.equal(canonicalSnapshotDigest(await adapter.readProject()), canonicalSnapshotDigest(before));
+});
+
+class UnexpectedDiffAdapter extends InMemoryEditorAdapter {
+  public override async applyTransaction(
+    operations: Parameters<InMemoryEditorAdapter["applyTransaction"]>[0],
+    expectedRevision: Parameters<InMemoryEditorAdapter["applyTransaction"]>[1],
+  ): Promise<void> {
+    await super.applyTransaction(operations, expectedRevision);
+    const after = await this.readProject();
+    await this.apply({
+      type: "add-marker",
+      timelineId: after.timeline.id,
+      marker: { id: "unauthorized-marker", start: 0, duration: 0, name: "Unauthorized" },
+    }, after.revision);
+  }
+}
+
+test("unexpected canonical changes roll back a dialogue Skill transaction", async () => {
+  const fixture = createFixture();
+  const adapter = new UnexpectedDiffAdapter({
+    projectId: "dialogue-skill-project",
+    projectName: "Dialogue Skill",
+    timelineId: "dialogue-skill-timeline",
+    timelineName: "Main Edit",
+    clips: [{ id: "dialogue-occurrence", mediaId: "dialogue-media", name: "Dialogue", start: 0, duration: 10, track: 1 }],
+    media: [{ mediaId: "dialogue-media", source: "fixtures/dialogue.wav", mediaKind: "video", duration: 10 }],
+  });
+  const runtime = new AgentVideoRuntime(adapter, { audioAnalyzer: fixture.analyzer });
+  runtime.registerBuiltinSkills();
+  const { before, preview } = await previewDialogue(runtime);
+
+  const result = await runtime.executeSkill(preview.previewToken);
+
+  assert.equal(result.status, "ROLLED_BACK");
+  assert.equal(result.rollback.succeeded, true);
+  assert.equal(canonicalSnapshotDigest(await adapter.readProject()), canonicalSnapshotDigest(before));
+});
+
+test("dialogue Skill applies clip gain through the deterministic FCPXML adapter", async () => {
+  const directory = await mkdtemp(join(os.tmpdir(), "framekit-dialogue-skill-"));
+  const path = join(directory, "dialogue.fcpxml");
+  await writeFile(path, `<?xml version="1.0"?><fcpxml version="1.11"><resources><asset id="dialogue-media" name="dialogue.wav" src="file:///dialogue.wav" duration="10s" /></resources><library><event><project uid="dialogue-project" name="Dialogue"><sequence uid="dialogue-sequence" name="Main" duration="10s"><spine><asset-clip id="dialogue-occurrence" ref="dialogue-media" name="Dialogue" offset="0s" duration="10s" /></spine></sequence></project></event></library></fcpxml>`);
+  const adapter = new FcpxmlDocumentAdapter(path);
+  const analyzer: AudioAnalyzer = {
+    descriptor: { id: "fixture.fcpxml-dialogue", provider: "fixture", version: "1" },
+    analyze: async ({ project }) => {
+      const gain = project.timeline.clips[0]?.gainDb ?? 0;
+      return { integratedLufs: -20 + gain, truePeakDb: -6 + gain, silenceMs: 100, analyzedDurationSeconds: 10, dialoguePresent: true };
+    },
+  };
+  const runtime = new AgentVideoRuntime(adapter, { audioAnalyzer: analyzer });
+  runtime.registerBuiltinSkills();
+  const { preview } = await previewDialogue(runtime);
+
+  const result = await runtime.executeSkill(preview.previewToken);
+
+  assert.equal(result.status, "VERIFIED");
+  assert.match(await readFile(path, "utf8"), /adjust-volume amount="4dB"/);
+});

--- a/tests/integration/dialogue-normalization-skill.test.ts
+++ b/tests/integration/dialogue-normalization-skill.test.ts
@@ -184,6 +184,80 @@ test("dialogue execution remeasures after writing and verifies the new result", 
   assert.equal(canonicalSnapshotDigest(await adapter.readProject()), canonicalSnapshotDigest(before));
 });
 
+test("dialogue Skill targets the selected occurrence when media is repeated", async () => {
+  const ranges: Array<{ start: number; end: number } | undefined> = [];
+  const { runtime } = createFixture({
+    clips: [
+      { id: "dialogue-first", mediaId: "dialogue-media", start: 0, duration: 4, sourceStart: 0 },
+      { id: "dialogue-second", mediaId: "dialogue-media", start: 10, duration: 3, sourceStart: 5 },
+    ],
+    analyze: async ({ project }, range) => {
+      ranges.push(range);
+      const gain = project.timeline.clips.find((clip) => clip.id === "dialogue-second")?.gainDb ?? 0;
+      return { integratedLufs: -20 + gain, truePeakDb: -6 + gain, silenceMs: 100, analyzedDurationSeconds: 3, dialoguePresent: true };
+    },
+  });
+  runtime.registerBuiltinSkills();
+  const before = await runtime.inspectProject();
+  const preview = await runtime.previewSkill({
+    skillId: "dialogue-normalization",
+    baseRevision: before.revision,
+    input: { mediaId: "dialogue-media", occurrenceId: "dialogue-second" },
+  });
+
+  assert.equal(preview.plan.operations[0]?.type, "set-gain");
+  assert.equal(preview.plan.operations[0]?.type === "set-gain" ? preview.plan.operations[0].clipId : undefined, "dialogue-second");
+  assert.deepEqual(preview.plan.affectedRanges, [{ start: 10, end: 13 }]);
+  assert.deepEqual(ranges, [{ start: 5, end: 8 }]);
+});
+
+test("unsafe dialogue decisions skip without changing canonical state", async () => {
+  const cases = [
+    { name: "no dialogue", options: { dialoguePresent: false }, reason: "NO_DIALOGUE" },
+    { name: "silence", options: { silenceMs: 10_000 }, reason: "SILENCE" },
+    { name: "insufficient duration", options: { analyzedDurationSeconds: 0.5, duration: 0.5 }, reason: "DIALOGUE_TOO_SHORT" },
+    { name: "gain clamp", options: { integratedLufs: -30 }, reason: "GAIN_OUT_OF_BOUNDS" },
+    { name: "peak risk", options: { truePeakDb: -2 }, reason: "PEAK_RISK" },
+  ] as const;
+
+  for (const current of cases) {
+    const { runtime, adapter } = createFixture(current.options);
+    runtime.registerBuiltinSkills();
+    const { before, preview } = await previewDialogue(runtime);
+    assert.equal(preview.plan.decision, "SKIP", current.name);
+    assert.deepEqual(preview.plan.warnings, [current.reason], current.name);
+    const result = await runtime.executeSkill(preview.previewToken);
+    assert.equal(result.status, "SKIPPED", current.name);
+    assert.equal(canonicalSnapshotDigest(await adapter.readProject()), canonicalSnapshotDigest(before), current.name);
+  }
+});
+
+test("post-write true-peak failure rolls back the complete transaction", async () => {
+  let calls = 0;
+  const { runtime, adapter } = createFixture({
+    analyze: async ({ project }) => {
+      calls += 1;
+      const gain = project.timeline.clips.find((clip) => clip.id === "dialogue-occurrence")?.gainDb ?? 0;
+      return {
+        integratedLufs: -20 + gain,
+        truePeakDb: calls === 1 ? -6 : -0.5,
+        silenceMs: 100,
+        analyzedDurationSeconds: 10,
+        dialoguePresent: true,
+      };
+    },
+  });
+  runtime.registerBuiltinSkills();
+  const { before, preview } = await previewDialogue(runtime);
+
+  const result = await runtime.executeSkill(preview.previewToken);
+
+  assert.equal(calls, 2);
+  assert.equal(result.status, "ROLLED_BACK");
+  assert.equal(result.rollback.succeeded, true);
+  assert.equal(canonicalSnapshotDigest(await adapter.readProject()), canonicalSnapshotDigest(before));
+});
+
 test("invalid post-write dialogue measurements roll back the transaction", async () => {
   let calls = 0;
   const { runtime, adapter } = createFixture({

--- a/tests/integration/dialogue-normalization-skill.test.ts
+++ b/tests/integration/dialogue-normalization-skill.test.ts
@@ -136,7 +136,8 @@ test("dialogue preview resolves defaults and targets one complete occurrence ran
   assert.equal(preview.plan.details?.toleranceDb, 0.5);
   assert.equal(preview.plan.details?.clampedGainDb, 4);
   assert.equal(preview.plan.details?.estimatedPeakDb, -2);
-  assert.equal(preview.plan.operations[0]?.clipId, "dialogue-occurrence");
+  assert.equal(preview.plan.operations[0]?.type, "set-gain");
+  assert.equal(preview.plan.operations[0]?.type === "set-gain" ? preview.plan.operations[0].clipId : undefined, "dialogue-occurrence");
   assert.deepEqual(ranges, [{ start: 5, end: 8 }]);
   assert.equal(preview.previewToken.startsWith("skill-preview-"), true);
   assert.equal(canonicalSnapshotDigest(await adapter.readProject()), canonicalSnapshotDigest(before));

--- a/tests/integration/dialogue-normalization-skill.test.ts
+++ b/tests/integration/dialogue-normalization-skill.test.ts
@@ -184,6 +184,34 @@ test("dialogue execution remeasures after writing and verifies the new result", 
   assert.equal(canonicalSnapshotDigest(await adapter.readProject()), canonicalSnapshotDigest(before));
 });
 
+test("invalid post-write dialogue measurements roll back the transaction", async () => {
+  let calls = 0;
+  const { runtime, adapter } = createFixture({
+    analyze: async ({ project }) => {
+      calls += 1;
+      const gain = project.timeline.clips.find((clip) => clip.id === "dialogue-occurrence")?.gainDb ?? 0;
+      return {
+        integratedLufs: -20 + gain,
+        truePeakDb: -6 + gain,
+        silenceMs: 100,
+        analyzedDurationSeconds: 10,
+        dialoguePresent: true,
+        valid: calls === 1,
+        ...(calls === 1 ? {} : { invalidReason: "post-write analyzer rejected the sample" }),
+      };
+    },
+  });
+  runtime.registerBuiltinSkills();
+  const { before, preview } = await previewDialogue(runtime);
+
+  const result = await runtime.executeSkill(preview.previewToken);
+
+  assert.equal(calls, 2);
+  assert.equal(result.status, "ROLLED_BACK");
+  assert.equal(result.rollback.succeeded, true);
+  assert.equal(canonicalSnapshotDigest(await adapter.readProject()), canonicalSnapshotDigest(before));
+});
+
 class UnexpectedDiffAdapter extends InMemoryEditorAdapter {
   public override async applyTransaction(
     operations: Parameters<InMemoryEditorAdapter["applyTransaction"]>[0],

--- a/tests/integration/release-gate-docs.test.ts
+++ b/tests/integration/release-gate-docs.test.ts
@@ -29,6 +29,9 @@ test("Skill documentation describes only the generic MCP workflow", async () => 
   assert.match(documentation, /Final Cut-specific commands/i);
   assert.match(documentation, /preview/);
   assert.match(documentation, /rollback/);
+  assert.match(documentation, /targetLufs.*-16/);
+  assert.match(documentation, /occurrenceId/);
+  assert.match(documentation, /verified no-op/i);
 });
 
 test("compatibility and release documentation identify the v0.0.3 gate", async () => {

--- a/tests/release-gate/mcp-skill.test.ts
+++ b/tests/release-gate/mcp-skill.test.ts
@@ -90,17 +90,12 @@ test("generic Skill tools execute filler removal and dialogue normalization", as
           mediaId: "dialogue-media",
           occurrenceId: "dialogue-clip",
           baseRevision: before.revision,
-          targetLufs: -16,
-          toleranceDb: 0.5,
-          maxTruePeakDb: -1,
-          minGainDb: -6,
-          maxGainDb: 6,
-          minDialogueDurationSeconds: 1,
         },
       },
     });
     const dialoguePlan = JSON.parse(textFrom(dialoguePreview)) as { previewToken: string; plan: { decision: string } };
     assert.equal(dialoguePlan.plan.decision, "APPLY");
+    assert.equal((dialoguePlan.plan as { normalizedInput?: { targetLufs?: number } }).normalizedInput?.targetLufs, -16);
     const dialogueResult = await client.callTool({
       name: "skill.execute",
       arguments: { skill: "dialogue-normalization", previewToken: dialoguePlan.previewToken },


### PR DESCRIPTION
## Summary

- Implement the versioned generic `dialogue-normalization` Skill for complete clip occurrences.
- Add default policy normalization, source-range-bound audio measurement, deterministic gain planning, and explicit APPLY/NO_OP/SKIP decisions.
- Enforce post-write remeasurement, LUFS/true-peak verification, authorized-diff checks, and canonical rollback on failure.
- Advertise `set-gain` in the deterministic FCPXML adapter and document the Skill contract.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm run test` — 550 passed
- `pnpm run check:boundaries`
- Native Swift/Xcode gates skipped: no native files changed.

## TDD coverage

The committed test steps cover defaults and discovery, repeated occurrences, source ranges, no-op and safety skips, gain clamping, peak risk, stale and invalid measurements, post-write failures, unauthorized diffs, rollback, MCP normalization, FCPXML gain output, and documentation.

Closes #44
