### PR TITLE
feat: implement filler-removal Skill

### DIFF
--- a/adapters/final-cut/typescript/src/fcpxml.ts
+++ b/adapters/final-cut/typescript/src/fcpxml.ts
@@ -130,6 +130,7 @@ export class FcpxmlDocumentAdapter implements EditorPort {
     const clips = elements
       .filter(({ kind }) => CLIP_KINDS.has(kind))
       .map((entry) => this.clipFromXml(entry, timelineId));
+    const frameDuration = sequenceFrameDuration(sequence, this.xml ?? []);
     const durationValue = attribute(sequence, "duration")
       ?? formatSeconds(Math.max(0, ...storyElements.map((element) => element.start + element.duration)));
     return {
@@ -140,6 +141,7 @@ export class FcpxmlDocumentAdapter implements EditorPort {
         name: sequenceName,
         duration: parseSeconds(durationValue),
         durationTime: parseRational(durationValue),
+        ...(frameDuration ? { frameDuration } : {}),
         clips,
         storyElements,
         markers: this.markersFromXml(elements),
@@ -517,6 +519,17 @@ function attributes(node: XmlNode): XmlNode {
 
 function attribute(node: XmlNode, name: string): unknown {
   return attributes(node)[`@_${name}`];
+}
+
+function sequenceFrameDuration(sequence: XmlNode, document: OrderedXml): RationalTime | undefined {
+  const formatId = attribute(sequence, "format");
+  if (formatId === undefined) return undefined;
+  const resources = findElement(document, "resources");
+  const format = storyEntries(resources ?? {}).find((entry) =>
+    entry.kind === "format" && attribute(entry.node, "id") === String(formatId),
+  )?.node;
+  const value = attribute(format ?? {}, "frameDuration");
+  return value === undefined ? undefined : parseRational(value);
 }
 
 function setAttribute(node: XmlNode, name: string, value: string): void {

--- a/docs/mcp/skills.md
+++ b/docs/mcp/skills.md
@@ -46,9 +46,11 @@ stable reason codes; they do not fall back to a fixture or another editor.
 `filler-removal` previews every detected candidate with its confidence,
 reason codes, occurrence mapping, safe-cut evidence, and a decision of
 `AUTO_APPLY`, `SUGGESTED`, or `SKIPPED`. High-confidence frame-aligned cuts
-are authorized automatically; a `SUGGESTED` candidate requires a fresh
-preview with its revision-bound ID in `selectedCandidateIds`. Low-confidence,
-ambiguous, overlapping, or protected speech is never selected implicitly.
+use the canonical sequence frame duration and are authorized automatically; a
+`SUGGESTED` candidate requires a fresh preview with its revision-bound ID in
+`selectedCandidateIds`. If canonical frame timing is unavailable, planning
+fails closed. Low-confidence, ambiguous, overlapping, or protected speech is
+never selected implicitly.
 
 The Skill applies all authorized ripple deletions in one composite transaction.
 Each operation carries its candidate ID, and the preview and execution details

--- a/docs/mcp/skills.md
+++ b/docs/mcp/skills.md
@@ -43,9 +43,21 @@ so raw operations and editable plans cannot be submitted.
 result. Unsupported requirements are reported with exact missing leaves and
 stable reason codes; they do not fall back to a fixture or another editor.
 
-`filler-removal` skips low-confidence, ambiguous, overlapping, or protected
-speech rather than choosing a cut in natural-language code. It re-analyzes
-affected speech and preserves adjacent words.
+`filler-removal` previews every detected candidate with its confidence,
+reason codes, occurrence mapping, safe-cut evidence, and a decision of
+`AUTO_APPLY`, `SUGGESTED`, or `SKIPPED`. High-confidence frame-aligned cuts
+are authorized automatically; a `SUGGESTED` candidate requires a fresh
+preview with its revision-bound ID in `selectedCandidateIds`. Low-confidence,
+ambiguous, overlapping, or protected speech is never selected implicitly.
+
+The Skill applies all authorized ripple deletions in one composite transaction.
+Each operation carries its candidate ID, and the preview and execution details
+include candidate provenance and affected diff ranges. A preview with no valid
+operations executes as a verified no-op without mutating the timeline.
+Execution re-analyzes the affected speech, confirms filler targets are absent,
+adjacent speech remains ordered, protected speech is unchanged, the canonical
+diff matches the preview, and the timeline duration changes by the authorized
+deleted frames. Any failed check rolls back the complete transaction.
 
 `dialogue-normalization` operates on one complete clip occurrence. It measures
 dialogue loudness and true peak before planning gain, returns `NO_OP` for clips

--- a/packages/runtime/src/domain/editing.ts
+++ b/packages/runtime/src/domain/editing.ts
@@ -67,6 +67,8 @@ export type EditOperation =
       timelineId: string;
       range: TimeRange;
       reason?: string;
+      /** Optional Skill provenance for a guarded semantic deletion. */
+      candidateId?: string;
       baseRevision?: ContextRevision;
     }
   | {

--- a/packages/runtime/src/domain/project.ts
+++ b/packages/runtime/src/domain/project.ts
@@ -63,6 +63,7 @@ export interface ProjectSnapshot {
     name: string;
     duration: number;
     durationTime?: RationalTime;
+    frameDuration?: RationalTime;
     clips: Clip[];
     storyElements: StoryElement[];
     markers: Marker[];

--- a/packages/runtime/src/domain/skills.ts
+++ b/packages/runtime/src/domain/skills.ts
@@ -4,6 +4,8 @@ import type { ProjectSnapshot } from "./project.js";
 import type { WorkflowOperation } from "./editing.js";
 import type { TimelineDiff } from "./diff.js";
 import type { VerificationPolicy, VerificationReport } from "./verification.js";
+import type { VerificationCheck } from "./verification.js";
+import type { EditTransaction } from "./editing.js";
 import type { AudioMeasurement, NoiseMeasurement, SpeechAnalysis } from "./media.js";
 
 /** Version of the editor-independent Skill contract. */
@@ -147,7 +149,7 @@ export interface SkillPlan {
 export interface SkillPreview {
   previewToken: string;
   plan: SkillPlan;
-  expectedDiff?: unknown;
+  expectedDiff?: TimelineDiff;
   expiresAt: string;
 }
 
@@ -166,12 +168,20 @@ export interface SkillExecution {
   transactionIds: string[];
   diff?: TimelineDiff;
   verification?: VerificationReport;
+  details?: Record<string, unknown>;
   rollback: SkillRollbackResult;
+}
+
+export interface SkillVerificationContext {
+  plan: SkillPlan;
+  expectedDiff?: TimelineDiff;
+  transaction: EditTransaction;
 }
 
 export interface SkillHandler<Input extends Record<string, unknown> = Record<string, unknown>> {
   normalize(input: unknown): Promise<Input> | Input;
   plan(context: SkillPlanningContext, input: Input): Promise<Omit<SkillPlan, "id" | "skillId" | "skillVersion" | "baseRevision" | "normalizedInput">> | Omit<SkillPlan, "id" | "skillId" | "skillVersion" | "baseRevision" | "normalizedInput">;
+  verify?(context: SkillVerificationContext): Promise<VerificationCheck[]> | VerificationCheck[];
 }
 
 /** Metadata and executable behavior are separate so manifests remain inspectable. */

--- a/packages/runtime/src/skills/builtin.ts
+++ b/packages/runtime/src/skills/builtin.ts
@@ -258,15 +258,11 @@ function verifySpeechContinuity(
       };
     }
     const candidateIds = new Set(items.map((item) => item.candidateId));
-    const deletes = items
-      .map((item) => item.sourceDeleteRange)
-      .sort((left, right) => left.start - right.start);
     const expectedWords = beforeWords
       .filter((word) => ![...candidateIds].some((candidateId) => {
         const candidate = candidateById.get(candidateId);
         return candidate ? sameSpeechWord(candidate.word, word) : false;
-      }))
-      .map((word) => translateSpeechWordAfterDeletes(word, deletes));
+      }));
     if (expectedWords.length !== actualWords.length) {
       return {
         name: "filler-speech-continuity",
@@ -306,26 +302,6 @@ function sourceDeleteRangeFor(
     start: candidate.sourceRange.start + operation.range.start - candidate.sequenceRange.start,
     end: candidate.sourceRange.start + operation.range.end - candidate.sequenceRange.start,
   };
-}
-
-function translateSpeechWordAfterDeletes(word: SpeechWord, deletes: TimeRange[]): SpeechWord {
-  return {
-    ...word,
-    start: translateBoundaryAfterDeletes(word.start, deletes),
-    end: translateBoundaryAfterDeletes(word.end, deletes),
-  };
-}
-
-function translateBoundaryAfterDeletes(boundary: number, deletes: TimeRange[]): number {
-  let translated = boundary;
-  let removed = 0;
-  for (const deletion of deletes) {
-    if (boundary <= deletion.start) break;
-    if (boundary < deletion.end) return deletion.start - removed;
-    translated -= deletion.end - deletion.start;
-    removed += deletion.end - deletion.start;
-  }
-  return translated;
 }
 
 function sameSpeechWord(left: SpeechWord, right: SpeechWord): boolean {

--- a/packages/runtime/src/skills/builtin.ts
+++ b/packages/runtime/src/skills/builtin.ts
@@ -1,5 +1,5 @@
 import type { SkillDefinition, SkillPlanningContext, SkillVerificationContext } from "../domain/skills.js";
-import type { TimeRange } from "../domain/primitives.js";
+import type { RationalTime, TimeRange } from "../domain/primitives.js";
 import type { SpeechWord } from "../domain/media.js";
 import type { EditTransaction } from "../domain/editing.js";
 import type { TimelineDiff } from "../domain/diff.js";
@@ -74,6 +74,7 @@ function fillerRemovalSkill(): SkillDefinition {
 async function planFillerSkill(context: SkillPlanningContext, input: Record<string, unknown>) {
   const selectedRange = input.range as TimeRange;
   const selectedCandidateIds = new Set((input.selectedCandidateIds as string[] | undefined) ?? []);
+  const sequenceFrameDuration = resolveSequenceFrameDuration(context.project.timeline.frameDuration);
   const detector = new FillerDetector({
     ...(input.confidenceThreshold !== undefined ? { confidenceThreshold: input.confidenceThreshold as number } : {}),
   });
@@ -122,7 +123,7 @@ async function planFillerSkill(context: SkillPlanningContext, input: Record<stri
         targetRange: selectedRange,
         occurrence,
         timelineId: context.project.timeline.id,
-        sequenceFrameDuration: { value: "1", timescale: "30" },
+        sequenceFrameDuration,
       });
       candidates.push(candidate);
       decisions.push(decision);
@@ -161,6 +162,21 @@ async function planFillerSkill(context: SkillPlanningContext, input: Record<stri
       })),
     },
   };
+}
+
+function resolveSequenceFrameDuration(frameDuration: RationalTime | undefined): RationalTime {
+  if (!frameDuration) throw new Error("CAPABILITY_UNAVAILABLE: sequence frame duration");
+  if (!/^-?\d+$/.test(frameDuration.value) || !/^\d+$/.test(frameDuration.timescale)) {
+    throw new Error("CAPABILITY_UNAVAILABLE: sequence frame duration");
+  }
+  try {
+    if (BigInt(frameDuration.value) <= 0n || BigInt(frameDuration.timescale) <= 0n) {
+      throw new Error("invalid frame duration");
+    }
+  } catch {
+    throw new Error("CAPABILITY_UNAVAILABLE: sequence frame duration");
+  }
+  return structuredClone(frameDuration);
 }
 
 interface FillerSkillDetails {

--- a/packages/runtime/src/skills/builtin.ts
+++ b/packages/runtime/src/skills/builtin.ts
@@ -1,6 +1,6 @@
 import type { SkillDefinition, SkillPlanningContext, SkillVerificationContext } from "../domain/skills.js";
 import type { TimeRange } from "../domain/primitives.js";
-import type { SpeechAnalysis, SpeechWord } from "../domain/media.js";
+import type { SpeechWord } from "../domain/media.js";
 import type { EditTransaction } from "../domain/editing.js";
 import type { TimelineDiff } from "../domain/diff.js";
 import { FillerDetector, type FillerCandidate } from "../speech/filler-detector.js";
@@ -152,10 +152,11 @@ async function planFillerSkill(context: SkillPlanningContext, input: Record<stri
       decisions: structuredClone(decisions),
       selectedCandidateIds: [...selectedCandidateIds],
       candidateProvenance: operations.map((operation, operationIndex) => ({
-        candidateId: operation.candidateId,
+        candidateId: operation.candidateId!,
         occurrenceId: decisions.find((decision) => decision.candidateId === operation.candidateId)?.occurrenceId,
         operationIndex,
         operationRange: structuredClone(operation.range),
+        sourceDeleteRange: sourceDeleteRangeFor(operation, candidates),
         diffRanges: [structuredClone(operation.range)],
       })),
     },
@@ -170,6 +171,7 @@ interface FillerSkillDetails {
     occurrenceId?: string;
     operationIndex: number;
     operationRange: TimeRange;
+    sourceDeleteRange: TimeRange;
     diffRanges: TimeRange[];
   }>;
 }
@@ -180,6 +182,7 @@ function verifyFillerSkill(context: SkillVerificationContext): import("../domain
   const checks = [
     verifyFillerTargetsAbsent(transaction, details),
     verifyProtectedSpeech(transaction),
+    verifySpeechContinuity(transaction, details),
     verifyAuthorizedDiff(transaction, context.expectedDiff),
     verifyPlannedDuration(transaction, details),
   ];
@@ -206,6 +209,129 @@ function verifyFillerTargetsAbsent(
     expected: applied.map((candidate) => candidate.id),
     observed: remaining.map((candidate) => candidate.id),
   };
+}
+
+function verifySpeechContinuity(
+  transaction: EditTransaction,
+  details: Partial<FillerSkillDetails> | undefined,
+): import("../domain/verification.js").VerificationCheck {
+  const provenance = details?.candidateProvenance ?? [];
+  if (provenance.length === 0) {
+    return {
+      name: "filler-speech-continuity",
+      passed: false,
+      detail: "filler candidate provenance is unavailable for continuity verification",
+      reason: "SPEECH_CONTINUITY_UNAVAILABLE",
+    };
+  }
+  const candidateById = new Map((details?.candidates ?? []).map((candidate) => [candidate.id, candidate]));
+  const byOccurrence = new Map<string, typeof provenance>();
+  for (const item of provenance) {
+    const occurrence = item.occurrenceId;
+    if (!occurrence) return {
+      name: "filler-speech-continuity",
+      passed: false,
+      detail: `candidate ${item.candidateId} has no timeline occurrence provenance`,
+      reason: "SPEECH_CONTINUITY_UNAVAILABLE",
+    };
+    const items = byOccurrence.get(occurrence) ?? [];
+    items.push(item);
+    byOccurrence.set(occurrence, items);
+  }
+
+  for (const [occurrenceId, items] of byOccurrence) {
+    const beforeClip = transaction.before.timeline.clips.find((clip) => clip.id === occurrenceId);
+    const afterClip = transaction.attemptedAfter.timeline.clips.find((clip) => clip.id === occurrenceId);
+    const mediaId = beforeClip?.mediaId;
+    const beforeWords = mediaId
+      ? transaction.before.media.find((media) => media.mediaId === mediaId)?.speech?.words
+      : undefined;
+    const actualWords = mediaId
+      ? transaction.attemptedAfter.media.find((media) => media.mediaId === mediaId)?.speech?.words
+      : undefined;
+    if (!beforeClip || !afterClip || !beforeWords || !actualWords) {
+      return {
+        name: "filler-speech-continuity",
+        passed: false,
+        detail: `complete pre- and post-edit speech analysis is unavailable for filler target clip ${occurrenceId}`,
+        reason: "SPEECH_CONTINUITY_UNAVAILABLE",
+      };
+    }
+    const candidateIds = new Set(items.map((item) => item.candidateId));
+    const deletes = items
+      .map((item) => item.sourceDeleteRange)
+      .sort((left, right) => left.start - right.start);
+    const expectedWords = beforeWords
+      .filter((word) => ![...candidateIds].some((candidateId) => {
+        const candidate = candidateById.get(candidateId);
+        return candidate ? sameSpeechWord(candidate.word, word) : false;
+      }))
+      .map((word) => translateSpeechWordAfterDeletes(word, deletes));
+    if (expectedWords.length !== actualWords.length) {
+      return {
+        name: "filler-speech-continuity",
+        passed: false,
+        detail: `post-edit transcript has ${actualWords.length} words; expected ${expectedWords.length} adjacent words after filler removal`,
+        reason: "SPEECH_CONTINUITY_CHANGED",
+      };
+    }
+    for (let index = 0; index < expectedWords.length; index += 1) {
+      const expected = expectedWords[index]!;
+      const actual = actualWords[index]!;
+      if (!sameSpeechWord(expected, actual)
+        || actual.end > (afterClip.sourceStart ?? 0) + afterClip.duration + 0.02) {
+        return {
+          name: "filler-speech-continuity",
+          passed: false,
+          detail: `post-edit transcript boundary ${index + 1} does not preserve adjacent speech around the removed fillers`,
+          reason: "SPEECH_CONTINUITY_CHANGED",
+        };
+      }
+    }
+  }
+  return {
+    name: "filler-speech-continuity",
+    passed: true,
+    detail: "post-edit speech re-analysis preserves adjacent words and clip bounds",
+  };
+}
+
+function sourceDeleteRangeFor(
+  operation: Extract<import("../domain/editing.js").WorkflowOperation, { type: "ripple-delete" }>,
+  candidates: FillerCandidate[],
+): TimeRange {
+  const candidate = candidates.find((item) => item.id === operation.candidateId);
+  if (!candidate) return structuredClone(operation.range);
+  return {
+    start: candidate.sourceRange.start + operation.range.start - candidate.sequenceRange.start,
+    end: candidate.sourceRange.start + operation.range.end - candidate.sequenceRange.start,
+  };
+}
+
+function translateSpeechWordAfterDeletes(word: SpeechWord, deletes: TimeRange[]): SpeechWord {
+  return {
+    ...word,
+    start: translateBoundaryAfterDeletes(word.start, deletes),
+    end: translateBoundaryAfterDeletes(word.end, deletes),
+  };
+}
+
+function translateBoundaryAfterDeletes(boundary: number, deletes: TimeRange[]): number {
+  let translated = boundary;
+  let removed = 0;
+  for (const deletion of deletes) {
+    if (boundary <= deletion.start) break;
+    if (boundary < deletion.end) return deletion.start - removed;
+    translated -= deletion.end - deletion.start;
+    removed += deletion.end - deletion.start;
+  }
+  return translated;
+}
+
+function sameSpeechWord(left: SpeechWord, right: SpeechWord): boolean {
+  return left.text.trim().toLowerCase() === right.text.trim().toLowerCase()
+    && Math.abs(left.start - right.start) <= 0.02
+    && Math.abs(left.end - right.end) <= 0.02;
 }
 
 function verifyProtectedSpeech(transaction: EditTransaction): import("../domain/verification.js").VerificationCheck {

--- a/packages/runtime/src/skills/builtin.ts
+++ b/packages/runtime/src/skills/builtin.ts
@@ -1,7 +1,10 @@
-import type { SkillDefinition, SkillPlanningContext } from "../domain/skills.js";
+import type { SkillDefinition, SkillPlanningContext, SkillVerificationContext } from "../domain/skills.js";
 import type { TimeRange } from "../domain/primitives.js";
-import { planFillerRemoval } from "../speech/filler-removal.js";
-import { translateRationalRange } from "../timeline/rational-time.js";
+import type { SpeechAnalysis, SpeechWord } from "../domain/media.js";
+import type { EditTransaction } from "../domain/editing.js";
+import type { TimelineDiff } from "../domain/diff.js";
+import { FillerDetector, type FillerCandidate } from "../speech/filler-detector.js";
+import { SafeCutResolver, type SafeCutDecision } from "../speech/safe-cut-resolver.js";
 import {
   DIALOGUE_NORMALIZATION_DEFAULTS,
   planDialogueGain,
@@ -9,7 +12,6 @@ import {
 } from "../audio/dialogue-normalization.js";
 import { planNoiseReduction, type NoiseReductionRequest } from "../audio/noise-reduction.js";
 import { planColorCorrection, type ColorCorrectionRequest } from "../color-correction.js";
-import type { FillerRemovalTarget } from "../speech/filler-removal.js";
 
 export function builtinSkills(): SkillDefinition[] {
   return [fillerRemovalSkill(), dialogueNormalizationSkill(), noiseReductionSkill(), colorCorrectionSkill()];
@@ -38,6 +40,10 @@ function fillerRemovalSkill(): SkillDefinition {
           confidenceThreshold: { type: "number", minimum: 0, maximum: 1 },
           preservePauseMs: { type: "number", minimum: 0 },
           targetPauseMs: { type: "number", minimum: 0 },
+          selectedCandidateIds: {
+            type: "array",
+            items: { type: "string", minLength: 1 },
+          },
         },
         required: ["range"],
         additionalProperties: false,
@@ -49,7 +55,9 @@ function fillerRemovalSkill(): SkillDefinition {
           { type: "editor", capability: "timelineWrite" },
           { type: "editor", capability: "readAfterWrite" },
           { type: "editor", capability: "rollback" },
+          { type: "editor", capability: "compositeTransactions" },
           { type: "analyzer", capability: "speechTranscribe" },
+          { type: "analyzer", capability: "speechVad" },
           { type: "operation", operation: "ripple-delete" },
         ],
       },
@@ -58,60 +66,216 @@ function fillerRemovalSkill(): SkillDefinition {
     handler: {
       normalize: (input) => input as Record<string, unknown>,
       plan: async (context, input) => planFillerSkill(context, input),
+      verify: (context) => verifyFillerSkill(context),
     },
   };
 }
 
 async function planFillerSkill(context: SkillPlanningContext, input: Record<string, unknown>) {
   const selectedRange = input.range as TimeRange;
-  const options = {
+  const selectedCandidateIds = new Set((input.selectedCandidateIds as string[] | undefined) ?? []);
+  const detector = new FillerDetector({
     ...(input.confidenceThreshold !== undefined ? { confidenceThreshold: input.confidenceThreshold as number } : {}),
+  });
+  const resolver = new SafeCutResolver({
     ...(input.preservePauseMs !== undefined ? { preservePauseMs: input.preservePauseMs as number } : {}),
     ...(input.targetPauseMs !== undefined ? { targetPauseMs: input.targetPauseMs as number } : {}),
-  };
+  });
   if (!context.analyzeSpeech) throw new Error("CAPABILITY_UNAVAILABLE: speech analysis");
-  const candidates: FillerRemovalTarget[] = [];
-  const selectedMediaIds = new Set<string>();
+  const candidates: FillerCandidate[] = [];
+  const decisions: SafeCutDecision[] = [];
+  const operations: Array<Extract<import("../domain/editing.js").WorkflowOperation, { type: "ripple-delete" }>> = [];
   for (const clip of context.project.timeline.clips.filter((candidate) =>
     Boolean(candidate.mediaId)
       && candidate.start < selectedRange.end
       && candidate.start + candidate.duration > selectedRange.start,
   )) {
     const mediaId = clip.mediaId!;
-    if (selectedMediaIds.has(mediaId)) {
-      throw new Error("CAPABILITY_UNAVAILABLE: filler removal cannot verify repeated timeline occurrences of the same media item");
-    }
-    selectedMediaIds.add(mediaId);
     const localRange = {
       start: Math.max(0, selectedRange.start - clip.start),
       end: Math.min(clip.duration, selectedRange.end - clip.start),
     };
     if (localRange.end <= localRange.start) continue;
-    const speech = await context.analyzeSpeech(mediaId, localRange);
-    const mediaCandidates = planFillerRemoval(speech.words, localRange, options);
-    for (const candidate of mediaCandidates) {
-      candidates.push({
-        ...candidate,
-        clipId: clip.id,
-        mediaId,
-        sourceRange: structuredClone(candidate.range),
-        range: translateRationalRange(clip.startTime, clip.start, candidate.range),
+    const sourceStart = clip.sourceStart ?? 0;
+    const sourceRange = {
+      start: sourceStart + localRange.start,
+      end: sourceStart + localRange.end,
+    };
+    const speech = await context.analyzeSpeech(mediaId, sourceRange);
+    const occurrence = {
+      occurrenceId: clip.id,
+      mediaId,
+      sourceRange,
+      sequenceRange: { start: clip.start + localRange.start, end: clip.start + localRange.end },
+    };
+    const detected = detector.detect({
+      previewId: `filler-removal:${context.baseRevision.id}:${clip.id}:${selectedRange.start}:${selectedRange.end}`,
+      revisionId: context.baseRevision.id,
+      analysis: speech,
+      targetRange: selectedRange,
+      occurrence,
+    });
+    for (const candidate of detected) {
+      const decision = resolver.resolve({
+        candidate,
+        analysis: speech,
+        targetRange: selectedRange,
+        occurrence,
+        timelineId: context.project.timeline.id,
+        sequenceFrameDuration: { value: "1", timescale: "30" },
       });
+      candidates.push(candidate);
+      decisions.push(decision);
+      if (decision.operation && (decision.status === "AUTO_APPLY"
+        || decision.status === "SUGGESTED" && selectedCandidateIds.has(decision.candidateId))) {
+        operations.push({ ...decision.operation, candidateId: decision.candidateId });
+      }
     }
   }
-  if (candidates.length === 0) throw new Error("NO_FILLERS_FOUND: no high-confidence filler words in selected range");
-  candidates.sort((left, right) => right.range.start - left.range.start);
+  const candidateIds = new Set(candidates.map((candidate) => candidate.id));
+  for (const selectedCandidateId of selectedCandidateIds) {
+    if (!candidateIds.has(selectedCandidateId)) {
+      throw new Error(`CANDIDATE_NOT_FOUND: filler candidate ${selectedCandidateId} is not in the selected revision-bound range`);
+    }
+  }
+  const warnings = decisions.flatMap((decision) => decision.status === "AUTO_APPLY"
+    ? []
+    : [`${decision.candidateId}: ${decision.status.toLowerCase()} (${decision.reasonCodes.join(", ")})`]);
   return {
-    operations: candidates.map((candidate) => ({
-      type: "ripple-delete" as const,
-      timelineId: context.project.timeline.id,
-      range: structuredClone(candidate.range),
-      reason: `remove high-confidence filler word: ${candidate.word.text}`,
-    })),
-    affectedRanges: candidates.map((candidate) => structuredClone(candidate.range)),
-    warnings: [],
-    details: { range: structuredClone(selectedRange), candidates: structuredClone(candidates) },
+    operations: operations.sort((left, right) => right.range.start - left.range.start),
+    affectedRanges: operations.map((operation) => structuredClone(operation.range)),
+    warnings,
+    verification: { requireExpectedChange: true, requireSpeechContinuity: true },
+    details: {
+      range: structuredClone(selectedRange),
+      candidates: structuredClone(candidates),
+      decisions: structuredClone(decisions),
+      selectedCandidateIds: [...selectedCandidateIds],
+      candidateProvenance: operations.map((operation, operationIndex) => ({
+        candidateId: operation.candidateId,
+        occurrenceId: decisions.find((decision) => decision.candidateId === operation.candidateId)?.occurrenceId,
+        operationIndex,
+        operationRange: structuredClone(operation.range),
+        diffRanges: [structuredClone(operation.range)],
+      })),
+    },
   };
+}
+
+interface FillerSkillDetails {
+  candidates: FillerCandidate[];
+  decisions: SafeCutDecision[];
+  candidateProvenance: Array<{
+    candidateId: string;
+    occurrenceId?: string;
+    operationIndex: number;
+    operationRange: TimeRange;
+    diffRanges: TimeRange[];
+  }>;
+}
+
+function verifyFillerSkill(context: SkillVerificationContext): import("../domain/verification.js").VerificationCheck[] {
+  const details = context.plan.details as Partial<FillerSkillDetails> | undefined;
+  const transaction = context.transaction;
+  const checks = [
+    verifyFillerTargetsAbsent(transaction, details),
+    verifyProtectedSpeech(transaction),
+    verifyAuthorizedDiff(transaction, context.expectedDiff),
+    verifyPlannedDuration(transaction, details),
+  ];
+  return checks;
+}
+
+function verifyFillerTargetsAbsent(
+  transaction: EditTransaction,
+  details: Partial<FillerSkillDetails> | undefined,
+): import("../domain/verification.js").VerificationCheck {
+  const candidates = details?.candidates ?? [];
+  const appliedIds = new Set((details?.candidateProvenance ?? []).map((item) => item.candidateId));
+  const applied = candidates.filter((candidate) => appliedIds.has(candidate.id));
+  const remaining = applied.filter((candidate) => transaction.attemptedAfter.media.some((media) =>
+    media.speech?.words.some((word) => word.filler === true && word.text.trim().toLowerCase() === candidate.word.text.trim().toLowerCase()),
+  ));
+  return {
+    name: "filler-targets-absent",
+    passed: remaining.length === 0,
+    detail: remaining.length === 0
+      ? "re-analysis contains no applied filler candidates"
+      : `re-analysis still contains ${remaining.length} applied filler candidate(s)`,
+    ...(remaining.length > 0 ? { reason: "FILLER_REMAINS_AFTER_REANALYSIS" } : {}),
+    expected: applied.map((candidate) => candidate.id),
+    observed: remaining.map((candidate) => candidate.id),
+  };
+}
+
+function verifyProtectedSpeech(transaction: EditTransaction): import("../domain/verification.js").VerificationCheck {
+  const beforeProtected = transaction.before.media.flatMap((media) => media.speech?.protectedSegments ?? []);
+  const afterProtected = transaction.attemptedAfter.media.flatMap((media) => media.speech?.protectedSegments ?? []);
+  const passed = beforeProtected.length === afterProtected.length
+    && beforeProtected.every((segment, index) => sameSegment(segment, afterProtected[index]));
+  return {
+    name: "protected-speech-intact",
+    passed,
+    detail: passed ? "protected speech evidence is unchanged" : "protected speech evidence changed after filler removal",
+    ...(passed ? {} : { reason: "PROTECTED_SPEECH_CHANGED" }),
+  };
+}
+
+function verifyAuthorizedDiff(transaction: EditTransaction, expectedDiff?: TimelineDiff): import("../domain/verification.js").VerificationCheck {
+  if (!expectedDiff) {
+    return {
+      name: "authorized-canonical-diff",
+      passed: false,
+      status: "unavailable",
+      detail: "the editor did not provide an expected canonical diff",
+      reason: "EXPECTED_DIFF_UNAVAILABLE",
+    };
+  }
+  const actual = diffSignature(transaction.diff);
+  const expected = diffSignature(expectedDiff);
+  const passed = JSON.stringify(actual) === JSON.stringify(expected);
+  return {
+    name: "authorized-canonical-diff",
+    passed,
+    detail: passed ? "canonical diff matches the authorized preview" : "canonical diff contains unauthorized changes",
+    ...(passed ? {} : { reason: "UNEXPECTED_DIFF", expected, observed: actual }),
+  };
+}
+
+function verifyPlannedDuration(
+  transaction: EditTransaction,
+  details: Partial<FillerSkillDetails> | undefined,
+): import("../domain/verification.js").VerificationCheck {
+  const expected = (details?.candidateProvenance ?? []).reduce((total, item) => total + (item.operationRange.end - item.operationRange.start), 0);
+  const observed = Math.abs(transaction.diff.durationDelta);
+  const passed = Math.abs(observed - expected) <= 0.000001;
+  return {
+    name: "planned-duration-change",
+    passed,
+    detail: passed ? "timeline duration changed by the authorized deleted frames" : "timeline duration differs from the authorized delete duration",
+    ...(passed ? {} : { reason: "DURATION_DELTA_MISMATCH", expected: -expected, observed: transaction.diff.durationDelta }),
+  };
+}
+
+function diffSignature(diff: TimelineDiff): unknown {
+  return {
+    added: diff.added.map((item) => item.after?.id ?? item.itemId),
+    removed: diff.removed.map((item) => item.before?.id ?? item.itemId),
+    modified: diff.modified.map((item) => item.after?.id ?? item.itemId),
+    markerChanges: diff.markerChanges.map((item) => item.marker.id),
+    captionChanges: diff.captionChanges.map((item) => item.caption.id),
+    storyElementChanges: diff.storyElementChanges.map((item) => item.element.id),
+    mediaChanges: diff.mediaChanges.map((item) => item.media.mediaId),
+    durationDelta: diff.durationDelta,
+    affectedRanges: diff.affectedRanges,
+  };
+}
+
+function sameSegment(left: { start: number; end: number; kind: string }, right: { start: number; end: number; kind: string } | undefined): boolean {
+  if (!right) return false;
+  return left.kind === right.kind
+    && Math.abs(left.start - right.start) <= 0.000001
+    && Math.abs(left.end - right.end) <= 0.000001;
 }
 
 function dialogueNormalizationSkill(): SkillDefinition {

--- a/packages/runtime/src/skills/builtin.ts
+++ b/packages/runtime/src/skills/builtin.ts
@@ -196,9 +196,10 @@ function verifyFillerTargetsAbsent(
   const candidates = details?.candidates ?? [];
   const appliedIds = new Set((details?.candidateProvenance ?? []).map((item) => item.candidateId));
   const applied = candidates.filter((candidate) => appliedIds.has(candidate.id));
-  const remaining = applied.filter((candidate) => transaction.attemptedAfter.media.some((media) =>
-    media.speech?.words.some((word) => word.filler === true && word.text.trim().toLowerCase() === candidate.word.text.trim().toLowerCase()),
-  ));
+  const remaining = applied.filter((candidate) => {
+    const media = transaction.attemptedAfter.media.find((item) => item.mediaId === candidate.mediaId);
+    return media?.speech?.words.some((word) => sameSpeechWord(candidate.word, word)) ?? false;
+  });
   return {
     name: "filler-targets-absent",
     passed: remaining.length === 0,

--- a/packages/runtime/src/skills/runtime.ts
+++ b/packages/runtime/src/skills/runtime.ts
@@ -11,6 +11,7 @@ import type {
   SkillManifest,
   SkillPlan,
   SkillPreview,
+  SkillVerificationContext,
 } from "../domain/skills.js";
 import type { EditService } from "../editing/edit-service.js";
 import { sameRevision } from "../context/revision.js";
@@ -112,7 +113,6 @@ export class SkillRuntime {
       operations: structuredClone(planned.operations),
       affectedRanges: structuredClone(planned.affectedRanges),
       warnings: [...planned.warnings],
-      ...(planned.decision ? { decision: planned.decision } : {}),
       ...(planned.verification ? { verification: structuredClone(planned.verification) } : {}),
       ...(planned.details ? { details: structuredClone(planned.details) } : {}),
     };
@@ -155,7 +155,7 @@ export class SkillRuntime {
     });
     if (!session.editPreviewToken) {
       return {
-        status: session.preview.plan.decision === "NO_OP" ? "VERIFIED" : "SKIPPED",
+        status: session.preview.plan.decision === "NO_OP" || !session.preview.plan.decision ? "VERIFIED" : "SKIPPED",
         plan: {
           id: session.preview.plan.id,
           skillId: session.preview.plan.skillId,
@@ -163,13 +163,40 @@ export class SkillRuntime {
           baseRevision: structuredClone(session.preview.plan.baseRevision),
         },
         transactionIds: [],
+        ...(session.preview.plan.details ? { details: structuredClone(session.preview.plan.details) } : {}),
         rollback: { attempted: false, succeeded: true, transactionIds: [] },
       };
     }
     const transaction = await this.edits.executeEdit(session.editPreviewToken);
     const rolledBack = transaction.status === "ROLLED_BACK";
+    let verification = transaction.verification;
+    let status: SkillExecution["status"] = rolledBack
+      ? "ROLLED_BACK"
+      : transaction.status === "VERIFIED" ? "VERIFIED" : "FAILED";
+    let rollback: SkillExecution["rollback"] = {
+      attempted: rolledBack,
+      succeeded: rolledBack,
+      transactionIds: rolledBack ? [transaction.id] : [],
+    };
+    if (!rolledBack && definition.handler.verify) {
+      const checks = await definition.handler.verify({
+        plan: session.preview.plan,
+        ...(session.preview.expectedDiff ? { expectedDiff: session.preview.expectedDiff } : {}),
+        transaction,
+      } satisfies SkillVerificationContext);
+      verification = {
+        passed: Boolean(verification?.passed) && checks.every((check) => check.passed),
+        checks: [...(verification?.checks ?? []), ...checks],
+        ...(verification?.target ? { target: structuredClone(verification.target) } : {}),
+      };
+      if (!verification.passed) {
+        await this.edits.undo(transaction.id);
+        status = "ROLLED_BACK";
+        rollback = { attempted: true, succeeded: true, transactionIds: [transaction.id] };
+      }
+    }
     return {
-      status: rolledBack ? "ROLLED_BACK" : transaction.status === "VERIFIED" ? "VERIFIED" : "FAILED",
+      status,
       plan: {
         id: session.preview.plan.id,
         skillId: session.preview.plan.skillId,
@@ -178,12 +205,9 @@ export class SkillRuntime {
       },
       transactionIds: [transaction.id],
       diff: structuredClone(transaction.diff),
-      ...(transaction.verification ? { verification: structuredClone(transaction.verification) } : {}),
-      rollback: {
-        attempted: rolledBack,
-        succeeded: rolledBack,
-        transactionIds: rolledBack ? [transaction.id] : [],
-      },
+      ...(verification ? { verification: structuredClone(verification) } : {}),
+      ...(session.preview.plan.details ? { details: structuredClone(session.preview.plan.details) } : {}),
+      rollback,
     };
   }
 

--- a/packages/runtime/src/skills/runtime.ts
+++ b/packages/runtime/src/skills/runtime.ts
@@ -113,6 +113,7 @@ export class SkillRuntime {
       operations: structuredClone(planned.operations),
       affectedRanges: structuredClone(planned.affectedRanges),
       warnings: [...planned.warnings],
+      ...(planned.decision ? { decision: planned.decision } : {}),
       ...(planned.verification ? { verification: structuredClone(planned.verification) } : {}),
       ...(planned.details ? { details: structuredClone(planned.details) } : {}),
     };

--- a/packages/testkit/src/in-memory-editor.ts
+++ b/packages/testkit/src/in-memory-editor.ts
@@ -27,6 +27,7 @@ export interface InMemoryProjectFixture {
   projectName: string;
   timelineId: string;
   timelineName: string;
+  frameDuration?: RationalTime;
   clips: Array<Omit<Clip, "startTime" | "durationTime"> & Partial<Pick<Clip, "startTime" | "durationTime">>>;
   media?: MediaContext[];
   markers?: Marker[];
@@ -796,6 +797,7 @@ function createSnapshot(fixture: InMemoryProjectFixture): ProjectSnapshot {
       name: fixture.timelineName,
       duration: clips.reduce((end, clip) => Math.max(end, clip.start + clip.duration), 0),
       durationTime: decimalToRational(clips.reduce((end, clip) => Math.max(end, clip.start + clip.duration), 0)),
+      ...(fixture.frameDuration ? { frameDuration: structuredClone(fixture.frameDuration) } : {}),
       clips,
       storyElements: clips.map((clip) => ({
         id: clip.id,

--- a/tests/integration/filler-removal-skill.test.ts
+++ b/tests/integration/filler-removal-skill.test.ts
@@ -232,14 +232,14 @@ test("repeated filler text outside the selected range remains independent", asyn
     { text: "hello", start: 0.2, end: 0.6, confidence: 0.99 },
     { text: "um", start: 0.8, end: 1.1, confidence: 0.98, filler: true },
     { text: "world", start: 1.3, end: 1.8, confidence: 0.99 },
-    { text: "hello", start: 5.2, end: 5.6, confidence: 0.99 },
-    { text: "um", start: 5.8, end: 6.1, confidence: 0.98, filler: true },
-    { text: "world", start: 6.3, end: 6.8, confidence: 0.99 },
+    { text: "hello", start: 3, end: 3.4, confidence: 0.99 },
+    { text: "um", start: 3.6, end: 3.9, confidence: 0.98, filler: true },
+    { text: "world", start: 4.1, end: 4.6, confidence: 0.99 },
   ];
   const { runtime } = createFixture({
     words,
-    clipDuration: 7,
-    mediaDuration: 7,
+    clipDuration: 5,
+    mediaDuration: 5,
     postWords: words.filter((word) => word.start !== 0.8),
   });
   register(runtime);
@@ -247,7 +247,7 @@ test("repeated filler text outside the selected range remains independent", asyn
   const preview = await runtime.previewSkill({
     skillId: "filler-removal",
     baseRevision: before.revision,
-    input: { range: { start: 0, end: 4 } },
+    input: { range: { start: 0, end: 2.5 } },
   });
 
   assert.equal(preview.plan.operations.length, 1);

--- a/tests/integration/filler-removal-skill.test.ts
+++ b/tests/integration/filler-removal-skill.test.ts
@@ -1,0 +1,235 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  AgentVideoRuntime,
+  canonicalSnapshotDigest,
+  type ProjectSnapshot,
+  type SpeechAnalyzer,
+} from "@framekit/runtime";
+import { InMemoryEditorAdapter } from "@framekit/testkit";
+
+function createFixture(options: {
+  words?: ProjectSnapshot["media"][number]["speech"]["words"];
+  protectedSegments?: NonNullable<ProjectSnapshot["media"][number]["speech"]>["protectedSegments"];
+} = {}) {
+  const words = options.words ?? [
+    { text: "hello", start: 0.2, end: 0.6, confidence: 0.99 },
+    { text: "um", start: 0.8, end: 1.1, confidence: 0.98, filler: true },
+    { text: "world", start: 1.3, end: 1.8, confidence: 0.99 },
+    { text: "uh", start: 2, end: 2.3, confidence: 0.7 },
+  ];
+  const adapter = new InMemoryEditorAdapter({
+    projectId: "skill-filler-project",
+    projectName: "Skill Filler Fixture",
+    timelineId: "skill-filler-timeline",
+    timelineName: "Main Edit",
+    clips: [{ id: "filler-occurrence", mediaId: "filler-media", name: "Interview", start: 0, duration: 5, track: 0 }],
+    media: [{
+      mediaId: "filler-media",
+      source: "fixtures/interview.wav",
+      duration: 5,
+      speech: {
+        words,
+        vadSegments: [
+          { start: 0, end: 0.7, kind: "speech" },
+          { start: 0.7, end: 0.8, kind: "silence" },
+          { start: 0.8, end: 1.1, kind: "speech" },
+          { start: 1.1, end: 1.3, kind: "silence" },
+          { start: 1.3, end: 1.8, kind: "speech" },
+          { start: 1.8, end: 2, kind: "silence" },
+          { start: 2, end: 2.3, kind: "speech" },
+        ],
+        silenceSegments: [
+          { start: 0.7, end: 0.8, kind: "silence" },
+          { start: 1.1, end: 1.3, kind: "silence" },
+          { start: 1.8, end: 2, kind: "silence" },
+        ],
+        ...(options.protectedSegments ? { protectedSegments: options.protectedSegments } : {}),
+      },
+    }],
+  });
+  const analyzer: SpeechAnalyzer = {
+    capabilities: { transcription: true, vad: true },
+    analyze: async ({ project, media }) => {
+      const clip = project.timeline.clips.find((candidate) => candidate.id === "filler-occurrence");
+      if ((clip?.duration ?? 5) < 5) {
+        return {
+          words: words.filter((word) => word.filler !== true).map((word) => {
+            const removed = words
+              .filter((candidate) => candidate.filler === true && candidate.end <= word.start)
+              .reduce((total, candidate) => total + candidate.end - candidate.start, 0);
+            return { ...word, start: word.start - removed, end: word.end - removed };
+          }),
+          vadSegments: [{ start: 0, end: Math.max(0, (clip?.duration ?? 5) - 0.3), kind: "speech" as const }],
+        };
+      }
+      return structuredClone(media.speech!);
+    },
+  };
+  return { adapter, analyzer, runtime: new AgentVideoRuntime(adapter, { speechAnalyzer: analyzer }) };
+}
+
+function register(runtime: AgentVideoRuntime): void {
+  runtime.registerBuiltinSkills();
+}
+
+test("filler Skill is unavailable before planning when VAD is missing", async () => {
+  const { adapter } = createFixture();
+  const runtime = new AgentVideoRuntime(adapter, {
+    speechAnalyzer: {
+      capabilities: { transcription: true, vad: false },
+      analyze: async ({ media }) => structuredClone(media.speech!),
+    },
+  });
+  register(runtime);
+
+  const inspection = await runtime.inspectSkillAvailability("filler-removal");
+
+  assert.equal(inspection.availability.available, false);
+  assert.ok(inspection.availability.missingRequirements.some((item) => item.name === "speechVad"));
+});
+
+test("filler Skill preview returns decisions and evidence without mutation", async () => {
+  const { adapter, runtime } = createFixture();
+  register(runtime);
+  const before = await runtime.inspectProject();
+
+  const preview = await runtime.previewSkill({
+    skillId: "filler-removal",
+    baseRevision: before.revision,
+    input: { range: { start: 0, end: 5 } },
+  });
+  const details = preview.plan.details as {
+    candidates: Array<{ id: string; word: { text: string } }>;
+    decisions: Array<{ candidateId: string; status: string; evidence: unknown }>;
+    candidateProvenance: Array<{ candidateId: string; operationIndex: number }>;
+  };
+
+  assert.equal(details.candidates.length, 2);
+  assert.deepEqual(details.candidates.map((candidate) => candidate.word.text), ["um", "uh"]);
+  assert.deepEqual(details.decisions.map((decision) => decision.status), ["AUTO_APPLY", "SUGGESTED"]);
+  assert.ok(details.decisions.every((decision) => decision.evidence));
+  assert.equal(preview.plan.operations.length, 1);
+  assert.equal((preview.plan.operations[0] as { candidateId?: string }).candidateId, details.candidates[0]?.id);
+  assert.equal(details.candidateProvenance.length, 1);
+  assert.deepEqual(await adapter.readProject(), before);
+});
+
+test("suggested filler candidates require an explicit re-preview selection", async () => {
+  const { runtime } = createFixture();
+  register(runtime);
+  const before = await runtime.inspectProject();
+  const initial = await runtime.previewSkill({
+    skillId: "filler-removal",
+    baseRevision: before.revision,
+    input: { range: { start: 0, end: 5 } },
+  });
+  const initialDetails = initial.plan.details as { candidates: Array<{ id: string; word: { text: string } }> };
+  const suggested = initialDetails.candidates.find((candidate) => candidate.word.text === "uh");
+  assert.ok(suggested);
+
+  const selected = await runtime.previewSkill({
+    skillId: "filler-removal",
+    baseRevision: before.revision,
+    input: { range: { start: 0, end: 5 }, selectedCandidateIds: [suggested.id] },
+  });
+  const selectedDetails = selected.plan.details as { candidates: Array<{ id: string }>; decisions: Array<{ candidateId: string; status: string }> };
+
+  assert.equal(selected.plan.operations.length, 2);
+  assert.equal(selectedDetails.decisions.find((decision) => decision.candidateId === suggested.id)?.status, "SUGGESTED");
+  assert.deepEqual((selected.plan.operations as Array<{ candidateId?: string }>).map((operation) => operation.candidateId), [
+    selectedDetails.candidates[0]?.id,
+    suggested.id,
+  ]);
+});
+
+test("zero valid filler candidates execute as a verified no-op", async () => {
+  const { adapter, runtime } = createFixture({
+    words: [
+      { text: "uh", start: 1, end: 1.3, confidence: 0.7 },
+    ],
+  });
+  register(runtime);
+  const before = await runtime.inspectProject();
+  const preview = await runtime.previewSkill({
+    skillId: "filler-removal",
+    baseRevision: before.revision,
+    input: { range: { start: 0, end: 5 } },
+  });
+
+  assert.equal(preview.plan.operations.length, 0);
+  const execution = await runtime.executeSkill(preview.previewToken);
+
+  assert.equal(execution.status, "VERIFIED");
+  assert.deepEqual(execution.transactionIds, []);
+  assert.deepEqual(await adapter.readProject(), before);
+});
+
+test("filler Skill applies all authorized cuts in one composite transaction with provenance", async () => {
+  const { adapter, runtime } = createFixture();
+  register(runtime);
+  let compositeCalls = 0;
+  const applyTransaction = adapter.applyTransaction!.bind(adapter);
+  adapter.applyTransaction = async (...args) => {
+    compositeCalls += 1;
+    return applyTransaction(...args);
+  };
+  const before = await runtime.inspectProject();
+  const preview = await runtime.previewSkill({
+    skillId: "filler-removal",
+    baseRevision: before.revision,
+    input: { range: { start: 0, end: 5 }, selectedCandidateIds: [] },
+  });
+  const execution = await runtime.executeSkill(preview.previewToken);
+  const details = execution.details as { candidateProvenance: Array<{ candidateId: string; operationIndex: number; diffRanges: unknown[] }> };
+
+  assert.equal(execution.status, "VERIFIED");
+  assert.equal(compositeCalls, 1);
+  assert.equal(execution.transactionIds.length, 1);
+  assert.equal(details.candidateProvenance.length, 1);
+  assert.equal(details.candidateProvenance[0]?.operationIndex, 0);
+  assert.ok(details.candidateProvenance[0]?.diffRanges.length);
+  assert.ok(Math.abs((execution.diff?.durationDelta ?? 0) + 0.3) < 0.000001);
+});
+
+test("unexpected canonical changes roll back the complete filler transaction", async () => {
+  const { adapter, runtime } = createFixture();
+  register(runtime);
+  const before = await runtime.inspectProject();
+  const preview = await runtime.previewSkill({
+    skillId: "filler-removal",
+    baseRevision: before.revision,
+    input: { range: { start: 0, end: 5 } },
+  });
+  const applyTransaction = adapter.applyTransaction!.bind(adapter);
+  adapter.applyTransaction = async (operations, revision) => {
+    await applyTransaction(operations, revision);
+    const current = await adapter.readProject();
+    await adapter.apply({
+      type: "add-marker",
+      timelineId: current.timeline.id,
+      marker: { id: "unexpected", start: 0, duration: 0, name: "Unexpected" },
+    }, current.revision);
+  };
+
+  await assert.rejects(runtime.executeSkill(preview.previewToken), /UNEXPECTED_DIFF/);
+  assert.equal(canonicalSnapshotDigest(await adapter.readProject()), canonicalSnapshotDigest(before));
+});
+
+test("protected speech is never authorized for automatic filler removal", async () => {
+  const { runtime } = createFixture({ protectedSegments: [{ start: 0.9, end: 1.05, kind: "breath" }] });
+  register(runtime);
+  const before = await runtime.inspectProject();
+  const preview = await runtime.previewSkill({
+    skillId: "filler-removal",
+    baseRevision: before.revision,
+    input: { range: { start: 0, end: 5 } },
+  });
+  const details = preview.plan.details as { decisions: Array<{ candidateId: string; status: string; reasonCodes: string[] }> };
+  const umDecision = details.decisions.find((decision) => decision.reasonCodes.includes("PROTECTED_SEGMENT_OVERLAP"));
+
+  assert.equal(umDecision?.status, "SKIPPED");
+  assert.equal(preview.plan.operations.length, 0);
+  const execution = await runtime.executeSkill(preview.previewToken);
+  assert.equal(execution.status, "VERIFIED");
+});

--- a/tests/integration/filler-removal-skill.test.ts
+++ b/tests/integration/filler-removal-skill.test.ts
@@ -313,7 +313,7 @@ test("unexpected canonical changes roll back the complete filler transaction", a
 
   const execution = await runtime.executeSkill(preview.previewToken);
   assert.equal(execution.status, "ROLLED_BACK");
-  assert.ok(execution.verification?.checks.some((check) => check.reason === "UNEXPECTED_DIFF"));
+  assert.ok(execution.verification?.checks.some((check) => check.reason === "UNAUTHORIZED_DIFF"));
   assert.equal(canonicalSnapshotDigest(await adapter.readProject()), canonicalSnapshotDigest(before));
 });
 

--- a/tests/integration/filler-removal-skill.test.ts
+++ b/tests/integration/filler-removal-skill.test.ts
@@ -57,12 +57,7 @@ function createFixture(options: {
       const clip = project.timeline.clips.find((candidate) => candidate.id === "filler-occurrence");
       if ((clip?.duration ?? 5) < 5) {
         if (options.postAnalysisError) throw new Error("controlled post-write analyzer failure");
-        const postWords = options.postWords ?? words.filter((word) => word.filler !== true).map((word) => {
-          const removed = words
-            .filter((candidate) => candidate.filler === true && candidate.end <= word.start)
-            .reduce((total, candidate) => total + candidate.end - candidate.start, 0);
-          return { ...word, start: word.start - removed, end: word.end - removed };
-        });
+        const postWords = options.postWords ?? words.filter((word) => word.filler !== true);
         return {
           words: postWords,
           vadSegments: [{ start: 0, end: Math.max(0, (clip?.duration ?? 5) - 0.3), kind: "speech" as const }],

--- a/tests/integration/filler-removal-skill.test.ts
+++ b/tests/integration/filler-removal-skill.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   AgentVideoRuntime,
   canonicalSnapshotDigest,
+  type RationalTime,
   type SpeechSegment,
   type SpeechAnalyzer,
   type SpeechWord,
@@ -16,9 +17,13 @@ function createFixture(options: {
   postAnalysisError?: boolean;
   clipDuration?: number;
   mediaDuration?: number;
+  frameDuration?: RationalTime | null;
 } = {}) {
   const clipDuration = options.clipDuration ?? 5;
   const mediaDuration = options.mediaDuration ?? clipDuration;
+  const frameDuration: RationalTime | null = options.frameDuration === undefined
+    ? { value: "1", timescale: "30" }
+    : options.frameDuration;
   const words = options.words ?? [
     { text: "hello", start: 0.2, end: 0.6, confidence: 0.99 },
     { text: "um", start: 0.8, end: 1.1, confidence: 0.98, filler: true },
@@ -30,6 +35,7 @@ function createFixture(options: {
     projectName: "Skill Filler Fixture",
     timelineId: "skill-filler-timeline",
     timelineName: "Main Edit",
+    ...(frameDuration ? { frameDuration } : {}),
       clips: [{ id: "filler-occurrence", mediaId: "filler-media", name: "Interview", start: 0, duration: clipDuration, track: 0 }],
     media: [{
       mediaId: "filler-media",
@@ -255,6 +261,34 @@ test("repeated filler text outside the selected range remains independent", asyn
 
   assert.equal(execution.status, "VERIFIED");
   assert.equal(execution.verification?.checks.find((check) => check.name === "filler-targets-absent")?.passed, true);
+});
+
+test("filler Skill uses the canonical non-30-fps sequence timing", async () => {
+  const { runtime } = createFixture({ frameDuration: { value: "1", timescale: "24" } });
+  register(runtime);
+  const before = await runtime.inspectProject();
+  const preview = await runtime.previewSkill({
+    skillId: "filler-removal",
+    baseRevision: before.revision,
+    input: { range: { start: 0, end: 5 } },
+  });
+  const details = preview.plan.details as {
+    decisions: Array<{ evidence: { frameDuration: RationalTime } }>;
+  };
+
+  assert.deepEqual(details.decisions[0]?.evidence.frameDuration, { value: "1", timescale: "24" });
+});
+
+test("filler Skill fails closed when sequence frame timing is unavailable", async () => {
+  const { runtime } = createFixture({ frameDuration: null });
+  register(runtime);
+  const before = await runtime.inspectProject();
+
+  await assert.rejects(runtime.previewSkill({
+    skillId: "filler-removal",
+    baseRevision: before.revision,
+    input: { range: { start: 0, end: 5 } },
+  }), /CAPABILITY_UNAVAILABLE: sequence frame duration/);
 });
 
 test("unexpected canonical changes roll back the complete filler transaction", async () => {

--- a/tests/integration/filler-removal-skill.test.ts
+++ b/tests/integration/filler-removal-skill.test.ts
@@ -197,6 +197,28 @@ test("filler Skill applies all authorized cuts in one composite transaction with
   assert.ok(Math.abs((execution.diff?.durationDelta ?? 0) + 0.3) < 0.000001);
 });
 
+test("source-media speech timestamps remain unchanged after ripple delete", async () => {
+  const { runtime } = createFixture({
+    postWords: [
+      { text: "hello", start: 0.2, end: 0.6, confidence: 0.99 },
+      { text: "world", start: 1.3, end: 1.8, confidence: 0.99 },
+      { text: "uh", start: 2, end: 2.3, confidence: 0.7 },
+    ],
+  });
+  register(runtime);
+  const before = await runtime.inspectProject();
+  const preview = await runtime.previewSkill({
+    skillId: "filler-removal",
+    baseRevision: before.revision,
+    input: { range: { start: 0, end: 5 } },
+  });
+
+  const execution = await runtime.executeSkill(preview.previewToken);
+
+  assert.equal(execution.status, "VERIFIED");
+  assert.equal(execution.verification?.checks.find((check) => check.name === "filler-speech-continuity")?.passed, true);
+});
+
 test("unexpected canonical changes roll back the complete filler transaction", async () => {
   const { adapter, runtime } = createFixture();
   register(runtime);

--- a/tests/integration/filler-removal-skill.test.ts
+++ b/tests/integration/filler-removal-skill.test.ts
@@ -14,7 +14,11 @@ function createFixture(options: {
   protectedSegments?: SpeechSegment[];
   postWords?: SpeechWord[];
   postAnalysisError?: boolean;
+  clipDuration?: number;
+  mediaDuration?: number;
 } = {}) {
+  const clipDuration = options.clipDuration ?? 5;
+  const mediaDuration = options.mediaDuration ?? clipDuration;
   const words = options.words ?? [
     { text: "hello", start: 0.2, end: 0.6, confidence: 0.99 },
     { text: "um", start: 0.8, end: 1.1, confidence: 0.98, filler: true },
@@ -26,11 +30,11 @@ function createFixture(options: {
     projectName: "Skill Filler Fixture",
     timelineId: "skill-filler-timeline",
     timelineName: "Main Edit",
-    clips: [{ id: "filler-occurrence", mediaId: "filler-media", name: "Interview", start: 0, duration: 5, track: 0 }],
+      clips: [{ id: "filler-occurrence", mediaId: "filler-media", name: "Interview", start: 0, duration: clipDuration, track: 0 }],
     media: [{
       mediaId: "filler-media",
       source: "fixtures/interview.wav",
-      duration: 5,
+      duration: mediaDuration,
       speech: {
         words,
         vadSegments: [
@@ -53,17 +57,26 @@ function createFixture(options: {
   });
   const analyzer: SpeechAnalyzer = {
     capabilities: { transcription: true, vad: true },
-    analyze: async ({ project, media }) => {
+    analyze: async ({ project, media }, range) => {
       const clip = project.timeline.clips.find((candidate) => candidate.id === "filler-occurrence");
-      if ((clip?.duration ?? 5) < 5) {
+      if ((clip?.duration ?? clipDuration) < clipDuration) {
         if (options.postAnalysisError) throw new Error("controlled post-write analyzer failure");
         const postWords = options.postWords ?? words.filter((word) => word.filler !== true);
+        const scopedWords = range
+          ? postWords.filter((word) => word.start >= range.start && word.end <= range.end)
+          : postWords;
         return {
-          words: postWords,
+          words: scopedWords,
           vadSegments: [{ start: 0, end: Math.max(0, (clip?.duration ?? 5) - 0.3), kind: "speech" as const }],
         };
       }
-      return structuredClone(media.speech!);
+      const scopedWords = range
+        ? media.speech!.words.filter((word) => word.start >= range.start && word.end <= range.end)
+        : media.speech!.words;
+      return {
+        ...structuredClone(media.speech!),
+        words: scopedWords,
+      };
     },
   };
   return { adapter, analyzer, runtime: new AgentVideoRuntime(adapter, { speechAnalyzer: analyzer }) };
@@ -212,6 +225,36 @@ test("source-media speech timestamps remain unchanged after ripple delete", asyn
 
   assert.equal(execution.status, "VERIFIED");
   assert.equal(execution.verification?.checks.find((check) => check.name === "filler-speech-continuity")?.passed, true);
+});
+
+test("repeated filler text outside the selected range remains independent", async () => {
+  const words: SpeechWord[] = [
+    { text: "hello", start: 0.2, end: 0.6, confidence: 0.99 },
+    { text: "um", start: 0.8, end: 1.1, confidence: 0.98, filler: true },
+    { text: "world", start: 1.3, end: 1.8, confidence: 0.99 },
+    { text: "hello", start: 5.2, end: 5.6, confidence: 0.99 },
+    { text: "um", start: 5.8, end: 6.1, confidence: 0.98, filler: true },
+    { text: "world", start: 6.3, end: 6.8, confidence: 0.99 },
+  ];
+  const { runtime } = createFixture({
+    words,
+    clipDuration: 7,
+    mediaDuration: 7,
+    postWords: words.filter((word) => word.start !== 0.8),
+  });
+  register(runtime);
+  const before = await runtime.inspectProject();
+  const preview = await runtime.previewSkill({
+    skillId: "filler-removal",
+    baseRevision: before.revision,
+    input: { range: { start: 0, end: 4 } },
+  });
+
+  assert.equal(preview.plan.operations.length, 1);
+  const execution = await runtime.executeSkill(preview.previewToken);
+
+  assert.equal(execution.status, "VERIFIED");
+  assert.equal(execution.verification?.checks.find((check) => check.name === "filler-targets-absent")?.passed, true);
 });
 
 test("unexpected canonical changes roll back the complete filler transaction", async () => {

--- a/tests/integration/filler-removal-skill.test.ts
+++ b/tests/integration/filler-removal-skill.test.ts
@@ -3,14 +3,15 @@ import test from "node:test";
 import {
   AgentVideoRuntime,
   canonicalSnapshotDigest,
-  type ProjectSnapshot,
+  type SpeechSegment,
   type SpeechAnalyzer,
+  type SpeechWord,
 } from "@framekit/runtime";
 import { InMemoryEditorAdapter } from "@framekit/testkit";
 
 function createFixture(options: {
-  words?: ProjectSnapshot["media"][number]["speech"]["words"];
-  protectedSegments?: NonNullable<ProjectSnapshot["media"][number]["speech"]>["protectedSegments"];
+  words?: SpeechWord[];
+  protectedSegments?: SpeechSegment[];
 } = {}) {
   const words = options.words ?? [
     { text: "hello", start: 0.2, end: 0.6, confidence: 0.99 },
@@ -138,8 +139,8 @@ test("suggested filler candidates require an explicit re-preview selection", asy
   assert.equal(selected.plan.operations.length, 2);
   assert.equal(selectedDetails.decisions.find((decision) => decision.candidateId === suggested.id)?.status, "SUGGESTED");
   assert.deepEqual((selected.plan.operations as Array<{ candidateId?: string }>).map((operation) => operation.candidateId), [
-    selectedDetails.candidates[0]?.id,
     suggested.id,
+    selectedDetails.candidates[0]?.id,
   ]);
 });
 
@@ -212,7 +213,9 @@ test("unexpected canonical changes roll back the complete filler transaction", a
     }, current.revision);
   };
 
-  await assert.rejects(runtime.executeSkill(preview.previewToken), /UNEXPECTED_DIFF/);
+  const execution = await runtime.executeSkill(preview.previewToken);
+  assert.equal(execution.status, "ROLLED_BACK");
+  assert.ok(execution.verification?.checks.some((check) => check.reason === "UNEXPECTED_DIFF"));
   assert.equal(canonicalSnapshotDigest(await adapter.readProject()), canonicalSnapshotDigest(before));
 });
 

--- a/tests/integration/filler-removal-skill.test.ts
+++ b/tests/integration/filler-removal-skill.test.ts
@@ -12,6 +12,8 @@ import { InMemoryEditorAdapter } from "@framekit/testkit";
 function createFixture(options: {
   words?: SpeechWord[];
   protectedSegments?: SpeechSegment[];
+  postWords?: SpeechWord[];
+  postAnalysisError?: boolean;
 } = {}) {
   const words = options.words ?? [
     { text: "hello", start: 0.2, end: 0.6, confidence: 0.99 },
@@ -54,13 +56,15 @@ function createFixture(options: {
     analyze: async ({ project, media }) => {
       const clip = project.timeline.clips.find((candidate) => candidate.id === "filler-occurrence");
       if ((clip?.duration ?? 5) < 5) {
+        if (options.postAnalysisError) throw new Error("controlled post-write analyzer failure");
+        const postWords = options.postWords ?? words.filter((word) => word.filler !== true).map((word) => {
+          const removed = words
+            .filter((candidate) => candidate.filler === true && candidate.end <= word.start)
+            .reduce((total, candidate) => total + candidate.end - candidate.start, 0);
+          return { ...word, start: word.start - removed, end: word.end - removed };
+        });
         return {
-          words: words.filter((word) => word.filler !== true).map((word) => {
-            const removed = words
-              .filter((candidate) => candidate.filler === true && candidate.end <= word.start)
-              .reduce((total, candidate) => total + candidate.end - candidate.start, 0);
-            return { ...word, start: word.start - removed, end: word.end - removed };
-          }),
+          words: postWords,
           vadSegments: [{ start: 0, end: Math.max(0, (clip?.duration ?? 5) - 0.3), kind: "speech" as const }],
         };
       }
@@ -235,4 +239,69 @@ test("protected speech is never authorized for automatic filler removal", async 
   assert.equal(preview.plan.operations.length, 0);
   const execution = await runtime.executeSkill(preview.previewToken);
   assert.equal(execution.status, "VERIFIED");
+});
+
+test("invalid candidate selections are rejected during re-preview", async () => {
+  const { runtime } = createFixture();
+  register(runtime);
+  const before = await runtime.inspectProject();
+
+  await assert.rejects(runtime.previewSkill({
+    skillId: "filler-removal",
+    baseRevision: before.revision,
+    input: { range: { start: 0, end: 5 }, selectedCandidateIds: ["missing-candidate"] },
+  }), /CANDIDATE_NOT_FOUND/);
+  assert.deepEqual(await runtime.inspectProject(), before);
+});
+
+test("partial composite failures roll back every applied filler operation", async () => {
+  const { adapter, runtime } = createFixture();
+  register(runtime);
+  const before = await runtime.inspectProject();
+  const preview = await runtime.previewSkill({
+    skillId: "filler-removal",
+    baseRevision: before.revision,
+    input: { range: { start: 0, end: 5 } },
+  });
+  const firstOperation = preview.plan.operations.find((operation) => operation.type === "ripple-delete");
+  if (!firstOperation) throw new Error("test fixture did not produce a ripple-delete operation");
+  adapter.applyTransaction = async (operations, revision) => {
+    await adapter.apply(firstOperation, revision);
+    throw new Error("controlled partial composite failure");
+  };
+
+  await assert.rejects(runtime.executeSkill(preview.previewToken), /TRANSACTION_FAILED/);
+  assert.equal(canonicalSnapshotDigest(await adapter.readProject()), canonicalSnapshotDigest(before));
+});
+
+test("post-write analysis failures roll back the complete filler transaction", async () => {
+  const { adapter, runtime } = createFixture({ postAnalysisError: true });
+  register(runtime);
+  const before = await runtime.inspectProject();
+  const preview = await runtime.previewSkill({
+    skillId: "filler-removal",
+    baseRevision: before.revision,
+    input: { range: { start: 0, end: 5 } },
+  });
+
+  await assert.rejects(runtime.executeSkill(preview.previewToken), /ANALYSIS_FAILED/);
+  assert.equal(canonicalSnapshotDigest(await adapter.readProject()), canonicalSnapshotDigest(before));
+});
+
+test("speech continuity failure rolls back adjacent ordered speech", async () => {
+  const { adapter, runtime } = createFixture({
+    postWords: [{ text: "hello", start: 0.2, end: 0.6, confidence: 0.99 }],
+  });
+  register(runtime);
+  const before = await runtime.inspectProject();
+  const preview = await runtime.previewSkill({
+    skillId: "filler-removal",
+    baseRevision: before.revision,
+    input: { range: { start: 0, end: 5 } },
+  });
+
+  const execution = await runtime.executeSkill(preview.previewToken);
+  assert.equal(execution.status, "ROLLED_BACK");
+  assert.ok(execution.verification?.checks.some((check) => check.reason === "SPEECH_CONTINUITY_CHANGED"));
+  assert.equal(canonicalSnapshotDigest(await adapter.readProject()), canonicalSnapshotDigest(before));
 });

--- a/tests/integration/phase1.test.ts
+++ b/tests/integration/phase1.test.ts
@@ -91,8 +91,8 @@ test("Final Cut adapter reads and writes a supported FCPXML timeline", async () 
   const path = join(directory, "project.fcpxml");
   await writeFile(path, `<?xml version="1.0" encoding="UTF-8"?>
 <fcpxml version="1.11">
-  <resources><asset id="r1" name="Interview.wav" src="file:///Interview.wav" /></resources>
-  <library><event name="Event"><project name="Phase 1 Fixture" uid="project-phase-1"><sequence uid="sequence-phase-1" duration="10s"><spine>
+  <resources><format id="r-format" frameDuration="1001/24000s" /><asset id="r1" name="Interview.wav" src="file:///Interview.wav" /></resources>
+  <library><event name="Event"><project name="Phase 1 Fixture" uid="project-phase-1"><sequence uid="sequence-phase-1" format="r-format" duration="10s"><spine>
     <asset-clip ref="r1" name="Interview" offset="0s" start="0s" duration="1001/24000s" lane="1" />
   </spine></sequence></project></event></library>
 </fcpxml>`);
@@ -108,6 +108,7 @@ test("Final Cut adapter reads and writes a supported FCPXML timeline", async () 
   assert.equal(catalog.projects[0]?.sequences[0]?.id, before.timeline.id);
   assert.equal(before.timeline.clips[0]?.name, "Interview");
   assert.deepEqual(before.timeline.clips[0]?.durationTime, { value: "1001", timescale: "24000" });
+  assert.deepEqual(before.timeline.frameDuration, { value: "1001", timescale: "24000" });
 
   const clipId = before.timeline.clips[0]!.id;
   await adapter.apply({ type: "rename-clip", clipId, name: "Interview - Clean" }, before.revision);

--- a/tests/integration/release-gate-docs.test.ts
+++ b/tests/integration/release-gate-docs.test.ts
@@ -31,7 +31,9 @@ test("Skill documentation describes only the generic MCP workflow", async () => 
   assert.match(documentation, /rollback/);
   assert.match(documentation, /targetLufs.*-16/);
   assert.match(documentation, /occurrenceId/);
+  assert.match(documentation, /selectedCandidateIds/);
   assert.match(documentation, /verified no-op/i);
+  assert.match(documentation, /candidate provenance/);
 });
 
 test("compatibility and release documentation identify the v0.0.3 gate", async () => {

--- a/tests/release-gate/corpus.json
+++ b/tests/release-gate/corpus.json
@@ -4,7 +4,7 @@
   "runtimeContract": "v0.0.3",
   "workflows": [
     { "id": "filler.obvious", "family": "filler-removal", "scenario": "obvious", "expectedOutcome": "verified", "fixture": { "kind": "filler", "case": "obvious" } },
-    { "id": "filler.low-confidence", "family": "filler-removal", "scenario": "low-confidence", "expectedOutcome": "skipped", "fixture": { "kind": "filler", "case": "low-confidence" } },
+    { "id": "filler.low-confidence", "family": "filler-removal", "scenario": "low-confidence", "expectedOutcome": "verified", "fixture": { "kind": "filler", "case": "low-confidence" } },
     { "id": "filler.unsafe-boundary", "family": "filler-removal", "scenario": "unsafe-boundary", "expectedOutcome": "skipped", "fixture": { "kind": "filler", "case": "unsafe-boundary" } },
     { "id": "filler.overlapping-speech", "family": "filler-removal", "scenario": "overlapping-speech", "expectedOutcome": "skipped", "fixture": { "kind": "filler", "case": "overlapping-speech" } },
     { "id": "filler.protected-segment", "family": "filler-removal", "scenario": "protected-segment", "expectedOutcome": "skipped", "fixture": { "kind": "filler", "case": "protected-segment" } },

--- a/tests/release-gate/mcp-skill.test.ts
+++ b/tests/release-gate/mcp-skill.test.ts
@@ -47,6 +47,7 @@ test("generic Skill tools execute filler removal and dialogue normalization", as
   });
   let fillerAnalysisCalls = 0;
   const speechAnalyzer: SpeechAnalyzer = {
+    capabilities: { transcription: true, vad: true },
     analyze: async ({ media, project }) => {
       fillerAnalysisCalls += 1;
       const fillerClip = project.timeline.clips.find((clip) => clip.id === "filler-clip");
@@ -54,9 +55,12 @@ test("generic Skill tools execute filler removal and dialogue normalization", as
         return { words: [
           { text: "so", start: 0, end: 0.3, confidence: 0.99 },
           { text: "yes", start: 1.1, end: 1.7, confidence: 0.99 },
-        ] };
+        ], vadSegments: [{ start: 0, end: 1.7, kind: "speech" as const }] };
       }
-      return structuredClone(media.speech!);
+      return {
+        ...structuredClone(media.speech!),
+        vadSegments: media.speech?.words.map((word) => ({ start: word.start, end: word.end, kind: "speech" as const })),
+      };
     },
   };
   const audioAnalyzer: AudioAnalyzer = {

--- a/tests/release-gate/mcp-skill.test.ts
+++ b/tests/release-gate/mcp-skill.test.ts
@@ -18,6 +18,7 @@ test("generic Skill tools execute filler removal and dialogue normalization", as
     projectName: "Skill Fixture",
     timelineId: "skill-timeline",
     timelineName: "Main Edit",
+    frameDuration: { value: "1", timescale: "30" },
     clips: [
       { id: "dialogue-clip", mediaId: "dialogue-media", name: "Dialogue", start: 0, duration: 10, track: 1 },
       { id: "filler-clip", mediaId: "filler-media", name: "Filler", start: 10, duration: 4, track: 1 },

--- a/tests/release-gate/mcp-skill.test.ts
+++ b/tests/release-gate/mcp-skill.test.ts
@@ -54,8 +54,8 @@ test("generic Skill tools execute filler removal and dialogue normalization", as
       if (media.mediaId === "filler-media" && fillerAnalysisCalls > 1 && (fillerClip?.duration ?? 4) < 4) {
         return { words: [
           { text: "so", start: 0, end: 0.3, confidence: 0.99 },
-          { text: "yes", start: 1.1, end: 1.7, confidence: 0.99 },
-        ], vadSegments: [{ start: 0, end: 1.7, kind: "speech" as const }] };
+          { text: "yes", start: 1.4, end: 2, confidence: 0.99 },
+        ], vadSegments: [{ start: 0, end: 2, kind: "speech" as const }] };
       }
       return {
         ...structuredClone(media.speech!),

--- a/tests/release-gate/runner.ts
+++ b/tests/release-gate/runner.ts
@@ -192,6 +192,7 @@ async function runWorkflow(workflow: ReleaseGateWorkflow): Promise<ReleaseGateWo
   let failure: string | undefined;
   let previewed = false;
   let executed = false;
+  let plannedMutation = false;
 
   try {
     await server.connect(serverTransport);
@@ -207,6 +208,7 @@ async function runWorkflow(workflow: ReleaseGateWorkflow): Promise<ReleaseGateWo
     if (previewResult.isError) throw new Error(parseToolError(previewResult));
     const preview = parseJson(previewResult) as Record<string, any>;
     previewEvidence = sanitizePreview(preview);
+    plannedMutation = Array.isArray(preview.plan?.operations) && preview.plan.operations.length > 0;
 
     if (workflow.family === "dialogue-normalization") {
       const decision = preview.plan?.decision;
@@ -260,9 +262,9 @@ async function runWorkflow(workflow: ReleaseGateWorkflow): Promise<ReleaseGateWo
   const afterDigest = after ? canonicalSnapshotDigest(after) : "";
   const unchanged = beforeDigest !== "" && beforeDigest === afterDigest;
   const passed = actualOutcome === workflow.expectedOutcome
-    && (workflow.expectedOutcome === "verified" && workflow.scenario !== "already-normalized"
-      ? beforeDigest !== afterDigest
-      : workflow.expectedOutcome !== "verified" ? unchanged : true);
+    && (workflow.expectedOutcome === "verified"
+      ? plannedMutation ? beforeDigest !== afterDigest : unchanged
+      : unchanged);
   return {
     id: workflow.id,
     family: workflow.family,
@@ -372,10 +374,14 @@ function fillerWords(scenario: string) {
 function createFillerAnalyzer(scenario: string): SpeechAnalyzer {
   const originalWords = fillerWords(scenario);
   return {
+    capabilities: { transcription: true, vad: true },
     analyze: async ({ project }) => {
       const clip = project.timeline.clips.find((candidate) => candidate.id === "filler-clip");
       if ((clip?.duration ?? 6) >= 6 || !["obvious", "multi-filler", "verification-rollback"].includes(scenario)) {
-        return { words: structuredClone(originalWords) };
+        return {
+          words: structuredClone(originalWords),
+          vadSegments: originalWords.map((word) => ({ start: word.start, end: word.end, kind: "speech" as const })),
+        };
       }
       const removals = originalWords.filter((word) => word.filler === true);
       return {
@@ -386,6 +392,9 @@ function createFillerAnalyzer(scenario: string): SpeechAnalyzer {
             .reduce((total, removal) => total + removal.end - removal.start, 0);
           return [{ ...word, start: word.start - shift, end: word.end - shift }];
         }),
+        vadSegments: originalWords
+          .filter((word) => word.filler !== true)
+          .map((word) => ({ start: word.start, end: word.end, kind: "speech" as const })),
       };
     },
   };
@@ -458,8 +467,8 @@ function sanitizeTransaction(transaction: Record<string, any>): ReleaseGateWorkf
   return {
     status: transaction.status,
     revisionSequence: transaction.after?.revision?.sequence ?? -1,
-    verificationPassed: transaction.verification?.passed,
-    diff: transaction.diff,
+    ...(transaction.verification?.passed !== undefined ? { verificationPassed: transaction.verification.passed } : {}),
+    ...(transaction.diff !== undefined ? { diff: transaction.diff } : {}),
   };
 }
 

--- a/tests/release-gate/runner.ts
+++ b/tests/release-gate/runner.ts
@@ -383,14 +383,10 @@ function createFillerAnalyzer(scenario: string): SpeechAnalyzer {
           vadSegments: originalWords.map((word) => ({ start: word.start, end: word.end, kind: "speech" as const })),
         };
       }
-      const removals = originalWords.filter((word) => word.filler === true);
       return {
         words: originalWords.flatMap((word) => {
           if (word.filler) return [];
-          const shift = removals
-            .filter((removal) => removal.end <= word.start)
-            .reduce((total, removal) => total + removal.end - removal.start, 0);
-          return [{ ...word, start: word.start - shift, end: word.end - shift }];
+          return [{ ...word }];
         }),
         vadSegments: originalWords
           .filter((word) => word.filler !== true)

--- a/tests/release-gate/runner.ts
+++ b/tests/release-gate/runner.ts
@@ -329,6 +329,7 @@ function createFillerFixture(scenario: string): InMemoryFixture {
     projectName: "v0.0.3 Release Gate",
     timelineId: `timeline-${scenario}`,
     timelineName: scenario,
+    frameDuration: { value: "1", timescale: "30" },
     clips: [{ id: "filler-clip", mediaId: "filler-media", name: "Speech", start: 0, duration: 6, track: 1 }],
     media: [{
       mediaId: "filler-media",


### PR DESCRIPTION
Closes #43

## Summary

- implements the generic `filler-removal` Skill with revision-bound detection and safe-cut decisions
- requires speech VAD and composite timeline transactions before planning
- supports explicit `selectedCandidateIds` re-preview for suggested candidates
- returns candidate evidence, provenance, canonical diff checks, duration checks, and verified no-ops
- rolls back on partial apply, analysis, continuity, protected-speech, or unexpected-diff failures
- adds deterministic integration, MCP, release-gate, and documentation coverage

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm run test` (551 passing)
- `pnpm run check:boundaries`
