### PR TITLE
Discover built-in Final Cut Motion titles

### DIFF
--- a/adapters/final-cut/swift-bridge/FinalCutWorkflowExtension/FinalCutLiveWorkflowExtension.swift
+++ b/adapters/final-cut/swift-bridge/FinalCutWorkflowExtension/FinalCutLiveWorkflowExtension.swift
@@ -132,6 +132,7 @@ private struct NativeCapabilities: Codable {
     let mediaAppend: CapabilityDescriptor
     let mediaInsert: CapabilityDescriptor
     let titlePlacement: CapabilityDescriptor
+    let titleDiscovery: CapabilityDescriptor
     let transitionDiscovery: CapabilityDescriptor
     let transitionPlacement: CapabilityDescriptor
     let timelineFocus: CapabilityDescriptor
@@ -239,6 +240,7 @@ private func metadataOnlyCapabilityFamilies() -> CapabilityFamilies {
             mediaAppend: unavailableCapability(backend: nativeBackend, operation: "native media append"),
             mediaInsert: unavailableCapability(backend: nativeBackend, operation: "native media insert"),
             titlePlacement: unavailableCapability(backend: nativeBackend, operation: "native title placement"),
+            titleDiscovery: unavailableCapability(backend: nativeBackend, operation: "native title discovery"),
             transitionDiscovery: unavailableCapability(backend: nativeBackend, operation: "native transition discovery"),
             transitionPlacement: unavailableCapability(backend: nativeBackend, operation: "native transition placement"),
             timelineFocus: unavailableCapability(backend: nativeBackend, operation: "native timeline focus"),

--- a/adapters/final-cut/typescript/src/assets.ts
+++ b/adapters/final-cut/typescript/src/assets.ts
@@ -46,7 +46,15 @@ export class FinalCutAssetRegistry {
     if (!this.cached) this.cached = await this.scan();
     const filesystemAssets = filterAssets(this.cached, query);
     if (!this.nativeTitleProvider || (query?.kind && query.kind !== "title")) return filesystemAssets;
-    const nativeTitles = await this.nativeTitleProvider.searchTitles(query?.query ?? "");
+    let nativeTitles: NativeFinalCutTitleMatch[];
+    try {
+      nativeTitles = await this.nativeTitleProvider.searchTitles(query?.query ?? "");
+    } catch (error) {
+      // Filesystem assets remain truthful when the optional native browser is
+      // unavailable; native-only queries still fail closed below.
+      if (filesystemAssets.length > 0) return filesystemAssets;
+      throw error;
+    }
     const composed = [...filesystemAssets, ...nativeTitles.map(nativeTitleAsset)];
     return filterAssets(dedupeAssets(composed), query);
   }
@@ -105,12 +113,28 @@ async function scanCategory(directory: string, kind: EditorAsset["kind"], assets
         identity: path,
         provider: "filesystem-motion-template",
         source: "filesystem",
+        discovery: {
+          backend: "filesystem-motion-template",
+          guarantee: "observed",
+        },
+        ...(kind === "title"
+          ? {
+              placement: {
+                backend: "final-cut-accessibility",
+                guarantee: "native-verified",
+                operation: "editor.native.title.add",
+              },
+            }
+          : {}),
       },
     });
   }
 }
 
 function nativeTitleAsset(match: NativeFinalCutTitleMatch): EditorAsset {
+  if (!match.id.startsWith("final-cut:title:") || !match.identity.trim() || !match.name.trim()) {
+    throw new Error("FINAL_CUT_NATIVE_TITLE_ID_UNAVAILABLE: native title provider returned an unstable identity");
+  }
   return {
     id: match.id,
     kind: "title",
@@ -120,6 +144,15 @@ function nativeTitleAsset(match: NativeFinalCutTitleMatch): EditorAsset {
       identity: match.identity,
       provider: "final-cut-accessibility",
       source: "final-cut-titles-browser",
+      discovery: {
+        backend: "final-cut-accessibility",
+        guarantee: "observed",
+      },
+      placement: {
+        backend: "final-cut-accessibility",
+        guarantee: "native-verified",
+        operation: "editor.native.title.add",
+      },
     },
   };
 }

--- a/adapters/final-cut/typescript/src/assets.ts
+++ b/adapters/final-cut/typescript/src/assets.ts
@@ -2,6 +2,7 @@ import { readFile, readdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, join, resolve } from "node:path";
 import type { AssetSearchQuery, EditorAsset } from "@framekit/runtime";
+import type { NativeFinalCutTitleMatch } from "./native.js";
 
 const CATEGORY_BY_DIRECTORY: Record<string, EditorAsset["kind"]> = {
   "Audio Effects.localized": "audio-effect",
@@ -16,6 +17,11 @@ const BUNDLE_SUFFIXES = new Set([".moef", ".moti", ".motn", ".motr"]);
 
 export interface FinalCutAssetRegistryOptions {
   roots?: string[];
+  nativeTitleProvider?: Pick<NativeTitleProvider, "searchTitles">;
+}
+
+export interface NativeTitleProvider {
+  searchTitles(query: string): Promise<NativeFinalCutTitleMatch[]>;
 }
 
 export function defaultFinalCutAssetRoots(): string[] {
@@ -28,15 +34,21 @@ export function defaultFinalCutAssetRoots(): string[] {
 
 export class FinalCutAssetRegistry {
   private readonly roots: string[];
+  private readonly nativeTitleProvider?: Pick<NativeTitleProvider, "searchTitles">;
   private cached?: EditorAsset[];
 
   public constructor(options: FinalCutAssetRegistryOptions = {}) {
     this.roots = (options.roots ?? defaultFinalCutAssetRoots()).map((root) => resolve(root));
+    this.nativeTitleProvider = options.nativeTitleProvider;
   }
 
   public async listAssets(query?: AssetSearchQuery): Promise<EditorAsset[]> {
     if (!this.cached) this.cached = await this.scan();
-    return filterAssets(this.cached, query);
+    const filesystemAssets = filterAssets(this.cached, query);
+    if (!this.nativeTitleProvider || (query?.kind && query.kind !== "title")) return filesystemAssets;
+    const nativeTitles = await this.nativeTitleProvider.searchTitles(query?.query ?? "");
+    const composed = [...filesystemAssets, ...nativeTitles.map(nativeTitleAsset)];
+    return filterAssets(dedupeAssets(composed), query);
   }
 
   public refresh(): void {
@@ -83,13 +95,39 @@ async function scanCategory(directory: string, kind: EditorAsset["kind"], assets
     const path = join(directory, entry.name);
     const metadata = await readMetadata(path);
     assets.push({
-      id: path,
+      id: `filesystem:${kind}:${path}`,
       kind,
       name: metadata.name ?? basename(entry.name, extension(entry.name)),
       vendor: metadata.vendor ?? "Unknown",
-      metadata: { path, ...metadata },
+      metadata: {
+        path,
+        ...metadata,
+        identity: path,
+        provider: "filesystem-motion-template",
+        source: "filesystem",
+      },
     });
   }
+}
+
+function nativeTitleAsset(match: NativeFinalCutTitleMatch): EditorAsset {
+  return {
+    id: match.id,
+    kind: "title",
+    name: match.name,
+    vendor: match.vendor,
+    metadata: {
+      identity: match.identity,
+      provider: "final-cut-accessibility",
+      source: "final-cut-titles-browser",
+    },
+  };
+}
+
+function dedupeAssets(assets: EditorAsset[]): EditorAsset[] {
+  return assets
+    .sort((left, right) => `${left.kind}:${left.name}:${left.id}`.localeCompare(`${right.kind}:${right.name}:${right.id}`))
+    .filter((asset, index, all) => index === all.findIndex((candidate) => candidate.id === asset.id));
 }
 
 async function readMetadata(bundlePath: string): Promise<{ name?: string; vendor?: string; [key: string]: unknown }> {

--- a/adapters/final-cut/typescript/src/assets.ts
+++ b/adapters/final-cut/typescript/src/assets.ts
@@ -50,9 +50,9 @@ export class FinalCutAssetRegistry {
     try {
       nativeTitles = await this.nativeTitleProvider.searchTitles(query?.query ?? "");
     } catch (error) {
-      // Filesystem assets remain truthful when the optional native browser is
-      // unavailable; native-only queries still fail closed below.
-      if (filesystemAssets.length > 0) return filesystemAssets;
+      // Filesystem assets remain usable when the optional native browser is
+      // unavailable, but keep the native diagnostic visible in the response.
+      if (filesystemAssets.length > 0) return withNativeTitleDiagnostic(filesystemAssets, error);
       throw error;
     }
     const composed = [...filesystemAssets, ...nativeTitles.map(nativeTitleAsset)];
@@ -161,6 +161,27 @@ function dedupeAssets(assets: EditorAsset[]): EditorAsset[] {
   return assets
     .sort((left, right) => `${left.kind}:${left.name}:${left.id}`.localeCompare(`${right.kind}:${right.name}:${right.id}`))
     .filter((asset, index, all) => index === all.findIndex((candidate) => candidate.id === asset.id));
+}
+
+function withNativeTitleDiagnostic(assets: EditorAsset[], error: unknown): EditorAsset[] {
+  const native = {
+    backend: "final-cut-accessibility",
+    guarantee: "none",
+    unavailableReason: error instanceof Error ? error.message : String(error),
+  };
+  return assets.map((asset) => {
+    const discovery = asset.metadata.discovery;
+    return {
+      ...asset,
+      metadata: {
+        ...asset.metadata,
+        discovery: {
+          ...(typeof discovery === "object" && discovery !== null ? discovery : {}),
+          native: { ...native },
+        },
+      },
+    };
+  });
 }
 
 async function readMetadata(bundlePath: string): Promise<{ name?: string; vendor?: string; [key: string]: unknown }> {

--- a/adapters/final-cut/typescript/src/native.ts
+++ b/adapters/final-cut/typescript/src/native.ts
@@ -179,6 +179,14 @@ export interface NativeFinalCutTransitionMatch {
   identity: string;
 }
 
+export interface NativeFinalCutTitleMatch {
+  id: string;
+  kind: "title";
+  name: string;
+  vendor: string;
+  identity: string;
+}
+
 export interface NativeFinalCutTransitionPreview {
   previewToken: string;
   asset: NativeFinalCutTransitionMatch;
@@ -389,6 +397,7 @@ export interface NativeFinalCutEditor {
   executeInsertMedia(previewToken: string): Promise<NativeFinalCutMediaInsertionResult>;
   previewTitleAdd(request: NativeFinalCutTitleRequest): Promise<NativeFinalCutTitlePreview>;
   executeTitleAdd(previewToken: string): Promise<NativeFinalCutTitleResult>;
+  searchTitles(query: string): Promise<NativeFinalCutTitleMatch[]>;
   searchTransitions(query: string): Promise<NativeFinalCutTransitionMatch[]>;
   previewTransitionAdd(request: NativeFinalCutTransitionRequest): Promise<NativeFinalCutTransitionPreview>;
   executeTransitionAdd(previewToken: string): Promise<NativeFinalCutTransitionResult>;
@@ -1069,6 +1078,10 @@ export class FinalCutNativeAutomationAdapter implements NativeFinalCutEditor {
     return this.withNativeUi(() => this.executeTitleAddNative(previewToken));
   }
 
+  public async searchTitles(query: string): Promise<NativeFinalCutTitleMatch[]> {
+    return this.withNativeUi(() => this.searchTitlesNative(query));
+  }
+
   public async searchTransitions(query: string): Promise<NativeFinalCutTransitionMatch[]> {
     return this.withNativeUi(() => this.searchTransitionsNative(query));
   }
@@ -1079,6 +1092,30 @@ export class FinalCutNativeAutomationAdapter implements NativeFinalCutEditor {
 
   public async executeTransitionAdd(previewToken: string): Promise<NativeFinalCutTransitionResult> {
     return this.withNativeUi(() => this.executeTransitionAddNative(previewToken));
+  }
+
+  private async searchTitlesNative(query: string): Promise<NativeFinalCutTitleMatch[]> {
+    this.assertEnabled();
+    const normalizedQuery = query.trim();
+    const context = await this.requireTimelineContext();
+    if (!context.frontmost) throw new Error("FINAL_CUT_NATIVE_NOT_FRONTMOST: Final Cut must be frontmost for title discovery");
+    try {
+      const identity = titleIdentityFromId(normalizedQuery);
+      let lastError: unknown;
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        try {
+          return parseTitleMatches(await this.executeNativeScript(
+            titleSearchScript(identity ?? normalizedQuery, identity !== undefined),
+          ));
+        } catch (error) {
+          lastError = error;
+          if (attempt === 0) await this.sleep(250);
+        }
+      }
+      throw lastError;
+    } catch (error) {
+      throw new Error(`${nativeErrorCode(error)}: ${String(error)}`);
+    }
   }
 
   private async searchTransitionsNative(query: string): Promise<NativeFinalCutTransitionMatch[]> {
@@ -2219,6 +2256,30 @@ function verifyNativeTransition(
     verified: true,
     detail: `Final Cut verified ${preview.asset.name} at ${preview.editPoint.value}/${preview.editPoint.timescale} for requested and observed duration ${observedDuration.value}/${observedDuration.timescale} at revision ${afterLive.revision.id}`,
   };
+}
+
+function parseTitleMatches(output: string): NativeFinalCutTitleMatch[] {
+  const matches = new Map<string, NativeFinalCutTitleMatch>();
+  for (const record of output.split(String.fromCharCode(30)).map((value) => value.trim()).filter(Boolean)) {
+    const [name = "", identity = ""] = record.split(String.fromCharCode(31));
+    if (!name || !identity) {
+      throw new Error("FINAL_CUT_NATIVE_TITLE_ID_UNAVAILABLE: title browser did not expose stable identities");
+    }
+    const match = {
+      id: `final-cut:title:${identity}`,
+      kind: "title" as const,
+      name,
+      vendor: "Final Cut Pro",
+      identity,
+    };
+    matches.set(match.id, match);
+  }
+  return [...matches.values()].sort((left, right) => `${left.name}:${left.identity}`.localeCompare(`${right.name}:${right.identity}`));
+}
+
+function titleIdentityFromId(value: string): string | undefined {
+  const prefix = "final-cut:title:";
+  return value.startsWith(prefix) ? value.slice(prefix.length) : undefined;
 }
 
 function parseTransitionMatches(output: string): NativeFinalCutTransitionMatch[] {
@@ -3987,7 +4048,114 @@ function occurrenceRangeEndpointScript(timelineOffset: number, endpoint: "start"
   end tell`;
 }
 
-function titleAssetSelectionScript(assetName: string): string {
+function titleSearchScript(query: string, identityQuery = false): string {
+  const searchQuery = identityQuery ? "" : query;
+  return `
+  using terms from application "System Events"
+    on titlePaneVisible(candidate, mainOrigin, mainSize)
+      try
+        set candidatePosition to position of candidate
+        set candidateSize to size of candidate
+        set candidateX to item 1 of candidatePosition
+        set candidateY to item 2 of candidatePosition
+        set candidateRight to candidateX + (item 1 of candidateSize)
+        set candidateBottom to candidateY + (item 2 of candidateSize)
+        set minimumX to (item 1 of mainOrigin) + ((item 1 of mainSize) * 0.02)
+        set minimumY to (item 2 of mainOrigin) + ((item 2 of mainSize) * 0.25)
+        set maximumX to (item 1 of mainOrigin) + (item 1 of mainSize)
+        set maximumY to (item 2 of mainOrigin) + (item 2 of mainSize)
+        return candidateRight is greater than minimumX and candidateBottom is greater than minimumY and candidateX is less than maximumX and candidateY is less than maximumY
+      on error
+        return false
+      end try
+    end titlePaneVisible
+
+    on titleCandidateName(candidate)
+      set candidateName to ""
+      try
+        set candidateName to name of candidate as text
+      end try
+      if candidateName is "missing value" then set candidateName to ""
+      if candidateName is "" then
+        try
+          set candidateName to value of candidate as text
+        end try
+      end if
+      if candidateName is "missing value" then set candidateName to ""
+      return candidateName
+    end titleCandidateName
+
+    on collectTitleMatches(nodes, depth, queryText, identityQuery, seenIdentities, mainOrigin, mainSize)
+      if depth > 12 then return ""
+      set output to ""
+      repeat with candidateIndex from 1 to count of nodes
+        try
+          set candidate to contents of item candidateIndex of nodes
+          if my titlePaneVisible(candidate, mainOrigin, mainSize) then
+            set candidateName to my titleCandidateName(candidate)
+            set candidateIdentity to ""
+            try
+              set candidateIdentity to value of attribute "AXIdentifier" of candidate as text
+            end try
+            set matches to false
+            if candidateName is not "" and candidateIdentity is not "" then
+              if identityQuery then
+                set matches to candidateIdentity is queryText
+              else
+                set matches to candidateName contains queryText
+              end if
+            end if
+            if matches and seenIdentities does not contain candidateIdentity then
+              set end of seenIdentities to candidateIdentity
+              set output to output & candidateName & (ASCII character 31) & candidateIdentity & (ASCII character 30)
+            end if
+            set output to output & my collectTitleMatches(UI elements of candidate, depth + 1, queryText, identityQuery, seenIdentities, mainOrigin, mainSize)
+          end if
+        on error
+          -- Ignore inaccessible descendants and continue the bounded scan.
+        end try
+      end repeat
+      return output
+    end collectTitleMatches
+  end using terms from
+  tell application "System Events"
+    tell process "Final Cut Pro"
+      ${requireFrontmostAppleScript()}
+      set mainWindow to window "Final Cut Pro"
+      set mainOrigin to position of mainWindow
+      set mainSize to size of mainWindow
+      click at {(item 1 of mainOrigin) + 104, (item 2 of mainOrigin) + 53}
+      delay 0.3
+      set titleSearchField to missing value
+      repeat with candidate in entire contents of front window
+        try
+          set candidateRole to role of candidate as text
+          set candidateDescription to description of candidate as text
+          if (candidateRole is "AXTextField" or candidateRole is "AXSearchField") and (candidateDescription contains "search" or candidateDescription contains "Search") then
+            set titleSearchField to candidate
+            exit repeat
+          end if
+        end try
+      end repeat
+      if titleSearchField is not missing value then
+        set value of titleSearchField to ${appleScriptString(searchQuery)}
+        try
+          set value of attribute "AXFocused" of titleSearchField to true
+        end try
+      else if ${searchQuery === "" ? "false" : "true"} then
+        click at {(item 1 of mainOrigin) + 280, (item 2 of mainOrigin) + 83}
+        keystroke "a" using {command down}
+        key code 51
+        keystroke ${appleScriptString(searchQuery)}
+      end if
+      delay 0.6
+      set seenIdentities to {}
+      return my collectTitleMatches(UI elements of mainWindow, 0, ${appleScriptString(identityQuery ? query : searchQuery)}, ${identityQuery ? "true" : "false"}, seenIdentities, mainOrigin, mainSize)
+    end tell
+  end tell`;
+}
+
+function titleAssetSelectionScript(assetName: string, assetIdentity?: string): string {
   return `
 tell application "System Events"
   tell process "Final Cut Pro"

--- a/adapters/final-cut/typescript/src/native.ts
+++ b/adapters/final-cut/typescript/src/native.ts
@@ -1098,10 +1098,9 @@ export class FinalCutNativeAutomationAdapter implements NativeFinalCutEditor {
 
   private async searchTitlesNative(query: string): Promise<NativeFinalCutTitleMatch[]> {
     this.assertEnabled();
-    const normalizedQuery = query.trim();
-    const context = await this.requireTimelineContext();
-    if (!context.frontmost) throw new Error("FINAL_CUT_NATIVE_NOT_FRONTMOST: Final Cut must be frontmost for title discovery");
     try {
+      await this.ensureTitleBrowserReady();
+      const normalizedQuery = query.trim();
       const identity = titleIdentityFromId(normalizedQuery);
       let lastError: unknown;
       for (let attempt = 0; attempt < 2; attempt += 1) {
@@ -1118,6 +1117,13 @@ export class FinalCutNativeAutomationAdapter implements NativeFinalCutEditor {
     } catch (error) {
       throw new Error(`${nativeErrorCode(error)}: ${String(error)}`);
     }
+  }
+
+  private async ensureTitleBrowserReady(): Promise<void> {
+    const output = await this.executeNativeScript(titleBrowserPreflightScript());
+    const [frontmost = "false", windowAvailable = "false"] = output.split(String.fromCharCode(31));
+    if (frontmost !== "true") throw new Error("FINAL_CUT_NATIVE_NOT_FRONTMOST: Final Cut must be frontmost for title discovery");
+    if (windowAvailable !== "true") throw new Error("FINAL_CUT_NATIVE_TITLE_BROWSER_UNAVAILABLE: Final Cut's Titles browser is unavailable");
   }
 
   private async searchTransitionsNative(query: string): Promise<NativeFinalCutTransitionMatch[]> {
@@ -4160,6 +4166,25 @@ function titleSearchScript(query: string, identityQuery = false): string {
       return my collectTitleMatches(UI elements of mainWindow, 0, ${appleScriptString(identityQuery ? query : searchQuery)}, ${identityQuery ? "true" : "false"}, seenIdentities, mainOrigin, mainSize)
     end tell
   end tell`;
+}
+
+function titleBrowserPreflightScript(): string {
+  return `
+on titleBrowserPreflightResult(processFrontmost, browserWindowAvailable)
+  return processFrontmost & (ASCII character 31) & browserWindowAvailable
+end titleBrowserPreflightResult
+
+tell application "System Events"
+  tell process "Final Cut Pro"
+    set processFrontmost to frontmost as text
+    set browserWindowAvailable to false
+    try
+      set browserWindow to window "Final Cut Pro"
+      set browserWindowAvailable to true
+    end try
+    return my titleBrowserPreflightResult(processFrontmost, browserWindowAvailable)
+  end tell
+end tell`;
 }
 
 function titleAssetSelectionScript(assetName: string, assetIdentity?: string): string {

--- a/adapters/final-cut/typescript/src/native.ts
+++ b/adapters/final-cut/typescript/src/native.ts
@@ -2135,9 +2135,7 @@ function assertNativeTitleAsset(asset: EditorAsset): void {
 
 function nativeTitleIdentity(asset: EditorAsset): string | undefined {
   const idIdentity = titleIdentityFromId(asset.id);
-  if (idIdentity) return idIdentity;
-  const metadataIdentity = asset.metadata.identity;
-  return typeof metadataIdentity === "string" && metadataIdentity.trim() ? metadataIdentity : undefined;
+  return idIdentity?.trim() || undefined;
 }
 
 function publicTitleAsset(asset: EditorAsset): Pick<EditorAsset, "id" | "kind" | "name" | "vendor"> {

--- a/adapters/final-cut/typescript/src/native.ts
+++ b/adapters/final-cut/typescript/src/native.ts
@@ -303,6 +303,7 @@ export interface NativeFinalCutCapabilities {
   mediaAppend: boolean;
   mediaInsert: boolean;
   titlePlacement: boolean;
+  titleDiscovery?: boolean;
   transitionDiscovery?: boolean;
   transitionPlacement?: boolean;
   timelineFocus: boolean;
@@ -505,6 +506,7 @@ export class FinalCutNativeAutomationAdapter implements NativeFinalCutEditor {
       mediaAppend: this.enabled,
       mediaInsert: this.enabled,
       titlePlacement: this.enabled,
+      titleDiscovery: this.enabled,
       transitionDiscovery: this.enabled,
       transitionPlacement: this.enabled,
       timelineFocus: this.enabled,
@@ -1369,7 +1371,7 @@ export class FinalCutNativeAutomationAdapter implements NativeFinalCutEditor {
     const endTimecode = this.toTimecode(preview.end, beforeLive);
     try {
       await this.executeNativeSequence(async () => {
-        await this.executor(titleAssetSelectionScript(preview.asset.name));
+        await this.executor(titleAssetSelectionScript(preview.asset.name, nativeTitleIdentity(preview.asset)));
         await this.focusTimelineForMediaInsertion();
         await this.executor(setPlayheadScript(startTimecode));
         await this.waitForPlayhead(preview.start, beforeLive.sequence?.id);
@@ -2129,6 +2131,13 @@ function verifyNativeUndo(
 function assertNativeTitleAsset(asset: EditorAsset): void {
   if (!asset.id.trim() || !asset.name.trim()) throw new Error("TITLE_ASSET_NOT_FOUND: native title asset identity is incomplete");
   if (asset.kind !== "title") throw new Error(`TITLE_ASSET_INCOMPATIBLE: ${asset.id} is not a Final Cut title asset`);
+}
+
+function nativeTitleIdentity(asset: EditorAsset): string | undefined {
+  const idIdentity = titleIdentityFromId(asset.id);
+  if (idIdentity) return idIdentity;
+  const metadataIdentity = asset.metadata.identity;
+  return typeof metadataIdentity === "string" && metadataIdentity.trim() ? metadataIdentity : undefined;
 }
 
 function publicTitleAsset(asset: EditorAsset): Pick<EditorAsset, "id" | "kind" | "name" | "vendor"> {
@@ -4162,6 +4171,7 @@ tell application "System Events"
     ${requireFrontmostAppleScript()}
     set mainWindow to window "Final Cut Pro"
     set mainOrigin to position of mainWindow
+    set targetIdentity to ${appleScriptString(assetIdentity ?? "")}
     -- Final Cut 10.7 exposes the Titles tab as a custom Browser control. Its
     -- Control-Command-1 shortcut is not stable across releases (on some
     -- builds it opens Export), so use the bounded window-relative fallback.
@@ -4210,14 +4220,14 @@ tell application "System Events"
           set candidateIdentity to ""
           try
             set candidateSourceIdentity to value of attribute "AXIdentifier" of candidate as text
-            if candidateSourceIdentity is not "" then set candidateIdentity to "source:" & candidateSourceIdentity
+            if candidateSourceIdentity is not "" then set candidateIdentity to candidateSourceIdentity
           end try
           if candidateIdentity is "" then
             set candidateIdentity to (candidateRole as text) & "|" & (candidateName as text) & "|" & ((position of candidate) as text) & "|" & ((size of candidate) as text)
           end if
-          if (candidateName is ${appleScriptString(assetName)} or candidateName contains ${appleScriptString(assetName)}) and seenTitleIdentities does not contain candidateIdentity then
+          if ((targetIdentity is not "" and candidateIdentity is targetIdentity) or (targetIdentity is "" and (candidateName is ${appleScriptString(assetName)} or candidateName contains ${appleScriptString(assetName)}))) and seenTitleIdentities does not contain candidateIdentity then
             set end of seenTitleIdentities to candidateIdentity
-            if candidateName is ${appleScriptString(assetName)} then
+            if targetIdentity is not "" or candidateName is ${appleScriptString(assetName)} then
               set exactMatchCount to exactMatchCount + 1
               set exactTitleItem to candidate
             else

--- a/apps/mcp-server/src/main.ts
+++ b/apps/mcp-server/src/main.ts
@@ -76,6 +76,13 @@ const nativeOperationLease = autoConnect
       () => connection?.startAutoConnect(),
     )
   : undefined;
+const nativeEditor = liveMode
+  ? new FinalCutNativeAutomationAdapter({
+      enabled: !headlessFinalCut && process.env.FRAMEKIT_FINAL_CUT_NATIVE_WRITES === "1",
+      liveState: () => liveAdapter!.readLiveState(),
+      nativeOperationLease,
+    })
+  : undefined;
 
 const editor = liveMode
   ? new FinalCutSessionAdapter({
@@ -91,6 +98,7 @@ const editor = liveMode
           ?.split(process.platform === "win32" ? ";" : ":")
           .map((root) => root.trim())
           .filter(Boolean),
+        nativeTitleProvider: nativeEditor?.capabilities().titleDiscovery ? nativeEditor : undefined,
       }),
     })
   : fixture;
@@ -111,13 +119,6 @@ const analyzers = liveMode
     };
 
 const runtime = new AgentVideoRuntime(editor, analyzers);
-const nativeEditor = liveMode
-  ? new FinalCutNativeAutomationAdapter({
-      enabled: !headlessFinalCut && process.env.FRAMEKIT_FINAL_CUT_NATIVE_WRITES === "1",
-      liveState: () => liveAdapter!.readLiveState(),
-      nativeOperationLease,
-    })
-  : undefined;
 const disposableNative = liveMode && !headlessFinalCut && !fcpxmlPath && nativeEditor
   ? new DisposableNativeEditWorkflow({
       native: nativeEditor,

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -1525,6 +1525,7 @@ async function inspectMcpEditor(runtime: AgentVideoRuntime, options: McpServerOp
       mediaAppend: Boolean(native?.mediaAppend),
       mediaInsert: Boolean(native?.mediaInsert),
       titlePlacement: Boolean(native?.titlePlacement),
+      titleDiscovery: Boolean(native?.titleDiscovery),
       transitionDiscovery: Boolean(native?.transitionDiscovery),
       transitionPlacement: Boolean(native?.transitionPlacement),
       timelineFocus: Boolean(native?.timelineFocus),

--- a/docs/final-cut/README.md
+++ b/docs/final-cut/README.md
@@ -4,7 +4,8 @@ Framekit uses two distinct Final Cut backends:
 
 - FCPXML interchange for supported canonical timeline reads and artifact writes.
 - `FinalCutSessionAdapter` to compose the document and live providers.
-- Configurable local JSON analyzers and read-only Motion-template asset discovery.
+- Configurable local JSON analyzers, filesystem Motion-template discovery, and
+  opt-in headed Titles-browser discovery with provider-qualified asset IDs.
 - Guarded selection-scoped native UI edits through Accessibility automation.
 - A native Workflow Extension for live project/sequence metadata, playhead,
   selected range, and change events.

--- a/docs/final-cut/workflow-extension.md
+++ b/docs/final-cut/workflow-extension.md
@@ -9,6 +9,8 @@ rational playhead time, sequence time range, and observer-backed change events.
 
 It does not currently perform direct timeline writes, rollback, export,
 playback control, speech analysis, audio analysis, or native asset discovery.
+Native Titles-browser discovery is performed separately by the headed MCP
+Accessibility provider and is never inferred from this metadata-only bridge.
 Selection-scoped native writes are performed separately by the MCP process
 through guarded macOS Accessibility automation; the extension continues to
 provide live state and change events only.

--- a/docs/mcp/capabilities-and-errors.md
+++ b/docs/mcp/capabilities-and-errors.md
@@ -85,8 +85,10 @@ assets use `filesystem-motion-template`; headed Titles-browser assets use
 `final-cut:title:<AXIdentifier>`. Discovery has an `observed` guarantee and is
 not placement proof. Native title placement remains a separate operation with
 explicit text, timing, target, revision, and readback verification. If the
-Titles browser or Accessibility is unavailable, the provider fails closed with
-the native error instead of inventing an asset.
+Titles browser or Accessibility is unavailable, filesystem results may remain
+usable but include `metadata.discovery.native` with the native backend,
+`guarantee: "none"`, and `unavailableReason`; native-only queries fail closed
+with the native error instead of inventing an asset.
 
 `editor.inspect` also returns an inspect-time `preflight` report. Its `mode` is
 `fixture`, `fcpxml-artifact`, `metadata-only`, `canonical-live`, or

--- a/docs/mcp/capabilities-and-errors.md
+++ b/docs/mcp/capabilities-and-errors.md
@@ -66,7 +66,7 @@ The families are:
 | `observation` | `timeline`, `media` | Live metadata or canonical observation |
 | `canonicalDocument` | `read`, `write`, `artifactWrite` | Canonical timeline guarantees |
 | `editing` | `compositeTransactions`, `titlePlacement`, `pictureInPicture`, `masking` | Routed editing operations and explicit unsupported boundaries |
-| `native` | `selectionWrite`, `projectCreation`, `clipInsertion`, `clipMovement`, `titlePlacement` | Individual Final Cut Accessibility operations |
+| `native` | `selectionWrite`, `titleDiscovery`, `titlePlacement`, `projectCreation`, `clipInsertion`, `clipMovement` | Individual Final Cut Accessibility operations |
 | `publishing` | `projectCreation` | Importing a verified artifact as a new project |
 | `export` | `timeline` | Verified local video export |
 | `analyzers` | `speechTranscribe`, `speechVad`, `audioLoudness`, `visualTrack` | Configured analysis providers |
@@ -77,6 +77,16 @@ project creation, clip insertion, or clip movement remains present with
 media insertion operation does not imply that any other native operation is
 available. `ready` is only a connection state and never implies arbitrary
 editability.
+
+`editor.assets` preserves its array response while attaching provider
+provenance under each asset's `metadata.discovery`. Filesystem Motion-template
+assets use `filesystem-motion-template`; headed Titles-browser assets use
+`final-cut-accessibility` and stable IDs such as
+`final-cut:title:<AXIdentifier>`. Discovery has an `observed` guarantee and is
+not placement proof. Native title placement remains a separate operation with
+explicit text, timing, target, revision, and readback verification. If the
+Titles browser or Accessibility is unavailable, the provider fails closed with
+the native error instead of inventing an asset.
 
 `editor.inspect` also returns an inspect-time `preflight` report. Its `mode` is
 `fixture`, `fcpxml-artifact`, `metadata-only`, `canonical-live`, or

--- a/docs/mcp/final-cut-live.md
+++ b/docs/mcp/final-cut-live.md
@@ -239,11 +239,17 @@ already at or beyond the current duration returns a verified no-op.
 
 ## Native title placement
 
-Native titles use the installed Motion-template registry and a guarded
-preview/execute flow:
+Native titles use the composed Motion-template registry and headed Titles
+browser with a guarded preview/execute flow:
 
-1. Call `editor.assets` with `kind: "title"` and choose one returned `assetId`.
-2. Call `editor.native.title.add.preview` with that `assetId`, title `text`,
+1. Call `editor.inspect` and require
+   `capabilities.families.native.titleDiscovery` and `titlePlacement` when
+   using a headed native title. Call `editor.assets` with `kind: "title"` and
+   choose one returned provider-qualified `id`. Native browser results use IDs
+   such as `final-cut:title:<AXIdentifier>` and identify their source under
+   `metadata.discovery`; filesystem results use
+   `filesystem:title:<absolute-path>`.
+2. Call `editor.native.title.add.preview` with that `id` as `assetId`, title `text`,
    and a positive rational `duration`. Omit `start` to use the current
    playhead; provide `start` to place the title across an explicit range.
 3. Confirm the returned title, range, sequence, and revision, then call
@@ -260,8 +266,10 @@ misaligned timing and `FINAL_CUT_NATIVE_TITLE_ASSET_AMBIGUOUS` when the Titles
 browser exposes multiple matching templates. The native adapter does
 not invent title assets or claim canonical timeline enumeration; it uses
 Accessibility automation to open Final Cut's Titles and Generators browser,
-select the discovered template, apply the text, and verify the selected title
-and live revision.
+select the discovered template by its stable AX identity, apply the text, and
+verify the selected title and live revision. Missing Accessibility permission,
+an unavailable browser, or a missing AX identity is not converted into a
+fabricated asset.
 
 ## Native transition placement
 

--- a/docs/mcp/final-cut-live.md
+++ b/docs/mcp/final-cut-live.md
@@ -248,7 +248,9 @@ browser with a guarded preview/execute flow:
    choose one returned provider-qualified `id`. Native browser results use IDs
    such as `final-cut:title:<AXIdentifier>` and identify their source under
    `metadata.discovery`; filesystem results use
-   `filesystem:title:<absolute-path>`.
+   `filesystem:title:<absolute-path>`. If native discovery is unavailable while
+   filesystem results remain usable, inspect `metadata.discovery.native` for
+   the native backend, `guarantee: "none"`, and `unavailableReason`.
 2. Call `editor.native.title.add.preview` with that `id` as `assetId`, title `text`,
    and a positive rational `duration`. Omit `start` to use the current
    playhead; provide `start` to place the title across an explicit range.

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -93,7 +93,7 @@ this routing tool.
 | `visual.analyze` | Scenes, subjects, motion, and keyframes | Fixture or configured local JSON provider |
 | `media.understand` | Combined speech, audio, visual, and metadata understanding | Returns per-capability analyzed or unavailable statuses |
 | `rough-cut.plan` | Explainable read-only shot plan from semantic media ranges | Requires analyzed usable ranges; never mutates the timeline |
-| `editor.assets` | Search native editor assets by text, kind, or vendor | Fixture or Motion-template registry |
+| `editor.assets` | Search editor assets by text, kind, or vendor; IDs are provider-qualified and include discovery provenance | Fixture, filesystem Motion-template registry, or headed Final Cut Titles browser; native discovery requires Accessibility and Final Cut frontmost |
 | `edit.diff` | Transaction diff | Fixture/FCPXML transaction path or a canonical-capable live Final Cut bridge |
 | `edit.verify` | Verification results | Fixture/FCPXML transaction path or a canonical-capable live Final Cut bridge |
 | `edit.undo` | Restore a transaction | Fixture/FCPXML transaction path or a canonical-capable live Final Cut bridge |

--- a/docs/tests/final-cut-live-e2e.md
+++ b/docs/tests/final-cut-live-e2e.md
@@ -73,6 +73,26 @@ Then verify `project.inspect`, `timeline.inspect`, `context.inspect`,
 JSON analyzers and Motion-template roots separately when testing media analysis
 and `editor.assets`.
 
+## Headed native title discovery and placement
+
+Use a disposable Final Cut project with the Titles browser visible to prove
+native discovery and placement separately from fixture and FCPXML evidence:
+
+```sh
+FRAMEKIT_FINAL_CUT_E2E_PROJECT="Framekit Native E2E" \
+FRAMEKIT_FINAL_CUT_E2E_TITLE_QUERY="Basic Title" \
+FRAMEKIT_FINAL_CUT_E2E_TITLE_TEXT="Framekit title proof" \
+pnpm run test:final-cut-title-headed
+```
+
+The runner requires a provider-qualified `final-cut:title:` asset with
+`final-cut-accessibility` discovery provenance, previews placement at the live
+playhead, executes with explicit text and duration, verifies the new revision
+and selected title, then restores the disposable project with native Undo. Its
+JSON evidence records discovery and placement as separate sections. Missing
+Accessibility permission, an unavailable Titles browser, ambiguous results,
+or missing identities fail closed.
+
 ## Safety boundary
 
 The live-only test must not write timeline edits, alter media, or claim full

--- a/docs/tests/mcp-qa-prompt.md
+++ b/docs/tests/mcp-qa-prompt.md
@@ -51,7 +51,7 @@ live-write は、ユーザーが明示的に許可し、TARGET_PROJECT が使い
 2. 次の capability を operation ごとに表にする。
    - canonical document: read / write / artifactWrite
    - observation: live state / timeline snapshot / changes
-   - native: selectionWrite / clipInsertion / clipMovement / titlePlacement / undo / timelineFocus
+   - native: selectionWrite / titleDiscovery / clipInsertion / clipMovement / titlePlacement / undo / timelineFocus
    - publishing: projectCreation
    - export: timeline
    - analyzers: speech / audio / visual / metadata

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "test:watch": "tsx --test --watch tests/integration/*.test.ts tests/evaluation/*.test.ts tests/filler-removal/*.test.ts tests/golden/*.test.ts",
     "test:final-cut-disposable-headed": "node scripts/final-cut-disposable-native-headed-e2e.mjs",
     "test:final-cut-transition-headed": "node scripts/final-cut-transition-headed-e2e.mjs",
+    "test:final-cut-title-headed": "node scripts/final-cut-title-discovery-headed-e2e.mjs",
     "hooks:install": "node scripts/install-git-hooks.mjs",
     "mcp": "tsx apps/mcp-server/src/main.ts",
     "framekit": "node ./bin/framekit.mjs",

--- a/packages/runtime/src/capabilities.ts
+++ b/packages/runtime/src/capabilities.ts
@@ -332,6 +332,7 @@ function nativeFamily(
     "mediaAppend",
     "mediaInsert",
     "titlePlacement",
+    "titleDiscovery",
     "timelineFocus",
     "projectCreation",
     "clipInsertion",

--- a/packages/runtime/src/domain/capabilities.ts
+++ b/packages/runtime/src/domain/capabilities.ts
@@ -97,6 +97,7 @@ export type NativeCapabilityOperation =
   | "mediaAppend"
   | "mediaInsert"
   | "titlePlacement"
+  | "titleDiscovery"
   | "timelineFocus"
   | "projectCreation"
   | "clipInsertion"

--- a/scripts/final-cut-evidence.mjs
+++ b/scripts/final-cut-evidence.mjs
@@ -59,6 +59,7 @@ const nativeCapabilityKeys = [
   "trimToDuration",
   "mediaAppend",
   "mediaInsert",
+  "titleDiscovery",
   "titlePlacement",
   "timelineFocus",
   "requiresAccessibility",

--- a/scripts/final-cut-title-discovery-headed-e2e.mjs
+++ b/scripts/final-cut-title-discovery-headed-e2e.mjs
@@ -1,0 +1,164 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { evidenceEnvironment } from "./final-cut-evidence.mjs";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const expectedProject = process.env.FRAMEKIT_FINAL_CUT_E2E_PROJECT;
+const titleQuery = process.env.FRAMEKIT_FINAL_CUT_E2E_TITLE_QUERY;
+const titleText = process.env.FRAMEKIT_FINAL_CUT_E2E_TITLE_TEXT ?? "Framekit Native Title";
+const duration = parseDuration(process.env.FRAMEKIT_FINAL_CUT_E2E_TITLE_DURATION ?? "3/1");
+
+if (process.argv.includes("--help")) {
+  process.stdout.write([
+    "Native Final Cut title discovery and placement E2E",
+    "",
+    "Required:",
+    "  FRAMEKIT_FINAL_CUT_E2E_PROJECT=exact-disposable-project-name",
+    "  FRAMEKIT_FINAL_CUT_E2E_TITLE_QUERY=title-browser-search-query",
+    "",
+    "Optional:",
+    "  FRAMEKIT_FINAL_CUT_E2E_TITLE_TEXT=title-text",
+    "  FRAMEKIT_FINAL_CUT_E2E_TITLE_DURATION=positive-value/timescale",
+  ].join("\n"));
+  process.stdout.write("\n");
+  process.exit(0);
+}
+
+if (!expectedProject || !titleQuery) {
+  throw new Error("Set FRAMEKIT_FINAL_CUT_E2E_PROJECT and FRAMEKIT_FINAL_CUT_E2E_TITLE_QUERY before running the headed title E2E");
+}
+
+const transport = new StdioClientTransport({
+  command: process.execPath,
+  args: ["--import", "tsx", join(root, "apps/mcp-server/src/main.ts")],
+  env: {
+    ...process.env,
+    FRAMEKIT_EDITOR: "final-cut-live",
+    FRAMEKIT_AUTO_CONNECT: "0",
+    FRAMEKIT_FCPXML_PATH: "",
+    FRAMEKIT_FINAL_CUT_HEADLESS: "0",
+    FRAMEKIT_FINAL_CUT_NATIVE_WRITES: "1",
+  },
+  stderr: "pipe",
+});
+const client = new Client({ name: "framekit-title-discovery-headed-e2e", version: "0.1.0" });
+let operationId;
+
+try {
+  await client.connect(transport);
+  const editor = await callJson("editor.inspect");
+  if (editor.native?.titleDiscovery !== true) {
+    throw new Error("CAPABILITY_UNAVAILABLE: native title discovery is not enabled");
+  }
+  if (editor.native?.titlePlacement !== true) {
+    throw new Error("CAPABILITY_UNAVAILABLE: native title placement is not enabled");
+  }
+  if (editor.native?.requiresAccessibility !== true) {
+    throw new Error("CAPABILITY_UNAVAILABLE: Accessibility permission is required");
+  }
+  if (editor.native?.requiresFinalCutFrontmost !== true) {
+    throw new Error("CAPABILITY_UNAVAILABLE: Final Cut must be frontmost");
+  }
+  if (editor.native?.project && editor.native.project !== expectedProject) {
+    throw new Error(`FINAL_CUT_E2E_PROJECT_MISMATCH: expected ${expectedProject}, observed ${editor.native.project}`);
+  }
+
+  const assets = await callJson("editor.assets", { kind: "title", query: titleQuery });
+  const title = Array.isArray(assets)
+    ? assets.find((asset) => asset.id?.startsWith("final-cut:title:"))
+    : undefined;
+  if (!title) {
+    throw new Error("FINAL_CUT_E2E_NATIVE_TITLE_NOT_FOUND: no provider-qualified native title matched the query");
+  }
+  if (title.metadata?.discovery?.backend !== "final-cut-accessibility"
+    || title.metadata?.discovery?.guarantee !== "observed"
+    || !title.metadata?.identity) {
+    throw new Error("FINAL_CUT_E2E_NATIVE_TITLE_PROVENANCE_FAILED: discovery did not return native provenance and identity");
+  }
+
+  const preview = await callJson("editor.native.title.add.preview", {
+    assetId: title.id,
+    text: titleText,
+    duration,
+  });
+  if (preview.asset?.id !== title.id || preview.target !== "playhead" || !preview.revision) {
+    throw new Error("FINAL_CUT_E2E_TITLE_PREVIEW_FAILED: preview lost the discovered identity or live target");
+  }
+
+  const executed = await callJson("editor.native.title.add.execute", { previewToken: preview.previewToken });
+  operationId = executed.operationId;
+  if (!executed.verification?.verified
+    || executed.asset?.id !== title.id
+    || executed.beforeRevision?.id === executed.afterRevision?.id
+    || !executed.undoAvailable
+    || !executed.undoCommand) {
+    throw new Error("FINAL_CUT_E2E_TITLE_PLACEMENT_FAILED: native title placement was not read-back verified");
+  }
+
+  const undone = await callJson("editor.native.undo", { operationId });
+  if (!undone.undone || !undone.verification?.verified) {
+    throw new Error("FINAL_CUT_E2E_TITLE_UNDO_FAILED: native Undo did not verify restoration");
+  }
+  operationId = undefined;
+
+  const environment = await evidenceEnvironment(root);
+  process.stdout.write(`${JSON.stringify({
+    schemaVersion: 1,
+    evidenceType: "headed-native-title-discovery-and-placement",
+    passed: true,
+    recordedAt: new Date().toISOString(),
+    environment,
+    project: expectedProject,
+    discovery: {
+      id: title.id,
+      name: title.name,
+      vendor: title.vendor,
+      identity: title.metadata.identity,
+      backend: title.metadata.discovery.backend,
+      guarantee: title.metadata.discovery.guarantee,
+    },
+    placement: {
+      text: titleText,
+      target: preview.target,
+      start: preview.start,
+      duration: preview.duration,
+      beforeRevision: executed.beforeRevision.id,
+      afterRevision: executed.afterRevision.id,
+      verified: executed.verification.verified,
+      undo: { command: executed.undoCommand, verified: undone.verification.verified },
+    },
+  }, null, 2)}\n`);
+} catch (error) {
+  if (operationId) {
+    try {
+      await callJson("editor.native.undo", { operationId });
+    } catch (rollbackError) {
+      throw new AggregateError([error, rollbackError], "Native title headed E2E failed and compensating Undo also failed");
+    }
+  }
+  throw error;
+} finally {
+  await client.close().catch(() => {});
+  await transport.close().catch(() => {});
+}
+
+async function callJson(name, arguments_ = {}) {
+  const result = await client.callTool({ name, arguments: arguments_ });
+  const text = result.content?.find((item) => item.type === "text")?.text ?? "";
+  if (result.isError) throw new Error(text || `${name} failed`);
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(`${name} returned invalid JSON: ${text}`);
+  }
+}
+
+function parseDuration(value) {
+  const match = value.match(/^(\d+)\/(\d+)$/);
+  if (!match || match[2] === "0" || BigInt(match[1]) <= 0n) {
+    throw new Error(`FINAL_CUT_E2E_DURATION_INVALID: expected a positive rational value/timescale, observed ${value}`);
+  }
+  return { value: match[1], timescale: match[2] };
+}

--- a/tests/integration/capabilities.test.ts
+++ b/tests/integration/capabilities.test.ts
@@ -275,6 +275,7 @@ test("MCP editor inspection exposes native, publishing, export, and analyzer fam
       mediaAppend: true,
       mediaInsert: true,
       titlePlacement: true,
+      titleDiscovery: true,
       timelineFocus: true,
       requiresAccessibility: true,
       requiresFinalCutFrontmost: true,
@@ -303,6 +304,7 @@ test("MCP editor inspection exposes native, publishing, export, and analyzer fam
 
     assert.equal(payload.capabilities.schemaVersion, 1);
     assert.equal(payload.capabilities.families.native.selectionWrite.available, true);
+    assert.equal(payload.capabilities.families.native.titleDiscovery.available, true);
     assert.equal(payload.capabilities.families.native.selectionWrite.backend, "final-cut-accessibility");
     assert.equal(payload.capabilities.families.native.clipInsertion.available, false);
     assert.equal(payload.capabilities.families.native.projectCreation.available, false);
@@ -488,6 +490,7 @@ test("Workflow Extension capability payload defines the versioned family contrac
   assert.match(swift, /clipInsertion: CapabilityDescriptor/);
   assert.match(swift, /clipMovement: CapabilityDescriptor/);
   assert.match(swift, /titlePlacement: CapabilityDescriptor/);
+  assert.match(swift, /titleDiscovery: CapabilityDescriptor/);
   assert.match(swift, /projectCatalogRead: Bool/);
   assert.match(swift, /projectSelection: Bool/);
   assert.match(swift, /transitionDiscovery: CapabilityDescriptor/);

--- a/tests/integration/final-cut-assets.test.ts
+++ b/tests/integration/final-cut-assets.test.ts
@@ -32,13 +32,13 @@ test("Final Cut asset discovery composes stable filesystem and native title iden
   const assets = await registry.listAssets({ kind: "title", query: "lower" });
 
   assert.deepEqual(assets.map((asset) => asset.id), [
-    nativeTitle.id,
     `filesystem:title:${bundle}`,
+    nativeTitle.id,
   ]);
   assert.deepEqual(assets.map((asset) => asset.metadata.provider), [
-    "final-cut-accessibility",
     "filesystem-motion-template",
+    "final-cut-accessibility",
   ]);
-  assert.equal(assets[0]?.metadata.identity, nativeTitle.identity);
-  assert.equal(assets[1]?.metadata.path, bundle);
+  assert.equal(assets[0]?.metadata.path, bundle);
+  assert.equal(assets[1]?.metadata.identity, nativeTitle.identity);
 });

--- a/tests/integration/final-cut-assets.test.ts
+++ b/tests/integration/final-cut-assets.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { FinalCutAssetRegistry } from "@framekit/final-cut";
+import type { NativeFinalCutTitleMatch } from "@framekit/final-cut";
+
+test("Final Cut asset discovery composes stable filesystem and native title identities", async () => {
+  const root = await mkdtemp(join(os.tmpdir(), "framekit-title-assets-"));
+  const bundle = join(root, "Titles.localized", "Lower Third.moti");
+  await mkdir(join(bundle, "Contents"), { recursive: true });
+  await writeFile(
+    join(bundle, "Contents", "Info.plist"),
+    "<plist><key>CFBundleDisplayName</key><string>Lower Third</string><key>CFBundleIdentifier</key><string>Framekit Fixture</string></plist>",
+  );
+  const nativeTitle: NativeFinalCutTitleMatch = {
+    id: "final-cut:title:fcp://title/lower-third",
+    kind: "title",
+    name: "Lower Third",
+    vendor: "Final Cut Pro",
+    identity: "fcp://title/lower-third",
+  };
+
+  const registry = new FinalCutAssetRegistry({
+    roots: [root],
+    nativeTitleProvider: {
+      searchTitles: async () => [nativeTitle, { ...nativeTitle }],
+    },
+  });
+
+  const assets = await registry.listAssets({ kind: "title", query: "lower" });
+
+  assert.deepEqual(assets.map((asset) => asset.id), [
+    nativeTitle.id,
+    `filesystem:title:${bundle}`,
+  ]);
+  assert.deepEqual(assets.map((asset) => asset.metadata.provider), [
+    "final-cut-accessibility",
+    "filesystem-motion-template",
+  ]);
+  assert.equal(assets[0]?.metadata.identity, nativeTitle.identity);
+  assert.equal(assets[1]?.metadata.path, bundle);
+});

--- a/tests/integration/final-cut-assets.test.ts
+++ b/tests/integration/final-cut-assets.test.ts
@@ -85,6 +85,37 @@ test("Final Cut asset discovery propagates native browser unavailability", async
   );
 });
 
+test("Final Cut asset discovery reports native unavailability with filesystem results", async () => {
+  const root = await mkdtemp(join(os.tmpdir(), "framekit-title-assets-diagnostic-"));
+  const bundle = join(root, "Titles.localized", "Lower Third.moti");
+  await mkdir(join(bundle, "Contents"), { recursive: true });
+  await writeFile(
+    join(bundle, "Contents", "Info.plist"),
+    "<plist><key>CFBundleDisplayName</key><string>Lower Third</string><key>CFBundleIdentifier</key><string>Framekit Fixture</string></plist>",
+  );
+  const registry = new FinalCutAssetRegistry({
+    roots: [root],
+    nativeTitleProvider: {
+      searchTitles: async () => {
+        throw new Error("FINAL_CUT_NATIVE_TITLE_BROWSER_PERMISSION: Accessibility permission is required");
+      },
+    },
+  });
+
+  const assets = await registry.listAssets({ kind: "title", query: "lower" });
+
+  assert.equal(assets.length, 1);
+  assert.deepEqual(assets[0]?.metadata.discovery, {
+    backend: "filesystem-motion-template",
+    guarantee: "observed",
+    native: {
+      backend: "final-cut-accessibility",
+      guarantee: "none",
+      unavailableReason: "FINAL_CUT_NATIVE_TITLE_BROWSER_PERMISSION: Accessibility permission is required",
+    },
+  });
+});
+
 test("MCP editor.assets exposes native title provenance", async () => {
   const nativeTitle: NativeFinalCutTitleMatch = {
     id: "final-cut:title:fcp://title/lower-third",

--- a/tests/integration/final-cut-assets.test.ts
+++ b/tests/integration/final-cut-assets.test.ts
@@ -3,8 +3,21 @@ import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import os from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { FinalCutAssetRegistry } from "@framekit/final-cut";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { FinalCutAssetRegistry, FinalCutSessionAdapter } from "@framekit/final-cut";
 import type { NativeFinalCutTitleMatch } from "@framekit/final-cut";
+import { AgentVideoRuntime } from "@framekit/runtime";
+import { InMemoryEditorAdapter } from "@framekit/testkit";
+import { createMcpServer } from "../../apps/mcp-server/src/server.js";
+
+function textFrom(result: unknown): string {
+  const content = (result as { content?: unknown }).content;
+  assert.ok(Array.isArray(content));
+  const first = content[0] as { text?: unknown } | undefined;
+  if (typeof first?.text !== "string") throw new Error("MCP result did not contain text");
+  return first.text;
+}
 
 test("Final Cut asset discovery composes stable filesystem and native title identities", async () => {
   const root = await mkdtemp(join(os.tmpdir(), "framekit-title-assets-"));
@@ -41,4 +54,76 @@ test("Final Cut asset discovery composes stable filesystem and native title iden
   ]);
   assert.equal(assets[0]?.metadata.path, bundle);
   assert.equal(assets[1]?.metadata.identity, nativeTitle.identity);
+  assert.deepEqual(assets[0]?.metadata.discovery, {
+    backend: "filesystem-motion-template",
+    guarantee: "observed",
+  });
+  assert.deepEqual(assets[1]?.metadata.discovery, {
+    backend: "final-cut-accessibility",
+    guarantee: "observed",
+  });
+  assert.deepEqual(assets[1]?.metadata.placement, {
+    backend: "final-cut-accessibility",
+    guarantee: "native-verified",
+    operation: "editor.native.title.add",
+  });
+});
+
+test("Final Cut asset discovery propagates native browser unavailability", async () => {
+  const registry = new FinalCutAssetRegistry({
+    roots: [],
+    nativeTitleProvider: {
+      searchTitles: async () => {
+        throw new Error("FINAL_CUT_NATIVE_TITLE_BROWSER_PERMISSION: Accessibility permission is required");
+      },
+    },
+  });
+
+  await assert.rejects(
+    registry.listAssets({ kind: "title" }),
+    /FINAL_CUT_NATIVE_TITLE_BROWSER_PERMISSION/,
+  );
+});
+
+test("MCP editor.assets exposes native title provenance", async () => {
+  const nativeTitle: NativeFinalCutTitleMatch = {
+    id: "final-cut:title:fcp://title/lower-third",
+    kind: "title",
+    name: "Lower Third",
+    vendor: "Final Cut Pro",
+    identity: "fcp://title/lower-third",
+  };
+  const editor = new FinalCutSessionAdapter({
+    snapshot: new InMemoryEditorAdapter({
+      projectId: "project-1",
+      projectName: "Asset MCP Fixture",
+      timelineId: "timeline-1",
+      timelineName: "Main",
+      clips: [],
+    }),
+    assets: new FinalCutAssetRegistry({
+      roots: [],
+      nativeTitleProvider: { searchTitles: async () => [nativeTitle] },
+    }),
+  });
+  const server = createMcpServer(new AgentVideoRuntime(editor));
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "asset-mcp-test", version: "0.1.0" });
+
+  try {
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    const assets = JSON.parse(textFrom(await client.callTool({
+      name: "editor.assets",
+      arguments: { kind: "title", query: "lower" },
+    })));
+    assert.equal(assets[0].id, nativeTitle.id);
+    assert.deepEqual(assets[0].metadata.discovery, {
+      backend: "final-cut-accessibility",
+      guarantee: "observed",
+    });
+  } finally {
+    await client.close();
+    await server.close();
+  }
 });

--- a/tests/integration/finalcut-mcp.test.ts
+++ b/tests/integration/finalcut-mcp.test.ts
@@ -102,7 +102,7 @@ test("Final Cut MCP composes FCPXML reads, local analysis, assets, edits, and un
     assert.equal(assets[0].name, "Cross Dissolve");
     const titles = JSON.parse(textFrom(await client.callTool({ name: "editor.assets", arguments: { kind: "title", query: "lower" } })));
     assert.deepEqual(titles[0], {
-      id: join(directory, "Motion Templates.localized", "Titles.localized", "Lower Third.moti"),
+      id: `filesystem:title:${join(directory, "Motion Templates.localized", "Titles.localized", "Lower Third.moti")}`,
       kind: "title",
       name: "Lower Third",
       vendor: "Framekit Fixture",
@@ -110,6 +110,9 @@ test("Final Cut MCP composes FCPXML reads, local analysis, assets, edits, and un
         path: join(directory, "Motion Templates.localized", "Titles.localized", "Lower Third.moti"),
         name: "Lower Third",
         vendor: "Framekit Fixture",
+        identity: join(directory, "Motion Templates.localized", "Titles.localized", "Lower Third.moti"),
+        provider: "filesystem-motion-template",
+        source: "filesystem",
       },
     });
 

--- a/tests/integration/finalcut-mcp.test.ts
+++ b/tests/integration/finalcut-mcp.test.ts
@@ -59,6 +59,7 @@ test("Final Cut MCP composes FCPXML reads, local analysis, assets, edits, and un
     env: finalCutMcpEnvironment({
       FRAMEKIT_FINAL_CUT_SOCKET: join(directory, "missing.sock"),
       FRAMEKIT_FCPXML_PATH: xmlPath,
+      FRAMEKIT_FINAL_CUT_NATIVE_WRITES: "0",
       FRAMEKIT_FINAL_CUT_ASSET_ROOTS: join(directory, "Motion Templates.localized"),
       FRAMEKIT_SPEECH_ANALYZER: speech,
       FRAMEKIT_AUDIO_ANALYZER: audio,
@@ -113,6 +114,15 @@ test("Final Cut MCP composes FCPXML reads, local analysis, assets, edits, and un
         identity: join(directory, "Motion Templates.localized", "Titles.localized", "Lower Third.moti"),
         provider: "filesystem-motion-template",
         source: "filesystem",
+        discovery: {
+          backend: "filesystem-motion-template",
+          guarantee: "observed",
+        },
+        placement: {
+          backend: "final-cut-accessibility",
+          guarantee: "native-verified",
+          operation: "editor.native.title.add",
+        },
       },
     });
 

--- a/tests/integration/native-title-discovery.test.ts
+++ b/tests/integration/native-title-discovery.test.ts
@@ -30,17 +30,23 @@ function context(frontmost = true): string {
   ].join(fieldSeparator);
 }
 
-test("native Final Cut adapter discovers stable title assets", async () => {
+function browserContext(frontmost = true): string {
+  return [String(frontmost), "true"].join(fieldSeparator);
+}
+
+test("native Final Cut adapter discovers stable title assets without a timeline", async () => {
   const scripts: string[] = [];
   const adapter = new FinalCutNativeAutomationAdapter({
     enabled: true,
+    nativePreflightTimeoutMs: 1,
+    sleep: async () => {},
     executor: async (script) => {
       scripts.push(script);
-      if (script.includes("on preflightResult") || script.includes('set selectedName to ""')) return context();
+      if (script.includes("titleBrowserPreflightResult")) return browserContext();
       if (script.includes("titleSearchField")) {
         return ["Lower Third", "fcp://title/lower-third"].join(fieldSeparator) + recordSeparator;
       }
-      return "";
+      throw new Error("timeline preflight should not run for title discovery");
     },
   });
 
@@ -53,6 +59,8 @@ test("native Final Cut adapter discovers stable title assets", async () => {
     vendor: "Final Cut Pro",
     identity: "fcp://title/lower-third",
   }]);
+  assert.equal(scripts.some((script) => script.includes("on preflightResult")), false);
+  assert.equal(scripts.some((script) => script.includes("titleBrowserPreflightResult")), true);
   assert.equal(scripts.some((script) => script.includes("titleSearchField")), true);
 });
 
@@ -68,7 +76,7 @@ test("native title discovery fails closed without browser identities or frontmos
   const missingIdentity = new FinalCutNativeAutomationAdapter({
     enabled: true,
     executor: async (script) => {
-      if (script.includes("on preflightResult") || script.includes('set selectedName to ""')) return context();
+      if (script.includes("titleBrowserPreflightResult")) return browserContext();
       return ["Lower Third", ""].join(fieldSeparator) + recordSeparator;
     },
   });
@@ -78,7 +86,7 @@ test("native title discovery fails closed without browser identities or frontmos
     enabled: true,
     nativePreflightTimeoutMs: 1,
     sleep: async () => {},
-    executor: async () => context(false),
+    executor: async (script) => script.includes("titleBrowserPreflightResult") ? browserContext(false) : "",
   });
   await assert.rejects(background.searchTitles("Lower Third"), /FINAL_CUT_NATIVE_NOT_FRONTMOST/);
 

--- a/tests/integration/native-title-discovery.test.ts
+++ b/tests/integration/native-title-discovery.test.ts
@@ -55,3 +55,11 @@ test("native Final Cut adapter discovers stable title assets", async () => {
   }]);
   assert.equal(scripts.some((script) => script.includes("titleSearchField")), true);
 });
+
+test("native title discovery capability follows the enabled native provider", () => {
+  const enabled = new FinalCutNativeAutomationAdapter({ enabled: true });
+  const disabled = new FinalCutNativeAutomationAdapter({ enabled: false });
+
+  assert.equal(enabled.capabilities().titleDiscovery, true);
+  assert.equal(disabled.capabilities().titleDiscovery, false);
+});

--- a/tests/integration/native-title-discovery.test.ts
+++ b/tests/integration/native-title-discovery.test.ts
@@ -76,6 +76,8 @@ test("native title discovery fails closed without browser identities or frontmos
 
   const background = new FinalCutNativeAutomationAdapter({
     enabled: true,
+    nativePreflightTimeoutMs: 1,
+    sleep: async () => {},
     executor: async () => context(false),
   });
   await assert.rejects(background.searchTitles("Lower Third"), /FINAL_CUT_NATIVE_NOT_FRONTMOST/);

--- a/tests/integration/native-title-discovery.test.ts
+++ b/tests/integration/native-title-discovery.test.ts
@@ -5,9 +5,9 @@ import { FinalCutNativeAutomationAdapter } from "@framekit/final-cut";
 const fieldSeparator = String.fromCharCode(31);
 const recordSeparator = String.fromCharCode(30);
 
-function context(): string {
+function context(frontmost = true): string {
   return [
-    "true",
+    String(frontmost),
     "Final Cut Pro",
     "0",
     "",
@@ -62,4 +62,24 @@ test("native title discovery capability follows the enabled native provider", ()
 
   assert.equal(enabled.capabilities().titleDiscovery, true);
   assert.equal(disabled.capabilities().titleDiscovery, false);
+});
+
+test("native title discovery fails closed without browser identities or frontmost access", async () => {
+  const missingIdentity = new FinalCutNativeAutomationAdapter({
+    enabled: true,
+    executor: async (script) => {
+      if (script.includes("on preflightResult") || script.includes('set selectedName to ""')) return context();
+      return ["Lower Third", ""].join(fieldSeparator) + recordSeparator;
+    },
+  });
+  await assert.rejects(missingIdentity.searchTitles("Lower Third"), /FINAL_CUT_NATIVE_TITLE_ID_UNAVAILABLE/);
+
+  const background = new FinalCutNativeAutomationAdapter({
+    enabled: true,
+    executor: async () => context(false),
+  });
+  await assert.rejects(background.searchTitles("Lower Third"), /FINAL_CUT_NATIVE_NOT_FRONTMOST/);
+
+  const disabled = new FinalCutNativeAutomationAdapter({ enabled: false });
+  await assert.rejects(disabled.searchTitles("Lower Third"), /CAPABILITY_UNAVAILABLE/);
 });

--- a/tests/integration/native-title-discovery.test.ts
+++ b/tests/integration/native-title-discovery.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { FinalCutNativeAutomationAdapter } from "@framekit/final-cut";
+
+const fieldSeparator = String.fromCharCode(31);
+const recordSeparator = String.fromCharCode(30);
+
+function context(): string {
+  return [
+    "true",
+    "Final Cut Pro",
+    "0",
+    "",
+    "",
+    "false",
+    "true",
+    "",
+    "",
+    "",
+    "true",
+    "true",
+    "timeline",
+    "1",
+    "false",
+    "false",
+    "Final Cut Pro",
+    "false",
+    "Undo",
+    "",
+  ].join(fieldSeparator);
+}
+
+test("native Final Cut adapter discovers stable title assets", async () => {
+  const scripts: string[] = [];
+  const adapter = new FinalCutNativeAutomationAdapter({
+    enabled: true,
+    executor: async (script) => {
+      scripts.push(script);
+      if (script.includes("on preflightResult") || script.includes('set selectedName to ""')) return context();
+      if (script.includes("titleSearchField")) {
+        return ["Lower Third", "fcp://title/lower-third"].join(fieldSeparator) + recordSeparator;
+      }
+      return "";
+    },
+  });
+
+  const titles = await adapter.searchTitles("Lower Third");
+
+  assert.deepEqual(titles, [{
+    id: "final-cut:title:fcp://title/lower-third",
+    kind: "title",
+    name: "Lower Third",
+    vendor: "Final Cut Pro",
+    identity: "fcp://title/lower-third",
+  }]);
+  assert.equal(scripts.some((script) => script.includes("titleSearchField")), true);
+});

--- a/tests/integration/native.test.ts
+++ b/tests/integration/native.test.ts
@@ -198,11 +198,15 @@ test("native Final Cut adapter previews and inserts a title at the playhead with
 
   const preview = await adapter.previewTitleAdd({
     asset: {
-      id: "/Motion Templates.localized/Titles.localized/Lower Third.moti",
+      id: "final-cut:title:fcp://title/lower-third",
       kind: "title",
       name: "Lower Third",
-      vendor: "Framekit Fixture",
-      metadata: {},
+      vendor: "Final Cut Pro",
+      metadata: {
+        identity: "fcp://title/lower-third",
+        provider: "final-cut-accessibility",
+        source: "final-cut-titles-browser",
+      },
     },
     text: "Framekit Native Title",
     duration: { value: "3", timescale: "1" },
@@ -222,6 +226,7 @@ test("native Final Cut adapter previews and inserts a title at the playhead with
   assert.equal(scripts.some((script) => script.includes("(item 1 of mainSize) - 385")), true);
   assert.equal(scripts.some((script) => script.includes("(item 1 of mainSize) - 215")), true);
   assert.equal(scripts.some((script) => script.includes("Lower Third")), true);
+  assert.equal(scripts.some((script) => script.includes("fcp://title/lower-third")), true);
   assert.equal(scripts.some((script) => script.includes("Framekit Native Title")), true);
   assert.equal(scripts.some((script) => script.includes('keystroke "i"')), true);
   assert.equal(scripts.some((script) => script.includes('keystroke "o"')), true);

--- a/tests/integration/native.test.ts
+++ b/tests/integration/native.test.ts
@@ -239,6 +239,70 @@ test("native Final Cut adapter previews and inserts a title at the playhead with
   assert.equal(scripts.some((script) => script.includes('click menu item "Undo Native Title" of menu "Edit"')), true);
 });
 
+test("native title placement keeps filesystem assets on name fallback", async () => {
+  const scripts: string[] = [];
+  let revision = 1;
+  let playhead = "5";
+  let titleAdded = false;
+  const liveState = async () => ({
+    project: { id: "project-1", name: "Edit" },
+    sequence: {
+      id: "sequence-1",
+      name: "Edit",
+      startTime: { value: "0", timescale: "1" },
+      duration: { value: "20", timescale: "1" },
+      frameDuration: { value: "1", timescale: "24" },
+    },
+    playheadTime: { value: playhead, timescale: "1" },
+    sequenceTimeRange: {
+      start: { value: "0", timescale: "1" },
+      duration: { value: "20", timescale: "1" },
+    },
+    revision: { id: `rev-${revision}`, sequence: revision, timestamp: new Date(revision).toISOString() },
+  });
+  const adapter = new FinalCutNativeAutomationAdapter({
+    enabled: true,
+    liveState,
+    sleep: async () => {},
+    executor: async (script) => {
+      scripts.push(script);
+      if (script.includes("00:00:05:00")) playhead = "5";
+      if (script.includes("00:00:08:00")) playhead = "8";
+      if (script.includes("Filesystem Title")) {
+        titleAdded = true;
+        revision = 2;
+      }
+      if (script.includes("timelineWindowAvailable")) {
+        return context(true, "Final Cut Pro", titleAdded ? "Lower Third" : "", titleAdded ? 1 : 0, true);
+      }
+      return "";
+    },
+  });
+  const filesystemPath = "/Motion Templates.localized/Titles.localized/Lower Third.moti";
+
+  const preview = await adapter.previewTitleAdd({
+    asset: {
+      id: `filesystem:title:${filesystemPath}`,
+      kind: "title",
+      name: "Lower Third",
+      vendor: "Framekit Fixture",
+      metadata: {
+        identity: filesystemPath,
+        provider: "filesystem-motion-template",
+      },
+    },
+    text: "Filesystem Title",
+    duration: { value: "3", timescale: "1" },
+  });
+
+  const result = await adapter.executeTitleAdd(preview.previewToken);
+  assert.equal(result.verification.verified, true);
+  const selectionScript = scripts.find((script) => script.includes("set targetIdentity"));
+  assert.ok(selectionScript);
+  assert.match(selectionScript, /set targetIdentity to ""/);
+  assert.equal(selectionScript.includes(filesystemPath), false);
+});
+
 test("native title previews bind explicit selected ranges and reject incompatible or out-of-bounds assets", async () => {
   const liveState = async () => ({
     project: { id: "project-1", name: "Edit" },


### PR DESCRIPTION
## Summary

- Discover built-in Final Cut Pro titles through the headed Titles browser with stable `final-cut:title:<AXIdentifier>` IDs.
- Compose filesystem and native title assets with explicit provider provenance and capability diagnostics.
- Place discovered titles by identity and verify readback, revision change, and native Undo.
- Add deterministic TDD coverage, documentation, and an opt-in headed native evidence runner.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm run test` — 546 passed
- `pnpm run check:boundaries`
- `pnpm run xcode:check`
- `xcodebuild -project adapters/final-cut/swift-bridge/FinalCutWorkflowExtension/FramekitFinalCutWorkflow.xcodeproj -list`
- `pnpm run test:final-cut-title-headed -- --help`

The live headed Final Cut scenario requires a disposable project, Accessibility permission, and Final Cut frontmost; its runner is included but was not run in this non-interactive validation environment.

Fixes #185
