### PR TITLE
feat: add native picture-in-picture

### DIFF
--- a/adapters/final-cut/swift-bridge/FinalCutWorkflowExtension/FinalCutLiveWorkflowExtension.swift
+++ b/adapters/final-cut/swift-bridge/FinalCutWorkflowExtension/FinalCutLiveWorkflowExtension.swift
@@ -132,6 +132,7 @@ private struct NativeCapabilities: Codable {
     let mediaAppend: CapabilityDescriptor
     let mediaInsert: CapabilityDescriptor
     let titlePlacement: CapabilityDescriptor
+    let pictureInPicture: CapabilityDescriptor
     let transitionDiscovery: CapabilityDescriptor
     let transitionPlacement: CapabilityDescriptor
     let timelineFocus: CapabilityDescriptor
@@ -155,10 +156,18 @@ private struct AnalyzerFamilyCapabilities: Codable {
     let visualTrack: CapabilityDescriptor
 }
 
+private struct EditingCapabilities: Codable {
+    let compositeTransactions: CapabilityDescriptor
+    let titlePlacement: CapabilityDescriptor
+    let pictureInPicture: CapabilityDescriptor
+    let masking: CapabilityDescriptor
+}
+
 private struct CapabilityFamilies: Codable {
     let connection: ConnectionCapabilities
     let observation: ObservationCapabilities
     let canonicalDocument: CanonicalDocumentCapabilities
+    let editing: EditingCapabilities
     let native: NativeCapabilities
     let publishing: PublishingCapabilities
     let `export`: ExportCapabilities
@@ -225,6 +234,12 @@ private func metadataOnlyCapabilityFamilies() -> CapabilityFamilies {
             write: unavailableCapability(backend: liveBackend, operation: "canonical timeline writes"),
             artifactWrite: unavailableCapability(backend: liveBackend, operation: "canonical artifact writes")
         ),
+        editing: EditingCapabilities(
+            compositeTransactions: unavailableCapability(backend: liveBackend, operation: "composite editing transactions"),
+            titlePlacement: unavailableCapability(backend: nativeBackend, operation: "title placement"),
+            pictureInPicture: unavailableCapability(backend: nativeBackend, operation: "picture-in-picture placement"),
+            masking: unavailableCapability(backend: nativeBackend, operation: "masking")
+        ),
         native: NativeCapabilities(
             selectionWrite: unavailableCapability(backend: nativeBackend, operation: "native selection write"),
             undo: unavailableCapability(backend: nativeBackend, operation: "native undo"),
@@ -239,6 +254,7 @@ private func metadataOnlyCapabilityFamilies() -> CapabilityFamilies {
             mediaAppend: unavailableCapability(backend: nativeBackend, operation: "native media append"),
             mediaInsert: unavailableCapability(backend: nativeBackend, operation: "native media insert"),
             titlePlacement: unavailableCapability(backend: nativeBackend, operation: "native title placement"),
+            pictureInPicture: unavailableCapability(backend: nativeBackend, operation: "native picture-in-picture placement"),
             transitionDiscovery: unavailableCapability(backend: nativeBackend, operation: "native transition discovery"),
             transitionPlacement: unavailableCapability(backend: nativeBackend, operation: "native transition placement"),
             timelineFocus: unavailableCapability(backend: nativeBackend, operation: "native timeline focus"),

--- a/adapters/final-cut/typescript/src/fcpxml.ts
+++ b/adapters/final-cut/typescript/src/fcpxml.ts
@@ -322,6 +322,9 @@ export class FcpxmlDocumentAdapter implements EditorPort {
       && anchorEntry.kind !== "mc-clip") {
       throw new Error("INVALID_OPERATION: PIP anchor must be a video occurrence");
     }
+    if (operation.frame) {
+      throw new Error("CAPABILITY_UNAVAILABLE: FCPXML picture-in-picture frame requires the native Final Cut provider");
+    }
     validatePictureInPictureOperation(operation, anchorEntry.startTime, anchorEntry.durationTime, media.duration);
     const connected = {
       "asset-clip": [],
@@ -341,20 +344,22 @@ export class FcpxmlDocumentAdapter implements EditorPort {
       ":@": {
         "@_position": `${operation.position.x} ${operation.position.y}`,
         "@_scale": `${operation.scale * 100} ${operation.scale * 100}`,
-        ...(operation.frame ? {
-          "@_frame-style": operation.frame.style,
-          "@_frame-color": operation.frame.color,
-          "@_frame-width": String(operation.frame.width),
-        } : {}),
       },
     });
     if (operation.crop) {
       appendChild(connected, "adjust-crop", {
         ":@": {
-          "@_top": String(operation.crop.top),
-          "@_right": String(operation.crop.right),
-          "@_bottom": String(operation.crop.bottom),
-          "@_left": String(operation.crop.left),
+          "@_mode": "crop",
+        },
+      });
+      const crop = firstChild(connected, "adjust-crop");
+      if (!crop) throw new Error("FCPXML_INVALID_PIP: crop adjustment could not be created");
+      appendChild(crop, "crop-rect", {
+        ":@": {
+          "@_top": formatPictureInPicturePercentage(operation.crop.top),
+          "@_right": formatPictureInPicturePercentage(operation.crop.right),
+          "@_bottom": formatPictureInPicturePercentage(operation.crop.bottom),
+          "@_left": formatPictureInPicturePercentage(operation.crop.left),
         },
       });
     }
@@ -726,48 +731,29 @@ function validatePictureInPictureCrop(crop: NonNullable<Clip["crop"]>): void {
   }
 }
 
-function validatePictureInPictureFrame(frame: NonNullable<Clip["frame"]>): void {
-  if (frame.style !== "solid" || !/^#[0-9a-f]{6}$/i.test(frame.color)
-    || !Number.isFinite(frame.width) || frame.width < 0) {
-    throw new Error("INVALID_OPERATION: PIP frame must be a solid hex-colored non-negative width");
-  }
-}
-
 function pictureInPictureProperties(node: XmlNode): Pick<Clip, "position" | "scale" | "crop" | "frame"> {
   const transform = firstChild(node, "adjust-transform");
   const crop = firstChild(node, "adjust-crop");
   const positionValue = transform ? attribute(transform, "position") : undefined;
   const scaleValue = transform ? attribute(transform, "scale") : undefined;
-  const frameStyle = transform ? attribute(transform, "frame-style") : undefined;
-  const frameColor = transform ? attribute(transform, "frame-color") : undefined;
-  const frameWidth = transform ? attribute(transform, "frame-width") : undefined;
   const position = positionValue === undefined ? undefined : parsePictureInPicturePosition(positionValue);
   const scale = scaleValue === undefined ? undefined : parsePictureInPictureScale(scaleValue);
+  const cropRect = crop ? firstChild(crop, "crop-rect") : undefined;
   const cropKeys = ["top", "right", "bottom", "left"];
-  const hasCrop = cropKeys.some((key) => crop && attribute(crop, key) !== undefined);
+  const hasCrop = cropRect !== undefined && cropKeys.some((key) => attribute(cropRect, key) !== undefined);
   const parsedCrop = hasCrop
     ? {
-      top: parsePictureInPictureNumber(crop && attribute(crop, "top"), "top crop"),
-      right: parsePictureInPictureNumber(crop && attribute(crop, "right"), "right crop"),
-      bottom: parsePictureInPictureNumber(crop && attribute(crop, "bottom"), "bottom crop"),
-      left: parsePictureInPictureNumber(crop && attribute(crop, "left"), "left crop"),
-    }
-    : undefined;
-  const hasFrame = frameStyle !== undefined || frameColor !== undefined || frameWidth !== undefined;
-  const frame = hasFrame
-    ? {
-      style: String(frameStyle ?? "") as "solid",
-      color: String(frameColor ?? ""),
-      width: parsePictureInPictureNumber(frameWidth, "frame width"),
+      top: parsePictureInPictureNumber(cropRect && attribute(cropRect, "top"), "top crop"),
+      right: parsePictureInPictureNumber(cropRect && attribute(cropRect, "right"), "right crop"),
+      bottom: parsePictureInPictureNumber(cropRect && attribute(cropRect, "bottom"), "bottom crop"),
+      left: parsePictureInPictureNumber(cropRect && attribute(cropRect, "left"), "left crop"),
     }
     : undefined;
   if (parsedCrop) validatePictureInPictureCrop(parsedCrop);
-  if (frame) validatePictureInPictureFrame(frame);
   return {
     ...(position ? { position } : {}),
     ...(scale !== undefined ? { scale } : {}),
     ...(parsedCrop ? { crop: parsedCrop } : {}),
-    ...(frame ? { frame } : {}),
   };
 }
 
@@ -789,9 +775,14 @@ function parsePictureInPictureScale(value: unknown): number {
 }
 
 function parsePictureInPictureNumber(value: unknown, label: string): number {
-  const parsed = Number(value);
+  const text = String(value ?? "").trim();
+  const parsed = Number(text.replace(/%$/, ""));
   if (!Number.isFinite(parsed)) throw new Error(`FCPXML_INVALID_PIP: ${label} is not finite`);
-  return parsed;
+  return text.endsWith("%") ? parsed / 100 : parsed;
+}
+
+function formatPictureInPicturePercentage(value: number): string {
+  return `${value * 100}%`;
 }
 
 function emptyAnalyzerCapabilities() {

--- a/adapters/final-cut/typescript/src/fcpxml.ts
+++ b/adapters/final-cut/typescript/src/fcpxml.ts
@@ -233,16 +233,26 @@ export class FcpxmlDocumentAdapter implements EditorPort {
     if (!sameRevision(expectedRevision, this.revision())) {
       throw new Error("STALE_CONTEXT: FCPXML document changed before transaction");
     }
+    const originalXml = structuredClone(this.xml!);
+    const originalSequence = this.sequence;
+    const originalSignature = this.fileSignature;
     this.history.set(expectedRevision.id, structuredClone(this.xml!));
-    for (const operation of operations) {
-      if (operation.type === "media.import"
-        || operation.type.startsWith("timeline.") && operation.type !== "timeline.picture-in-picture.add") {
-        throw new Error(`CAPABILITY_UNAVAILABLE: FCPXML transaction does not support ${operation.type}`);
+    try {
+      for (const operation of operations) {
+        if (operation.type === "media.import"
+          || operation.type.startsWith("timeline.") && operation.type !== "timeline.picture-in-picture.add") {
+          throw new Error(`CAPABILITY_UNAVAILABLE: FCPXML transaction does not support ${operation.type}`);
+        }
+        this.applyOperation(operation as EditOperation | AddPictureInPictureOperation);
       }
-      this.applyOperation(operation as EditOperation | AddPictureInPictureOperation);
+      this.sequence += 1;
+      await this.persist();
+    } catch (error) {
+      this.xml = originalXml;
+      this.sequence = originalSequence;
+      this.fileSignature = originalSignature;
+      throw error;
     }
-    this.sequence += 1;
-    await this.persist();
   }
 
   private applyOperation(operation: EditOperation | AddPictureInPictureOperation): void {

--- a/adapters/final-cut/typescript/src/fcpxml.ts
+++ b/adapters/final-cut/typescript/src/fcpxml.ts
@@ -7,6 +7,7 @@ import type {
   Caption,
   Clip,
   ContextRevision,
+  AddPictureInPictureOperation,
   EditOperation,
   EditorAsset,
   EditorCapabilities,
@@ -98,7 +99,8 @@ export class FcpxmlDocumentAdapter implements EditorPort {
         projectCatalogRead: true,
         projectSelection: true,
         compositeTransactions: true,
-        semanticOperations: { "add-marker": true },
+        pictureInPicture: true,
+        semanticOperations: { "add-marker": true, "timeline.picture-in-picture.add": true },
       },
       analyzers: emptyAnalyzerCapabilities(),
     }, { backend: "fcpxml-document" });
@@ -206,10 +208,11 @@ export class FcpxmlDocumentAdapter implements EditorPort {
     const originalSignature = this.fileSignature;
     try {
       for (const operation of operations) {
-        if (operation.type === "media.import" || operation.type.startsWith("timeline.")) {
+        if (operation.type === "media.import"
+          || operation.type.startsWith("timeline.") && operation.type !== "timeline.picture-in-picture.add") {
           throw new Error(`CAPABILITY_UNAVAILABLE: FCPXML preview does not support ${operation.type}`);
         }
-        this.applyOperation(operation as EditOperation);
+        this.applyOperation(operation as EditOperation | AddPictureInPictureOperation);
       }
       const preview = await this.readProject();
       return preview;
@@ -230,21 +233,28 @@ export class FcpxmlDocumentAdapter implements EditorPort {
     }
     this.history.set(expectedRevision.id, structuredClone(this.xml!));
     for (const operation of operations) {
-      if (operation.type === "media.import" || operation.type.startsWith("timeline.")) {
+      if (operation.type === "media.import"
+        || operation.type.startsWith("timeline.") && operation.type !== "timeline.picture-in-picture.add") {
         throw new Error(`CAPABILITY_UNAVAILABLE: FCPXML transaction does not support ${operation.type}`);
       }
-      this.applyOperation(operation as EditOperation);
+      this.applyOperation(operation as EditOperation | AddPictureInPictureOperation);
     }
     this.sequence += 1;
     await this.persist();
   }
 
-  private applyOperation(operation: EditOperation): void {
+  private applyOperation(operation: EditOperation | AddPictureInPictureOperation): void {
     const project = this.projectNode();
     const sequenceNode = findElement(project, "sequence");
     const sequence = sequenceNode ?? {};
     const spine = findElement(sequence, "spine") ?? {};
     const timelineId = stableTimelineId(project, sequenceNode);
+
+    if (operation.type === "timeline.picture-in-picture.add") {
+      this.applyPictureInPicture(spine, timelineId, operation);
+      this.updateSequenceDuration(sequence, spine);
+      return;
+    }
 
     switch (operation.type) {
       case "rename-clip": {
@@ -290,6 +300,66 @@ export class FcpxmlDocumentAdapter implements EditorPort {
     this.updateSequenceDuration(sequence, spine);
   }
 
+  private applyPictureInPicture(
+    spine: XmlNode,
+    timelineId: string,
+    operation: AddPictureInPictureOperation,
+  ): void {
+    const media = this.mediaFromResources().find((candidate) => candidate.mediaId === operation.mediaId);
+    if (!media) throw new Error(`MEDIA_NOT_FOUND: ${operation.mediaId}`);
+    if (media.mediaKind !== undefined && media.mediaKind !== "video") {
+      throw new Error(`MEDIA_KIND_MISMATCH: ${operation.mediaId}`);
+    }
+    if (this.findClipNode(spine, operation.occurrenceId, timelineId)) {
+      throw new Error(`OCCURRENCE_ALREADY_EXISTS: ${operation.occurrenceId}`);
+    }
+    const anchorEntry = timelineEntries(spine)
+      .find(({ kind, node, path }) => CLIP_KINDS.has(kind)
+        && this.instanceId(node, kind, path, timelineId) === operation.attachedTo);
+    if (!anchorEntry) throw new Error(`CLIP_NOT_FOUND: ${operation.attachedTo}`);
+    if (anchorEntry.kind !== "asset-clip" && anchorEntry.kind !== "clip"
+      && anchorEntry.kind !== "ref-clip" && anchorEntry.kind !== "sync-clip"
+      && anchorEntry.kind !== "mc-clip") {
+      throw new Error("INVALID_OPERATION: PIP anchor must be a video occurrence");
+    }
+    validatePictureInPictureOperation(operation, anchorEntry.startTime, anchorEntry.durationTime, media.duration);
+    const connected = {
+      "asset-clip": [],
+      ":@": {
+        "@_id": operation.occurrenceId,
+        "@_name": media.source.split("/").pop() || operation.mediaId,
+        "@_ref": operation.mediaId,
+        "@_offset": formatSeconds(operation.start - rationalSeconds(anchorEntry.startTime)),
+        "@_start": "0s",
+        "@_duration": formatSeconds(operation.duration),
+        "@_lane": String(operation.targetLane),
+        "@_framekit-attached-to": operation.attachedTo,
+      },
+    } satisfies XmlNode;
+    appendChild(anchorEntry.node, "asset-clip", connected);
+    appendChild(connected, "adjust-transform", {
+      ":@": {
+        "@_position": `${operation.position.x} ${operation.position.y}`,
+        "@_scale": `${operation.scale * 100} ${operation.scale * 100}`,
+        ...(operation.frame ? {
+          "@_frame-style": operation.frame.style,
+          "@_frame-color": operation.frame.color,
+          "@_frame-width": String(operation.frame.width),
+        } : {}),
+      },
+    });
+    if (operation.crop) {
+      appendChild(connected, "adjust-crop", {
+        ":@": {
+          "@_top": String(operation.crop.top),
+          "@_right": String(operation.crop.right),
+          "@_bottom": String(operation.crop.bottom),
+          "@_left": String(operation.crop.left),
+        },
+      });
+    }
+  }
+
   public async restore(snapshot: ProjectSnapshot, expectedRevision: ContextRevision): Promise<void> {
     await this.ensureLoaded();
     if (!sameRevision(expectedRevision, this.revision())) {
@@ -324,6 +394,7 @@ export class FcpxmlDocumentAdapter implements EditorPort {
 
   private storyElementFromXml(entry: TimelineEntry, timelineId: string): StoryElement {
     const { node, kind, path, startTime, durationTime } = entry;
+    const visual = pictureInPictureProperties(node);
     return {
       id: this.instanceId(node, kind, path, timelineId),
       kind,
@@ -333,12 +404,15 @@ export class FcpxmlDocumentAdapter implements EditorPort {
       durationTime,
       ...(attribute(node, "lane") !== undefined ? { lane: Number(attribute(node, "lane")) } : {}),
       ...(attribute(node, "ref") !== undefined ? { mediaId: String(attribute(node, "ref")) } : {}),
+      ...(attribute(node, "framekit-attached-to") !== undefined ? { attachedTo: String(attribute(node, "framekit-attached-to")) } : {}),
+      ...visual,
     };
   }
 
   private clipFromXml(entry: TimelineEntry, timelineId: string): Clip {
     const { node, kind, path, startTime, durationTime } = entry;
     const gain = firstChild(node, "adjust-volume");
+    const visual = pictureInPictureProperties(node);
     const sourceStartValue = attribute(node, "start");
     const sourceStartTime = sourceStartValue === undefined ? undefined : parseRational(sourceStartValue);
     const sourceStart = sourceStartTime === undefined ? undefined : rationalSeconds(sourceStartTime);
@@ -351,9 +425,11 @@ export class FcpxmlDocumentAdapter implements EditorPort {
       duration: rationalSeconds(durationTime),
       ...(sourceStart !== undefined ? { sourceStart, sourceStartTime } : {}),
       track: Number(attribute(node, "lane") ?? 0),
+      ...(attribute(node, "framekit-attached-to") !== undefined ? { attachedTo: String(attribute(node, "framekit-attached-to")) } : {}),
       startTime,
       durationTime,
       ...(gain ? { gainDb: parseDb(attribute(gain, "amount") ?? "0dB") } : {}),
+      ...visual,
     };
   }
 
@@ -421,12 +497,14 @@ export class FcpxmlDocumentAdapter implements EditorPort {
       .filter(({ kind }) => kind === "asset" || kind === "media" || kind === "effect")
       .map(({ node }) => {
         const durationValue = attribute(node, "duration");
+        const mediaKind = mediaKindFromResource(node);
         return {
           mediaId: String(attribute(node, "id") ?? ""),
           source: resolveMediaSource(
             String(attribute(node, "src") ?? attribute(node, "name") ?? attribute(node, "id") ?? ""),
             this.filePath,
           ),
+          ...(mediaKind ? { mediaKind } : {}),
           ...(durationValue !== undefined ? { duration: parseSeconds(durationValue) } : {}),
         };
       })
@@ -604,6 +682,116 @@ function decimalToRational(value: number): RationalTime {
 
 function formatDb(value: number): string {
   return `${value}dB`;
+}
+
+function mediaKindFromResource(node: XmlNode): "video" | "audio" | undefined {
+  const hasVideo = attribute(node, "hasVideo");
+  const hasAudio = attribute(node, "hasAudio");
+  if (hasVideo === "1" || hasVideo === "true") return "video";
+  if ((hasVideo === "0" || hasVideo === "false") && (hasAudio === "1" || hasAudio === "true")) return "audio";
+  return undefined;
+}
+
+function validatePictureInPictureOperation(
+  operation: AddPictureInPictureOperation,
+  anchorStartTime: RationalTime,
+  anchorDurationTime: RationalTime,
+  mediaDuration?: number,
+): void {
+  const anchorStart = rationalSeconds(anchorStartTime);
+  const anchorEnd = anchorStart + rationalSeconds(anchorDurationTime);
+  if (!Number.isFinite(operation.start) || !Number.isFinite(operation.duration)
+    || operation.start < anchorStart
+    || operation.duration <= 0
+    || operation.start + operation.duration > anchorEnd
+    || !Number.isInteger(operation.targetLane)
+    || operation.targetLane === 0
+    || !Number.isFinite(operation.position.x)
+    || !Number.isFinite(operation.position.y)
+    || !Number.isFinite(operation.scale)
+    || operation.scale <= 0
+    || mediaDuration !== undefined && operation.duration > mediaDuration) {
+    throw new Error("INVALID_OPERATION: PIP timing, connected lane, position, and scale are invalid");
+  }
+  if (operation.crop) validatePictureInPictureCrop(operation.crop);
+  if (operation.frame) validatePictureInPictureFrame(operation.frame);
+}
+
+function validatePictureInPictureCrop(crop: NonNullable<Clip["crop"]>): void {
+  const values = [crop.top, crop.right, crop.bottom, crop.left];
+  if (!values.every((value) => Number.isFinite(value) && value >= 0 && value < 1)
+    || crop.left + crop.right >= 1
+    || crop.top + crop.bottom >= 1) {
+    throw new Error("INVALID_OPERATION: PIP crop must leave a positive source rectangle");
+  }
+}
+
+function validatePictureInPictureFrame(frame: NonNullable<Clip["frame"]>): void {
+  if (frame.style !== "solid" || !/^#[0-9a-f]{6}$/i.test(frame.color)
+    || !Number.isFinite(frame.width) || frame.width < 0) {
+    throw new Error("INVALID_OPERATION: PIP frame must be a solid hex-colored non-negative width");
+  }
+}
+
+function pictureInPictureProperties(node: XmlNode): Pick<Clip, "position" | "scale" | "crop" | "frame"> {
+  const transform = firstChild(node, "adjust-transform");
+  const crop = firstChild(node, "adjust-crop");
+  const positionValue = transform ? attribute(transform, "position") : undefined;
+  const scaleValue = transform ? attribute(transform, "scale") : undefined;
+  const frameStyle = transform ? attribute(transform, "frame-style") : undefined;
+  const frameColor = transform ? attribute(transform, "frame-color") : undefined;
+  const frameWidth = transform ? attribute(transform, "frame-width") : undefined;
+  const position = positionValue === undefined ? undefined : parsePictureInPicturePosition(positionValue);
+  const scale = scaleValue === undefined ? undefined : parsePictureInPictureScale(scaleValue);
+  const cropKeys = ["top", "right", "bottom", "left"];
+  const hasCrop = cropKeys.some((key) => crop && attribute(crop, key) !== undefined);
+  const parsedCrop = hasCrop
+    ? {
+      top: parsePictureInPictureNumber(crop && attribute(crop, "top"), "top crop"),
+      right: parsePictureInPictureNumber(crop && attribute(crop, "right"), "right crop"),
+      bottom: parsePictureInPictureNumber(crop && attribute(crop, "bottom"), "bottom crop"),
+      left: parsePictureInPictureNumber(crop && attribute(crop, "left"), "left crop"),
+    }
+    : undefined;
+  const hasFrame = frameStyle !== undefined || frameColor !== undefined || frameWidth !== undefined;
+  const frame = hasFrame
+    ? {
+      style: String(frameStyle ?? "") as "solid",
+      color: String(frameColor ?? ""),
+      width: parsePictureInPictureNumber(frameWidth, "frame width"),
+    }
+    : undefined;
+  if (parsedCrop) validatePictureInPictureCrop(parsedCrop);
+  if (frame) validatePictureInPictureFrame(frame);
+  return {
+    ...(position ? { position } : {}),
+    ...(scale !== undefined ? { scale } : {}),
+    ...(parsedCrop ? { crop: parsedCrop } : {}),
+    ...(frame ? { frame } : {}),
+  };
+}
+
+function parsePictureInPicturePosition(value: unknown): { x: number; y: number } {
+  const values = String(value).trim().split(/\s+/).map(Number);
+  if (values.length !== 2 || !values.every(Number.isFinite)) {
+    throw new Error(`FCPXML_INVALID_PIP: position ${String(value)} is not a finite pair`);
+  }
+  return { x: values[0]!, y: values[1]! };
+}
+
+function parsePictureInPictureScale(value: unknown): number {
+  const values = String(value).trim().split(/\s+/).map(Number);
+  if (values.length !== 2 || !values.every((candidate) => Number.isFinite(candidate) && candidate > 0)
+    || values[0] !== values[1]) {
+    throw new Error(`FCPXML_INVALID_PIP: scale ${String(value)} is not a positive uniform pair`);
+  }
+  return values[0]! / 100;
+}
+
+function parsePictureInPictureNumber(value: unknown, label: string): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) throw new Error(`FCPXML_INVALID_PIP: ${label} is not finite`);
+  return parsed;
 }
 
 function emptyAnalyzerCapabilities() {

--- a/adapters/final-cut/typescript/src/fcpxml.ts
+++ b/adapters/final-cut/typescript/src/fcpxml.ts
@@ -719,7 +719,6 @@ function validatePictureInPictureOperation(
     throw new Error("INVALID_OPERATION: PIP timing, connected lane, position, and scale are invalid");
   }
   if (operation.crop) validatePictureInPictureCrop(operation.crop);
-  if (operation.frame) validatePictureInPictureFrame(operation.frame);
 }
 
 function validatePictureInPictureCrop(crop: NonNullable<Clip["crop"]>): void {

--- a/adapters/final-cut/typescript/src/native.ts
+++ b/adapters/final-cut/typescript/src/native.ts
@@ -220,6 +220,7 @@ export interface NativeFinalCutPictureInPictureResult {
   previewToken: string;
   media: NativeFinalCutMediaMatch;
   anchorOccurrence: NativeFinalCutOccurrence;
+  occurrence: NativeFinalCutOccurrence;
   start: RationalTime;
   end: RationalTime;
   duration: RationalTime;
@@ -1623,8 +1624,9 @@ export class FinalCutNativeAutomationAdapter implements NativeFinalCutEditor {
     try {
       after = await this.requireTimelineContext();
       afterLive = await this.waitForRevision(beforeLive.revision.id);
+      const occurrence = await this.readPictureInPictureOccurrence(preview, anchorOccurrence);
       const observed = parsePictureInPictureReadback(await this.executor(pictureInPictureInspectorReadbackScript()));
-      const verification = verifyNativePictureInPicture({ ...preview, media }, after, beforeLive, afterLive, observed);
+      const verification = verifyNativePictureInPicture({ ...preview, media }, after, beforeLive, afterLive, observed, occurrence);
       const operation = {
         kind: "picture-in-picture" as const,
         before,
@@ -1651,6 +1653,7 @@ export class FinalCutNativeAutomationAdapter implements NativeFinalCutEditor {
         previewToken,
         media: structuredClone(media),
         anchorOccurrence: structuredClone(anchorOccurrence),
+        occurrence: structuredClone(occurrence),
         start: structuredClone(preview.start),
         end: structuredClone(preview.end),
         duration: structuredClone(preview.duration),
@@ -2213,6 +2216,32 @@ export class FinalCutNativeAutomationAdapter implements NativeFinalCutEditor {
     }
   }
 
+  private async readPictureInPictureOccurrence(
+    preview: { mediaHandle: string; start: RationalTime; duration: RationalTime },
+    anchor: NativeFinalCutOccurrence,
+  ): Promise<NativeFinalCutOccurrence> {
+    const located = await this.locateOccurrenceNative(preview.mediaHandle, true);
+    const matches = located.occurrences.filter((occurrence) => pictureInPictureOccurrenceMatchesRange(occurrence, preview));
+    if (matches.length === 0) {
+      throw new Error("FINAL_CUT_NATIVE_PICTURE_IN_PICTURE_OCCURRENCE_UNAVAILABLE: inserted clip range was not read back");
+    }
+    if (matches.length > 1) {
+      throw new Error("FINAL_CUT_NATIVE_PICTURE_IN_PICTURE_OCCURRENCE_AMBIGUOUS: multiple inserted clips match the requested range");
+    }
+    const occurrence = matches[0]!;
+    if (!occurrence.identity) {
+      throw new Error("FINAL_CUT_NATIVE_PICTURE_IN_PICTURE_OCCURRENCE_UNAVAILABLE: inserted clip has no stable identity");
+    }
+    const context = await this.requireTimelineContext();
+    if (context.target.kind !== "selected-clip" || context.target.identity !== occurrence.identity) {
+      throw new Error("FINAL_CUT_NATIVE_PICTURE_IN_PICTURE_OCCURRENCE_STALE: selected clip does not match the inserted occurrence");
+    }
+    if (!anchor.identity) {
+      throw new Error("FINAL_CUT_NATIVE_OCCURRENCE_ID_UNAVAILABLE: native PIP anchor identity is unavailable");
+    }
+    return occurrence;
+  }
+
   private async ensureOccurrenceRange(occurrence: NativeFinalCutOccurrence): Promise<void> {
     if (occurrence.start && occurrence.duration) return;
     if (occurrence.timelineOffset === undefined) {
@@ -2570,12 +2599,19 @@ function verifyNativePictureInPicture(
   beforeLive: EditorLiveState,
   afterLive: EditorLiveState,
   observed: NativeFinalCutPictureInPictureReadback,
+  occurrence: NativeFinalCutOccurrence,
 ): NativeFinalCutPictureInPictureResult["verification"] {
   if (afterLive.revision.id === beforeLive.revision.id) {
     return { verified: false, detail: "Final Cut did not expose a new revision after native picture-in-picture placement" };
   }
   if (after.target.kind !== "selected-clip") {
     return { verified: false, detail: "Final Cut did not expose the inserted picture-in-picture clip as the selected timeline item" };
+  }
+  if (!occurrence.identity || after.target.identity !== occurrence.identity) {
+    return { verified: false, detail: "Final Cut did not expose the inserted picture-in-picture occurrence identity" };
+  }
+  if (!pictureInPictureOccurrenceMatchesRange(occurrence, preview)) {
+    return { verified: false, detail: "Final Cut did not read back the requested picture-in-picture timeline range" };
   }
   const observedName = after.target.name ?? "";
   if (observedName && !observedName.toLowerCase().includes(preview.media.name.toLowerCase())) {
@@ -2598,8 +2634,17 @@ function verifyNativePictureInPicture(
   }
   return {
     verified: true,
-    detail: `Final Cut verified ${preview.media.name} at ${preview.start.value}/${preview.start.timescale}-${preview.end.value}/${preview.end.timescale} with transform readback at revision ${afterLive.revision.id}`,
+    detail: `Final Cut verified ${preview.media.name} occurrence ${occurrence.identity} at ${preview.start.value}/${preview.start.timescale}-${preview.end.value}/${preview.end.timescale} on the selected anchor's connected lane with transform readback at revision ${afterLive.revision.id}`,
   };
+}
+
+function pictureInPictureOccurrenceMatchesRange(
+  occurrence: NativeFinalCutOccurrence,
+  preview: { start: RationalTime; duration: RationalTime },
+): boolean {
+  if (!occurrence.start || !occurrence.duration) return false;
+  return compareRational(parseRationalString(occurrence.start, "picture-in-picture occurrence start"), preview.start) === 0
+    && compareRational(parseRationalString(occurrence.duration, "picture-in-picture occurrence duration"), preview.duration) === 0;
 }
 
 function assertNativeTransitionAsset(asset: NativeFinalCutTransitionMatch): void {

--- a/adapters/final-cut/typescript/src/native.ts
+++ b/adapters/final-cut/typescript/src/native.ts
@@ -55,6 +55,7 @@ export interface NativeFinalCutOccurrence {
   handle: string;
   mediaHandle: string;
   name: string;
+  identity?: string;
   start?: string;
   duration?: string;
   timelineOffset?: number;
@@ -1581,6 +1582,7 @@ export class FinalCutNativeAutomationAdapter implements NativeFinalCutEditor {
         if (this.canDriveNativeMouse && anchorOccurrence.timelineOffset !== undefined) {
           await selectTimelineOccurrence(this.executor, anchorOccurrence.timelineOffset);
         }
+        await this.validateSelectedPictureInPictureAnchor(anchorOccurrence);
         await this.executor(setPlayheadScript(startTimecode));
         await this.waitForPlayhead(preview.start, beforeLive.sequence?.id);
         await this.executor(markRangeStartScript());
@@ -2188,6 +2190,29 @@ export class FinalCutNativeAutomationAdapter implements NativeFinalCutEditor {
     }
   }
 
+  private async validateSelectedPictureInPictureAnchor(anchor: NativeFinalCutOccurrence): Promise<void> {
+    if (!anchor.identity) {
+      throw new Error("FINAL_CUT_NATIVE_OCCURRENCE_ID_UNAVAILABLE: native PIP requires a stable anchor occurrence identity");
+    }
+    const context = await this.requireTimelineContext();
+    if (context.target.kind !== "selected-clip" || context.target.identity !== anchor.identity) {
+      throw new Error("FINAL_CUT_NATIVE_OCCURRENCE_HANDLE_STALE: selected timeline occurrence does not match the requested anchor");
+    }
+    const reread = await this.locateOccurrenceNative(anchor.mediaHandle, true);
+    if (reread.status !== "unique" || reread.occurrences[0]?.identity !== anchor.identity) {
+      throw new Error("FINAL_CUT_NATIVE_OCCURRENCE_HANDLE_STALE: anchor occurrence identity became ambiguous or changed");
+    }
+    const observed = reread.occurrences[0]!;
+    if (anchor.start && observed.start && parseRationalString(anchor.start, "anchor start")
+      && compareRational(parseRationalString(anchor.start, "anchor start"), parseRationalString(observed.start, "observed anchor start")) !== 0) {
+      throw new Error("FINAL_CUT_NATIVE_OCCURRENCE_HANDLE_STALE: anchor occurrence start changed");
+    }
+    if (anchor.duration && observed.duration && parseRationalString(anchor.duration, "anchor duration")
+      && compareRational(parseRationalString(anchor.duration, "anchor duration"), parseRationalString(observed.duration, "observed anchor duration")) !== 0) {
+      throw new Error("FINAL_CUT_NATIVE_OCCURRENCE_HANDLE_STALE: anchor occurrence duration changed");
+    }
+  }
+
   private async ensureOccurrenceRange(occurrence: NativeFinalCutOccurrence): Promise<void> {
     if (occurrence.start && occurrence.duration) return;
     if (occurrence.timelineOffset === undefined) {
@@ -2463,6 +2488,9 @@ function validatePictureInPictureStyle(crop?: PictureInPictureCrop, frame?: Pict
 }
 
 function validatePictureInPictureAnchor(anchor: NativeFinalCutOccurrence, live: EditorLiveState): void {
+  if (!anchor.identity) {
+    throw new Error("FINAL_CUT_NATIVE_OCCURRENCE_ID_UNAVAILABLE: native PIP requires a stable anchor occurrence identity");
+  }
   if (anchor.sequenceId && live.sequence?.id !== anchor.sequenceId) {
     throw new Error("FINAL_CUT_NATIVE_OCCURRENCE_HANDLE_STALE: active sequence changed");
   }
@@ -3901,7 +3929,12 @@ function locateOccurrenceScript(match: NativeFinalCutMediaMatch, scanAll: boolea
             end repeat
             if candidateStart is not "" and candidateDuration is not "" then
               set candidateOffset to ((item 1 of candidatePosition) + 10) - (item 1 of mainOrigin)
-              set output to output & targetName & (ASCII character 31) & candidateRole & (ASCII character 31) & sourceIdentity & (ASCII character 31) & (candidateOffset as text) & (ASCII character 31) & candidateStart & (ASCII character 31) & candidateDuration & (ASCII character 30)
+            set candidateIdentity to ""
+            try
+              set candidateIdentity to value of attribute "AXIdentifier" of candidate as text
+            end try
+            if candidateIdentity is "" then error "FINAL_CUT_NATIVE_OCCURRENCE_ID_UNAVAILABLE: timeline clip has no AXIdentifier"
+            set output to output & targetName & (ASCII character 31) & candidateRole & (ASCII character 31) & sourceIdentity & (ASCII character 31) & (candidateOffset as text) & (ASCII character 31) & candidateStart & (ASCII character 31) & candidateDuration & (ASCII character 31) & candidateIdentity & (ASCII character 30)
             end if
           else
             set shouldDescend to false
@@ -4847,7 +4880,7 @@ function parseOccurrences(output: string, mediaHandle: string): NativeFinalCutOc
     .filter(Boolean)
     .map((record, index) => {
       const fields = record.split(String.fromCharCode(31));
-      const [name = "", role = "", sourceIdentity = "", timelineOffsetOrDuration = "", legacyTimelineOffset, nativeDuration] = fields;
+      const [name = "", role = "", sourceIdentity = "", timelineOffsetOrDuration = "", legacyTimelineOffset, nativeDuration, identity] = fields;
       const nativeRange = nativeDuration !== undefined;
       const legacyRecord = legacyTimelineOffset !== undefined && !nativeRange;
       const identityOrStart = sourceIdentity;
@@ -4857,6 +4890,7 @@ function parseOccurrences(output: string, mediaHandle: string): NativeFinalCutOc
         handle: opaqueHandle("occurrence"),
         mediaHandle,
         name,
+        ...(identity ? { identity } : {}),
         ...(role ? { role } : {}),
         ...(sourceIdentity && !legacyRange ? { sourceIdentity } : {}),
         ...(nativeRange ? { start: legacyTimelineOffset, duration: nativeDuration } : {}),

--- a/adapters/final-cut/typescript/src/native.ts
+++ b/adapters/final-cut/typescript/src/native.ts
@@ -2676,7 +2676,13 @@ function verifyNativePictureInPicture(
   if (preview.crop && JSON.stringify(observed.crop) !== JSON.stringify(preview.crop)) {
     return { verified: false, detail: "Final Cut did not read back the requested picture-in-picture crop" };
   }
-  if (preview.frame && JSON.stringify(observed.frame) !== JSON.stringify(preview.frame)) {
+  const observedFrame = observed.frame
+    ? { ...observed.frame, color: observed.frame.color.toLowerCase() }
+    : undefined;
+  const previewFrame = preview.frame
+    ? { ...preview.frame, color: preview.frame.color.toLowerCase() }
+    : undefined;
+  if (preview.frame && JSON.stringify(observedFrame) !== JSON.stringify(previewFrame)) {
     return { verified: false, detail: "Final Cut did not read back the requested picture-in-picture frame" };
   }
   if (!after.undoAvailable || !after.undoCommand) {

--- a/adapters/final-cut/typescript/src/native.ts
+++ b/adapters/final-cut/typescript/src/native.ts
@@ -1572,6 +1572,7 @@ export class FinalCutNativeAutomationAdapter implements NativeFinalCutEditor {
     validatePictureInPictureAnchor(anchorOccurrence, beforeLive);
     const startTimecode = this.toTimecode(preview.start, beforeLive);
     const endTimecode = this.toTimecode(preview.end, beforeLive);
+    const operationId = opaqueHandle("native-picture-in-picture");
 
     try {
       await this.executeNativeSequence(async () => {
@@ -1594,10 +1595,27 @@ export class FinalCutNativeAutomationAdapter implements NativeFinalCutEditor {
         await this.focusTimelineForMediaInsertion();
       });
     } catch (error) {
+      const observedContext = await this.inspectRawNative();
+      const observedLive = await this.readLiveState();
+      if (observedLive && observedLive.revision.id !== beforeLive.revision.id && observedContext.undoCommand) {
+        this.rememberOperation(operationId, {
+          kind: "picture-in-picture",
+          before,
+          after: observedContext,
+          beforeLive,
+          afterLive: observedLive,
+          undoCommand: observedContext.undoCommand,
+        });
+        try {
+          await this.undo(operationId);
+        } catch (rollbackError) {
+          throw new Error(`${nativeErrorCode(error)}: ${String(error)}; operationId=${operationId}; native rollback failed: ${String(rollbackError)}`);
+        }
+        throw new Error(`${nativeErrorCode(error)}: ${String(error)}; picture-in-picture placement was rolled back`);
+      }
       throw new Error(`${nativeErrorCode(error)}: ${String(error)}`);
     }
 
-    const operationId = opaqueHandle("native-picture-in-picture");
     let after: NativeFinalCutContext | undefined;
     let afterLive: EditorLiveState | undefined;
     try {

--- a/adapters/final-cut/typescript/src/native.ts
+++ b/adapters/final-cut/typescript/src/native.ts
@@ -2919,6 +2919,21 @@ function requireFrontmostAppleScript(): string {
 
 function timelinePreflightScript(): string {
   return `
+on findInspectorField(fieldLabel)
+  tell application "System Events"
+    tell process "Final Cut Pro"
+      repeat with candidate in text fields of front window
+        try
+          set candidateDescription to description of candidate as text
+          set candidateName to name of candidate as text
+          if candidateDescription contains fieldLabel or candidateName contains fieldLabel then return candidate
+        end try
+      end repeat
+    end tell
+  end tell
+  return missing value
+end findInspectorField
+
 tell application "System Events"
   tell process "Final Cut Pro"
     set frontmost to true
@@ -4894,16 +4909,6 @@ tell application "System Events"
       click inspectorTab
     end try
     delay 0.3
-    on findInspectorField(fieldLabel)
-      repeat with candidate in text fields of front window
-        try
-          set candidateDescription to description of candidate as text
-          set candidateName to name of candidate as text
-          if candidateDescription contains fieldLabel or candidateName contains fieldLabel then return candidate
-        end try
-      end repeat
-      return missing value
-    end findInspectorField
     ${requiredFieldLookup}
     ${optionalLookup}
     ${optionalFields}
@@ -4914,11 +4919,9 @@ end tell`;
 
 function pictureInPictureInspectorReadbackScript(): string {
   return `
--- FRAMEKIT_NATIVE_PIP_READBACK
-tell application "System Events"
-  tell process "Final Cut Pro"
-    ${requireFrontmostAppleScript()}
-    on readInspectorField(fieldLabel, fallback)
+on readInspectorField(fieldLabel, fallback)
+  tell application "System Events"
+    tell process "Final Cut Pro"
       repeat with candidate in text fields of front window
         try
           set candidateDescription to description of candidate as text
@@ -4926,8 +4929,15 @@ tell application "System Events"
           if candidateDescription contains fieldLabel or candidateName contains fieldLabel then return value of candidate as text
         end try
       end repeat
-      return fallback
-    end readInspectorField
+    end tell
+  end tell
+  return fallback
+end readInspectorField
+
+-- FRAMEKIT_NATIVE_PIP_READBACK
+tell application "System Events"
+  tell process "Final Cut Pro"
+    ${requireFrontmostAppleScript()}
     set positionXText to my readInspectorField("Position X", "")
     set positionYText to my readInspectorField("Position Y", "")
     set scaleText to my readInspectorField("Scale", "")

--- a/adapters/final-cut/typescript/src/native.ts
+++ b/adapters/final-cut/typescript/src/native.ts
@@ -3,7 +3,15 @@ import { execFile as execFileCallback } from "node:child_process";
 import { access, constants, stat } from "node:fs/promises";
 import { basename, dirname, extname, resolve } from "node:path";
 import { promisify } from "node:util";
-import type { ContextRevision, EditorAsset, EditorLiveState, RationalTime } from "@framekit/runtime";
+import type {
+  ContextRevision,
+  EditorAsset,
+  EditorLiveState,
+  PictureInPictureCrop,
+  PictureInPictureFrame,
+  PictureInPicturePosition,
+  RationalTime,
+} from "@framekit/runtime";
 import type { NativeOperationLease } from "./native-operation.js";
 
 const execFile = promisify(execFileCallback);
@@ -171,6 +179,66 @@ export interface NativeFinalCutTitleResult {
   undoCommand?: string;
 }
 
+export interface NativeFinalCutPictureInPictureRequest {
+  mediaHandle: string;
+  anchorOccurrenceHandle: string;
+  start: RationalTime;
+  duration: RationalTime;
+  position: PictureInPicturePosition;
+  scale: number;
+  crop?: PictureInPictureCrop;
+  frame?: PictureInPictureFrame;
+}
+
+export interface NativeFinalCutPictureInPictureReadback {
+  position: PictureInPicturePosition;
+  scale: number;
+  crop?: PictureInPictureCrop;
+  frame?: PictureInPictureFrame;
+}
+
+export interface NativeFinalCutPictureInPicturePreview {
+  previewToken: string;
+  media: NativeFinalCutMediaMatch;
+  anchorOccurrence: NativeFinalCutOccurrence;
+  start: RationalTime;
+  end: RationalTime;
+  duration: RationalTime;
+  position: PictureInPicturePosition;
+  scale: number;
+  crop?: PictureInPictureCrop;
+  frame?: PictureInPictureFrame;
+  sequenceId?: string;
+  revision: string;
+  command: "Add native picture-in-picture";
+  expiresAt: string;
+}
+
+export interface NativeFinalCutPictureInPictureResult {
+  operationId: string;
+  previewToken: string;
+  media: NativeFinalCutMediaMatch;
+  anchorOccurrence: NativeFinalCutOccurrence;
+  start: RationalTime;
+  end: RationalTime;
+  duration: RationalTime;
+  position: PictureInPicturePosition;
+  scale: number;
+  crop?: PictureInPictureCrop;
+  frame?: PictureInPictureFrame;
+  observed: NativeFinalCutPictureInPictureReadback;
+  before: NativeFinalCutContext;
+  after: NativeFinalCutContext;
+  beforeRevision: ContextRevision;
+  afterRevision: ContextRevision;
+  verification: {
+    verified: boolean;
+    detail: string;
+  };
+  undoAvailable: boolean;
+  undoCommand?: string;
+}
+
 export interface NativeFinalCutTransitionMatch {
   id: string;
   kind: "transition";
@@ -295,6 +363,7 @@ export interface NativeFinalCutCapabilities {
   mediaAppend: boolean;
   mediaInsert: boolean;
   titlePlacement: boolean;
+  pictureInPicture?: boolean;
   transitionDiscovery?: boolean;
   transitionPlacement?: boolean;
   timelineFocus: boolean;
@@ -327,7 +396,7 @@ export interface NativeFinalCutUndoResult {
   };
 }
 
-type NativeOperationKind = "selection" | "blade" | "range" | "media-insertion" | "title-placement" | "transition-placement";
+type NativeOperationKind = "selection" | "blade" | "range" | "media-insertion" | "title-placement" | "picture-in-picture" | "transition-placement";
 type NativeRetryValidator = (context: NativeFinalCutContext) => Promise<void> | void;
 
 interface NativeOperationRecord {
@@ -389,6 +458,8 @@ export interface NativeFinalCutEditor {
   executeInsertMedia(previewToken: string): Promise<NativeFinalCutMediaInsertionResult>;
   previewTitleAdd(request: NativeFinalCutTitleRequest): Promise<NativeFinalCutTitlePreview>;
   executeTitleAdd(previewToken: string): Promise<NativeFinalCutTitleResult>;
+  previewPictureInPicture(request: NativeFinalCutPictureInPictureRequest): Promise<NativeFinalCutPictureInPicturePreview>;
+  executePictureInPicture(previewToken: string): Promise<NativeFinalCutPictureInPictureResult>;
   searchTransitions(query: string): Promise<NativeFinalCutTransitionMatch[]>;
   previewTransitionAdd(request: NativeFinalCutTransitionRequest): Promise<NativeFinalCutTransitionPreview>;
   executeTransitionAdd(previewToken: string): Promise<NativeFinalCutTransitionResult>;
@@ -454,6 +525,20 @@ export class FinalCutNativeAutomationAdapter implements NativeFinalCutEditor {
     revision: string;
     expiresAt: number;
   }>();
+  private readonly pictureInPicturePreviews = new Map<string, {
+    mediaHandle: string;
+    anchorOccurrence: NativeFinalCutOccurrence;
+    start: RationalTime;
+    end: RationalTime;
+    duration: RationalTime;
+    position: PictureInPicturePosition;
+    scale: number;
+    crop?: PictureInPictureCrop;
+    frame?: PictureInPictureFrame;
+    sequenceId?: string;
+    revision: string;
+    expiresAt: number;
+  }>();
   private readonly transitionPreviews = new Map<string, {
     asset: NativeFinalCutTransitionMatch;
     beforeOccurrence: NativeFinalCutOccurrence;
@@ -496,6 +581,7 @@ export class FinalCutNativeAutomationAdapter implements NativeFinalCutEditor {
       mediaAppend: this.enabled,
       mediaInsert: this.enabled,
       titlePlacement: this.enabled,
+      pictureInPicture: this.enabled,
       transitionDiscovery: this.enabled,
       transitionPlacement: this.enabled,
       timelineFocus: this.enabled,
@@ -1069,6 +1155,14 @@ export class FinalCutNativeAutomationAdapter implements NativeFinalCutEditor {
     return this.withNativeUi(() => this.executeTitleAddNative(previewToken));
   }
 
+  public async previewPictureInPicture(request: NativeFinalCutPictureInPictureRequest): Promise<NativeFinalCutPictureInPicturePreview> {
+    return this.withNativeUi(() => this.previewPictureInPictureNative(request));
+  }
+
+  public async executePictureInPicture(previewToken: string): Promise<NativeFinalCutPictureInPictureResult> {
+    return this.withNativeUi(() => this.executePictureInPictureNative(previewToken));
+  }
+
   public async searchTransitions(query: string): Promise<NativeFinalCutTransitionMatch[]> {
     return this.withNativeUi(() => this.searchTransitionsNative(query));
   }
@@ -1395,6 +1489,185 @@ export class FinalCutNativeAutomationAdapter implements NativeFinalCutEditor {
       undoAvailable: after.undoAvailable,
       ...(after.undoCommand ? { undoCommand: after.undoCommand } : {}),
     };
+  }
+
+  private async previewPictureInPictureNative(
+    request: NativeFinalCutPictureInPictureRequest,
+  ): Promise<NativeFinalCutPictureInPicturePreview> {
+    this.assertEnabled();
+    const media = this.mediaHandles.get(request.mediaHandle);
+    if (!media) throw new Error(`FINAL_CUT_NATIVE_MEDIA_HANDLE_STALE: unknown media handle ${request.mediaHandle}`);
+    if (this.selectedMediaHandle !== request.mediaHandle) {
+      throw new Error("FINAL_CUT_NATIVE_MEDIA_SELECTION_REQUIRED: select one Browser media result before picture-in-picture placement");
+    }
+    const anchorOccurrence = this.occurrenceHandles.get(request.anchorOccurrenceHandle);
+    if (!anchorOccurrence) {
+      throw new Error(`FINAL_CUT_NATIVE_OCCURRENCE_HANDLE_STALE: unknown anchor occurrence ${request.anchorOccurrenceHandle}`);
+    }
+    await this.ensureOccurrenceRange(anchorOccurrence);
+    const context = await this.requireTimelineContext();
+    if (!context.frontmost) throw new Error("FINAL_CUT_NATIVE_NOT_FRONTMOST: Final Cut's timeline must be frontmost");
+    const live = await this.requireLiveState();
+    const sequenceStart = live.sequenceTimeRange?.start ?? live.sequence?.startTime;
+    const sequenceDuration = live.sequenceTimeRange?.duration ?? live.sequence?.duration;
+    const frameDuration = live.sequence?.frameDuration;
+    if (!sequenceStart || !sequenceDuration || !frameDuration) {
+      throw new Error("CAPABILITY_UNAVAILABLE: Final Cut sequence timing is unavailable");
+    }
+    const start = structuredClone(request.start);
+    const duration = structuredClone(request.duration);
+    const end = addRational(start, duration);
+    validatePictureInPictureRequest(request, sequenceStart, sequenceDuration, frameDuration, start, end);
+    validatePictureInPictureAnchor(anchorOccurrence, live);
+
+    const expiresAt = this.now() + 30_000;
+    const previewToken = opaqueHandle("picture-in-picture-preview");
+    this.pictureInPicturePreviews.set(previewToken, {
+      mediaHandle: request.mediaHandle,
+      anchorOccurrence: structuredClone(anchorOccurrence),
+      start,
+      end,
+      duration,
+      position: structuredClone(request.position),
+      scale: request.scale,
+      ...(request.crop ? { crop: structuredClone(request.crop) } : {}),
+      ...(request.frame ? { frame: structuredClone(request.frame) } : {}),
+      sequenceId: live.sequence?.id,
+      revision: live.revision.id,
+      expiresAt,
+    });
+    return {
+      previewToken,
+      media: structuredClone(media),
+      anchorOccurrence: structuredClone(anchorOccurrence),
+      start,
+      end,
+      duration,
+      position: structuredClone(request.position),
+      scale: request.scale,
+      ...(request.crop ? { crop: structuredClone(request.crop) } : {}),
+      ...(request.frame ? { frame: structuredClone(request.frame) } : {}),
+      ...(live.sequence?.id ? { sequenceId: live.sequence.id } : {}),
+      revision: live.revision.id,
+      command: "Add native picture-in-picture",
+      expiresAt: new Date(expiresAt).toISOString(),
+    };
+  }
+
+  private async executePictureInPictureNative(previewToken: string): Promise<NativeFinalCutPictureInPictureResult> {
+    this.assertEnabled();
+    const preview = this.pictureInPicturePreviews.get(previewToken);
+    if (!preview) throw new Error("FINAL_CUT_NATIVE_PREVIEW_STALE: unknown native picture-in-picture preview");
+    this.pictureInPicturePreviews.delete(previewToken);
+    if (this.now() > preview.expiresAt) throw new Error("FINAL_CUT_NATIVE_PREVIEW_STALE: native picture-in-picture preview has expired");
+    const media = this.mediaHandles.get(preview.mediaHandle);
+    if (!media) throw new Error(`FINAL_CUT_NATIVE_MEDIA_HANDLE_STALE: unknown media handle ${preview.mediaHandle}`);
+    if (this.selectedMediaHandle !== preview.mediaHandle) {
+      throw new Error("FINAL_CUT_NATIVE_MEDIA_SELECTION_REQUIRED: selected Browser media changed before picture-in-picture placement");
+    }
+    const before = await this.requireTimelineContext();
+    const beforeLive = await this.requireLiveState();
+    validatePictureInPicturePreviewBinding(preview, beforeLive);
+    const anchorOccurrence = this.occurrenceHandles.get(preview.anchorOccurrence.handle) ?? preview.anchorOccurrence;
+    validatePictureInPictureAnchor(anchorOccurrence, beforeLive);
+    const startTimecode = this.toTimecode(preview.start, beforeLive);
+    const endTimecode = this.toTimecode(preview.end, beforeLive);
+
+    try {
+      await this.executeNativeSequence(async () => {
+        await this.selectMediaNative(preview.mediaHandle);
+        await this.focusTimelineForMediaInsertion();
+        if (this.canDriveNativeMouse && anchorOccurrence.timelineOffset !== undefined) {
+          await selectTimelineOccurrence(this.executor, anchorOccurrence.timelineOffset);
+        }
+        await this.executor(setPlayheadScript(startTimecode));
+        await this.waitForPlayhead(preview.start, beforeLive.sequence?.id);
+        await this.executor(markRangeStartScript());
+        await this.executor(setPlayheadScript(endTimecode));
+        await this.waitForPlayhead(preview.end, beforeLive.sequence?.id);
+        await this.executor(markRangeEndAndConnectPictureInPictureScript());
+        await this.executor(pictureInPictureTransformScript(preview));
+      }, async (recovered) => {
+        this.assertRetryContext(before, recovered, true);
+        validatePictureInPicturePreviewBinding(preview, await this.requireLiveState());
+        await this.selectMediaNative(preview.mediaHandle);
+        await this.focusTimelineForMediaInsertion();
+      });
+    } catch (error) {
+      throw new Error(`${nativeErrorCode(error)}: ${String(error)}`);
+    }
+
+    const operationId = opaqueHandle("native-picture-in-picture");
+    let after: NativeFinalCutContext | undefined;
+    let afterLive: EditorLiveState | undefined;
+    try {
+      after = await this.requireTimelineContext();
+      afterLive = await this.waitForRevision(beforeLive.revision.id);
+      const observed = parsePictureInPictureReadback(await this.executor(pictureInPictureInspectorReadbackScript()));
+      const verification = verifyNativePictureInPicture({ ...preview, media }, after, beforeLive, afterLive, observed);
+      const operation = {
+        kind: "picture-in-picture" as const,
+        before,
+        after,
+        beforeLive,
+        afterLive,
+        undoCommand: after.undoCommand,
+      } satisfies NativeOperationRecord;
+      if (!verification.verified) {
+        if (afterLive.revision.id !== beforeLive.revision.id && after.undoAvailable && after.undoCommand) {
+          this.rememberOperation(operationId, operation);
+          try {
+            await this.undo(operationId);
+          } catch (rollbackError) {
+            throw new Error(`FINAL_CUT_NATIVE_VERIFICATION_FAILED: ${verification.detail}; operationId=${operationId}; native rollback failed: ${String(rollbackError)}`);
+          }
+          throw new Error(`FINAL_CUT_NATIVE_VERIFICATION_FAILED: ${verification.detail}; picture-in-picture placement was rolled back`);
+        }
+        throw new Error(`FINAL_CUT_NATIVE_VERIFICATION_FAILED: ${verification.detail}`);
+      }
+      this.rememberOperation(operationId, operation);
+      return {
+        operationId,
+        previewToken,
+        media: structuredClone(media),
+        anchorOccurrence: structuredClone(anchorOccurrence),
+        start: structuredClone(preview.start),
+        end: structuredClone(preview.end),
+        duration: structuredClone(preview.duration),
+        position: structuredClone(preview.position),
+        scale: preview.scale,
+        ...(preview.crop ? { crop: structuredClone(preview.crop) } : {}),
+        ...(preview.frame ? { frame: structuredClone(preview.frame) } : {}),
+        observed,
+        before,
+        after,
+        beforeRevision: beforeLive.revision,
+        afterRevision: afterLive.revision,
+        verification,
+        undoAvailable: after.undoAvailable,
+        ...(after.undoCommand ? { undoCommand: after.undoCommand } : {}),
+      };
+    } catch (error) {
+      const observedContext = after ?? await this.inspectRawNative();
+      const observedLive = afterLive ?? await this.readLiveState();
+      if (observedLive && observedLive.revision.id !== beforeLive.revision.id && observedContext.undoCommand) {
+        this.rememberOperation(operationId, {
+          kind: "picture-in-picture",
+          before,
+          after: observedContext,
+          beforeLive,
+          afterLive: observedLive,
+          undoCommand: observedContext.undoCommand,
+        });
+        try {
+          await this.undo(operationId);
+        } catch (rollbackError) {
+          throw new Error(`${nativeErrorCode(error)}: ${String(error)}; operationId=${operationId}; native rollback failed: ${String(rollbackError)}`);
+        }
+        throw new Error(`${nativeErrorCode(error)}: ${String(error)}; picture-in-picture placement was rolled back`);
+      }
+      throw new Error(`${nativeErrorCode(error)}: ${String(error)}`);
+    }
   }
 
   private async previewMediaInsertionNative(
@@ -2127,6 +2400,159 @@ function verifyNativeTitle(
   return {
     verified: true,
     detail: `Final Cut selected ${preview.asset.name} for ${preview.start.value}/${preview.start.timescale}-${preview.end.value}/${preview.end.timescale} (${preview.duration.value}/${preview.duration.timescale}) at revision ${afterLive.revision.id}`,
+  };
+}
+
+function validatePictureInPictureRequest(
+  request: NativeFinalCutPictureInPictureRequest,
+  sequenceStart: RationalTime,
+  sequenceDuration: RationalTime,
+  frameDuration: RationalTime,
+  start: RationalTime,
+  end: RationalTime,
+): void {
+  if (compareRational(request.duration, zeroRational()) <= 0) {
+    throw new Error("INVALID_OPERATION: native picture-in-picture duration must be positive");
+  }
+  if (!isFrameAligned(start, sequenceStart, frameDuration) || !isFrameAligned(request.duration, zeroRational(), frameDuration)) {
+    throw new Error("INVALID_OPERATION: native picture-in-picture range must align to the sequence frame duration");
+  }
+  const sequenceEnd = addRational(sequenceStart, sequenceDuration);
+  if (compareRational(start, sequenceStart) < 0 || compareRational(end, sequenceEnd) > 0) {
+    throw new Error("FINAL_CUT_NATIVE_PICTURE_IN_PICTURE_RANGE_OUT_OF_BOUNDS: placement must be inside the active sequence");
+  }
+  if (!Number.isFinite(request.position.x) || !Number.isFinite(request.position.y)) {
+    throw new Error("INVALID_OPERATION: native picture-in-picture position must be finite");
+  }
+  if (!Number.isFinite(request.scale) || request.scale <= 0) {
+    throw new Error("INVALID_OPERATION: native picture-in-picture scale must be positive");
+  }
+  validatePictureInPictureStyle(request.crop, request.frame);
+}
+
+function validatePictureInPictureStyle(crop?: PictureInPictureCrop, frame?: PictureInPictureFrame): void {
+  if (crop) {
+    const values = [crop.top, crop.right, crop.bottom, crop.left];
+    if (!values.every((value) => Number.isFinite(value) && value >= 0 && value < 1)
+      || crop.left + crop.right >= 1
+      || crop.top + crop.bottom >= 1) {
+      throw new Error("INVALID_OPERATION: native picture-in-picture crop must leave a visible rectangle");
+    }
+  }
+  if (frame && (frame.style !== "solid" || !/^#[0-9a-f]{6}$/i.test(frame.color) || !Number.isFinite(frame.width) || frame.width < 0)) {
+    throw new Error("INVALID_OPERATION: native picture-in-picture frame must be a solid six-digit hex color with nonnegative width");
+  }
+}
+
+function validatePictureInPictureAnchor(anchor: NativeFinalCutOccurrence, live: EditorLiveState): void {
+  if (anchor.sequenceId && live.sequence?.id !== anchor.sequenceId) {
+    throw new Error("FINAL_CUT_NATIVE_OCCURRENCE_HANDLE_STALE: active sequence changed");
+  }
+  if (anchor.revision && live.revision.id !== anchor.revision) {
+    throw new Error("FINAL_CUT_NATIVE_OCCURRENCE_HANDLE_STALE: playhead or timeline revision changed");
+  }
+  if (!anchor.start || !anchor.duration) {
+    throw new Error("FINAL_CUT_NATIVE_EDIT_POINT_POSITION_UNAVAILABLE: anchor occurrence has no exact timeline range");
+  }
+}
+
+function validatePictureInPicturePreviewBinding(
+  preview: { sequenceId?: string; revision: string; anchorOccurrence: NativeFinalCutOccurrence },
+  live: EditorLiveState,
+): void {
+  if (preview.sequenceId && live.sequence?.id !== preview.sequenceId) {
+    throw new Error("FINAL_CUT_NATIVE_PREVIEW_STALE: active sequence changed");
+  }
+  if (live.revision.id !== preview.revision) {
+    throw new Error("FINAL_CUT_NATIVE_PREVIEW_STALE: playhead or timeline revision changed");
+  }
+  validatePictureInPictureAnchor(preview.anchorOccurrence, live);
+}
+
+function parsePictureInPictureReadback(output: string): NativeFinalCutPictureInPictureReadback {
+  const [xText, yText, scalePercentText, frameStyle = "", frameColor = "", frameWidthText = "", topText = "", rightText = "", bottomText = "", leftText = ""] = output.split(String.fromCharCode(31));
+  const x = inspectorNumber(xText);
+  const y = inspectorNumber(yText);
+  const scalePercent = inspectorNumber(scalePercentText);
+  if (![x, y, scalePercent].every(Number.isFinite) || scalePercent <= 0) {
+    throw new Error("FINAL_CUT_NATIVE_PICTURE_IN_PICTURE_READBACK_UNAVAILABLE: Final Cut did not expose finite transform values");
+  }
+  const readback: NativeFinalCutPictureInPictureReadback = {
+    position: { x, y },
+    scale: scalePercent / 100,
+  };
+  if (frameStyle || frameColor || frameWidthText) {
+    const frameWidth = inspectorNumber(frameWidthText);
+    if (!frameStyle || !frameColor || !Number.isFinite(frameWidth)) {
+      throw new Error("FINAL_CUT_NATIVE_PICTURE_IN_PICTURE_READBACK_UNAVAILABLE: Final Cut returned an incomplete frame");
+    }
+    const frame = { style: frameStyle as PictureInPictureFrame["style"], color: frameColor, width: frameWidth };
+    validatePictureInPictureStyle(undefined, frame);
+    readback.frame = frame;
+  }
+  if (topText || rightText || bottomText || leftText) {
+    const crop = {
+      top: inspectorFraction(topText),
+      right: inspectorFraction(rightText),
+      bottom: inspectorFraction(bottomText),
+      left: inspectorFraction(leftText),
+    };
+    if (![crop.top, crop.right, crop.bottom, crop.left].every(Number.isFinite)) {
+      throw new Error("FINAL_CUT_NATIVE_PICTURE_IN_PICTURE_READBACK_UNAVAILABLE: Final Cut returned an incomplete crop");
+    }
+    validatePictureInPictureStyle(crop, undefined);
+    readback.crop = crop;
+  }
+  return readback;
+}
+
+function inspectorNumber(value: string | undefined): number {
+  const normalized = (value ?? "").trim().replace(/,/g, "").replace(/%$/, "");
+  const number = Number(normalized);
+  return Number.isFinite(number) ? number : Number.NaN;
+}
+
+function inspectorFraction(value: string | undefined): number {
+  const normalized = (value ?? "").trim();
+  const number = inspectorNumber(normalized);
+  return normalized.endsWith("%") ? number / 100 : number;
+}
+
+function verifyNativePictureInPicture(
+  preview: { media: NativeFinalCutMediaMatch; position: PictureInPicturePosition; scale: number; crop?: PictureInPictureCrop; frame?: PictureInPictureFrame; start: RationalTime; end: RationalTime },
+  after: NativeFinalCutContext,
+  beforeLive: EditorLiveState,
+  afterLive: EditorLiveState,
+  observed: NativeFinalCutPictureInPictureReadback,
+): NativeFinalCutPictureInPictureResult["verification"] {
+  if (afterLive.revision.id === beforeLive.revision.id) {
+    return { verified: false, detail: "Final Cut did not expose a new revision after native picture-in-picture placement" };
+  }
+  if (after.target.kind !== "selected-clip") {
+    return { verified: false, detail: "Final Cut did not expose the inserted picture-in-picture clip as the selected timeline item" };
+  }
+  const observedName = after.target.name ?? "";
+  if (observedName && !observedName.toLowerCase().includes(preview.media.name.toLowerCase())) {
+    return { verified: false, detail: `Final Cut selected ${observedName}, not ${preview.media.name}` };
+  }
+  if (Math.abs(observed.position.x - preview.position.x) > 0.001 || Math.abs(observed.position.y - preview.position.y) > 0.001) {
+    return { verified: false, detail: `Final Cut read back position ${observed.position.x},${observed.position.y}, expected ${preview.position.x},${preview.position.y}` };
+  }
+  if (Math.abs(observed.scale - preview.scale) > 0.0001) {
+    return { verified: false, detail: `Final Cut read back scale ${observed.scale}, expected ${preview.scale}` };
+  }
+  if (preview.crop && JSON.stringify(observed.crop) !== JSON.stringify(preview.crop)) {
+    return { verified: false, detail: "Final Cut did not read back the requested picture-in-picture crop" };
+  }
+  if (preview.frame && JSON.stringify(observed.frame) !== JSON.stringify(preview.frame)) {
+    return { verified: false, detail: "Final Cut did not read back the requested picture-in-picture frame" };
+  }
+  if (!after.undoAvailable || !after.undoCommand) {
+    return { verified: false, detail: "Final Cut did not expose an Undo command for native picture-in-picture placement" };
+  }
+  return {
+    verified: true,
+    detail: `Final Cut verified ${preview.media.name} at ${preview.start.value}/${preview.start.timescale}-${preview.end.value}/${preview.end.timescale} with transform readback at revision ${afterLive.revision.id}`,
   };
 }
 
@@ -4089,6 +4515,128 @@ tell application "System Events"
     delay 0.2
     keystroke "q"
     delay 0.5
+  end tell
+end tell`;
+}
+
+function markRangeEndAndConnectPictureInPictureScript(): string {
+  return `
+tell application "System Events"
+  tell process "Final Cut Pro"
+    ${requireFrontmostAppleScript()}
+    keystroke "o"
+    delay 0.2
+    -- Q connects the selected Browser video to the selected primary clip.
+    keystroke "q"
+    delay 0.5
+  end tell
+end tell`;
+}
+
+function pictureInPictureTransformScript(preview: {
+  position: PictureInPicturePosition;
+  scale: number;
+  crop?: PictureInPictureCrop;
+  frame?: PictureInPictureFrame;
+}): string {
+  const optionalFields = [
+    preview.crop ? `
+    set value of cropTopField to ${appleScriptString(String(preview.crop.top * 100))}
+    set value of cropRightField to ${appleScriptString(String(preview.crop.right * 100))}
+    set value of cropBottomField to ${appleScriptString(String(preview.crop.bottom * 100))}
+    set value of cropLeftField to ${appleScriptString(String(preview.crop.left * 100))}` : "",
+    preview.frame ? `
+    set value of frameStyleField to ${appleScriptString(preview.frame.style)}
+    set value of frameColorField to ${appleScriptString(preview.frame.color)}
+    set value of frameWidthField to ${appleScriptString(String(preview.frame.width))}` : "",
+  ].join("");
+  const requiredFieldLookup = `
+    set positionXField to my findInspectorField("Position X")
+    set positionYField to my findInspectorField("Position Y")
+    set scaleField to my findInspectorField("Scale")
+    if positionXField is missing value or positionYField is missing value or scaleField is missing value then error "FINAL_CUT_NATIVE_PICTURE_IN_PICTURE_TRANSFORM_UNAVAILABLE: Transform inspector fields were not visible"
+    set value of positionXField to ${appleScriptString(String(preview.position.x))}
+    set value of positionYField to ${appleScriptString(String(preview.position.y))}
+    set value of scaleField to ${appleScriptString(String(preview.scale * 100))}`;
+  const optionalLookup = `${preview.crop ? `
+    set cropTopField to my findInspectorField("Crop Top")
+    set cropRightField to my findInspectorField("Crop Right")
+    set cropBottomField to my findInspectorField("Crop Bottom")
+    set cropLeftField to my findInspectorField("Crop Left")
+    if cropTopField is missing value or cropRightField is missing value or cropBottomField is missing value or cropLeftField is missing value then error "FINAL_CUT_NATIVE_PICTURE_IN_PICTURE_CROP_UNAVAILABLE: Crop inspector fields were not visible"` : ""}${preview.frame ? `
+    set frameStyleField to my findInspectorField("Frame Style")
+    set frameColorField to my findInspectorField("Frame Color")
+    set frameWidthField to my findInspectorField("Frame Width")
+    if frameStyleField is missing value or frameColorField is missing value or frameWidthField is missing value then error "FINAL_CUT_NATIVE_PICTURE_IN_PICTURE_FRAME_UNAVAILABLE: Frame inspector fields were not visible"` : ""}`;
+  return `
+tell application "System Events"
+  tell process "Final Cut Pro"
+    ${requireFrontmostAppleScript()}
+    set mainWindow to window "Final Cut Pro"
+    set inspectorTab to missing value
+    repeat with candidate in entire contents of mainWindow
+      try
+        set candidateDescription to description of candidate as text
+        set candidateName to name of candidate as text
+        if candidateDescription contains "Video Inspector" or candidateName is "Inspector" then
+          set inspectorTab to candidate
+          exit repeat
+        end if
+      end try
+    end repeat
+    if inspectorTab is missing value then error "FINAL_CUT_NATIVE_PICTURE_IN_PICTURE_TRANSFORM_UNAVAILABLE: Video Inspector was not visible"
+    try
+      perform action "AXPress" of inspectorTab
+    on error
+      click inspectorTab
+    end try
+    delay 0.3
+    on findInspectorField(fieldLabel)
+      repeat with candidate in text fields of front window
+        try
+          set candidateDescription to description of candidate as text
+          set candidateName to name of candidate as text
+          if candidateDescription contains fieldLabel or candidateName contains fieldLabel then return candidate
+        end try
+      end repeat
+      return missing value
+    end findInspectorField
+    ${requiredFieldLookup}
+    ${optionalLookup}
+    ${optionalFields}
+    delay 0.2
+  end tell
+end tell`;
+}
+
+function pictureInPictureInspectorReadbackScript(): string {
+  return `
+-- FRAMEKIT_NATIVE_PIP_READBACK
+tell application "System Events"
+  tell process "Final Cut Pro"
+    ${requireFrontmostAppleScript()}
+    on readInspectorField(fieldLabel, fallback)
+      repeat with candidate in text fields of front window
+        try
+          set candidateDescription to description of candidate as text
+          set candidateName to name of candidate as text
+          if candidateDescription contains fieldLabel or candidateName contains fieldLabel then return value of candidate as text
+        end try
+      end repeat
+      return fallback
+    end readInspectorField
+    set positionXText to my readInspectorField("Position X", "")
+    set positionYText to my readInspectorField("Position Y", "")
+    set scaleText to my readInspectorField("Scale", "")
+    if positionXText is "" or positionYText is "" or scaleText is "" then error "FINAL_CUT_NATIVE_PICTURE_IN_PICTURE_READBACK_UNAVAILABLE: Transform inspector values were not visible"
+    set frameStyleText to my readInspectorField("Frame Style", "")
+    set frameColorText to my readInspectorField("Frame Color", "")
+    set frameWidthText to my readInspectorField("Frame Width", "")
+    set cropTopText to my readInspectorField("Crop Top", "")
+    set cropRightText to my readInspectorField("Crop Right", "")
+    set cropBottomText to my readInspectorField("Crop Bottom", "")
+    set cropLeftText to my readInspectorField("Crop Left", "")
+    return positionXText & (ASCII character 31) & positionYText & (ASCII character 31) & scaleText & (ASCII character 31) & frameStyleText & (ASCII character 31) & frameColorText & (ASCII character 31) & frameWidthText & (ASCII character 31) & cropTopText & (ASCII character 31) & cropRightText & (ASCII character 31) & cropBottomText & (ASCII character 31) & cropLeftText
   end tell
 end tell`;
 }

--- a/adapters/final-cut/typescript/src/native.ts
+++ b/adapters/final-cut/typescript/src/native.ts
@@ -2594,7 +2594,7 @@ function inspectorFraction(value: string | undefined): number {
 }
 
 function verifyNativePictureInPicture(
-  preview: { media: NativeFinalCutMediaMatch; position: PictureInPicturePosition; scale: number; crop?: PictureInPictureCrop; frame?: PictureInPictureFrame; start: RationalTime; end: RationalTime },
+  preview: { media: NativeFinalCutMediaMatch; position: PictureInPicturePosition; scale: number; crop?: PictureInPictureCrop; frame?: PictureInPictureFrame; start: RationalTime; end: RationalTime; duration: RationalTime },
   after: NativeFinalCutContext,
   beforeLive: EditorLiveState,
   afterLive: EditorLiveState,

--- a/apps/mcp-server/src/routing.ts
+++ b/apps/mcp-server/src/routing.ts
@@ -3,6 +3,7 @@ import type { EditorIdentity, RuntimeCapabilities } from "@framekit/runtime";
 export type EditingRouteOperation =
   | "timeline.edit"
   | "editor.native.edit"
+  | "editor.native.picture-in-picture"
   | "timeline.publish.new-project"
   | "timeline.export";
 
@@ -91,6 +92,13 @@ const operationRequirements: Record<EditingRouteOperation, Requirement[]> = {
   ],
   "editor.native.edit": [
     nativeRequirement("selectionEdit"),
+    nativeRequirement("timelineFocus"),
+    nativeRequirement("undo"),
+  ],
+  "editor.native.picture-in-picture": [
+    nativeRequirement("pictureInPicture"),
+    nativeRequirement("mediaSelection"),
+    nativeRequirement("timelineOccurrenceLocate"),
     nativeRequirement("timelineFocus"),
     nativeRequirement("undo"),
   ],

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -335,6 +335,28 @@ const workflowOperationSchema = z.discriminatedUnion("type", [
     targetLane: z.union([z.literal("primary"), z.number().int()]).optional(),
   }),
   z.object({
+    type: z.literal("timeline.picture-in-picture.add"),
+    occurrenceId: z.string().min(1),
+    mediaId: z.string().min(1),
+    attachedTo: z.string().min(1),
+    start: z.number().finite().nonnegative(),
+    duration: z.number().finite().positive(),
+    targetLane: z.number().int().refine((lane) => lane !== 0, "PIP requires a connected non-primary lane"),
+    position: z.object({ x: z.number().finite(), y: z.number().finite() }),
+    scale: z.number().finite().positive(),
+    crop: z.object({
+      top: z.number().finite().min(0).lt(1),
+      right: z.number().finite().min(0).lt(1),
+      bottom: z.number().finite().min(0).lt(1),
+      left: z.number().finite().min(0).lt(1),
+    }).optional(),
+    frame: z.object({
+      style: z.literal("solid"),
+      color: z.string().regex(/^#[0-9a-f]{6}$/i),
+      width: z.number().finite().nonnegative(),
+    }).optional(),
+  }),
+  z.object({
     type: z.literal("timeline.audio.fades"),
     clipId: z.string().min(1),
     fadeIn: z.number().nonnegative(),
@@ -402,6 +424,11 @@ const workflowOperationsSchema = z.array(workflowOperationSchema).min(1).superRe
     if (operation.type === "timeline.media.add" && operation.role === "audio"
       && (typeof operation.targetLane !== "number" || operation.targetLane === 0)) {
       context.addIssue({ code: z.ZodIssueCode.custom, path: [index, "targetLane"], message: "audio requires an explicit non-primary lane" });
+    }
+    if (operation.type === "timeline.picture-in-picture.add"
+      && operation.crop
+      && (operation.crop.left + operation.crop.right >= 1 || operation.crop.top + operation.crop.bottom >= 1)) {
+      context.addIssue({ code: z.ZodIssueCode.custom, path: [index, "crop"], message: "PIP crop must leave a positive source rectangle" });
     }
     if (operation.type === "timeline.audio.mix"
       && operation.gainDb === undefined && operation.fadeIn === undefined && operation.fadeOut === undefined) {

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -541,6 +541,25 @@ const nativeTransitionPreviewSchema = {
   afterOccurrenceHandle: z.string().min(1),
   duration: rationalTimeSchema,
 };
+const nativePictureInPicturePreviewSchema = {
+  mediaHandle: z.string().min(1),
+  anchorOccurrenceHandle: z.string().min(1),
+  start: rationalTimeSchema,
+  duration: rationalTimeSchema,
+  position: z.object({ x: z.number().finite(), y: z.number().finite() }),
+  scale: z.number().finite().positive(),
+  crop: z.object({
+    top: z.number().finite().min(0).lt(1),
+    right: z.number().finite().min(0).lt(1),
+    bottom: z.number().finite().min(0).lt(1),
+    left: z.number().finite().min(0).lt(1),
+  }).optional(),
+  frame: z.object({
+    style: z.literal("solid"),
+    color: z.string().regex(/^#[0-9a-f]{6}$/i),
+    width: z.number().finite().nonnegative(),
+  }).optional(),
+};
 const exportAssertionSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("audio-audibility"),
@@ -819,9 +838,10 @@ export function createMcpServer(runtime: AgentVideoRuntime, options: McpServerOp
     description: "Resolve an editor-first path after capability checks; never bypass a connected editor, and require explicit external fallback selection.",
     inputSchema: {
       operation: z.enum([
-        "timeline.edit",
-        "editor.native.edit",
-        "timeline.publish.new-project",
+      "timeline.edit",
+      "editor.native.edit",
+      "editor.native.picture-in-picture",
+      "timeline.publish.new-project",
         "timeline.export",
       ]),
       fallback: z.enum(["none", "external-renderer"]).optional().default("none"),
@@ -906,6 +926,24 @@ export function createMcpServer(runtime: AgentVideoRuntime, options: McpServerOp
   }, async ({ previewToken }) => {
     if (!options.nativeEditor) throw new Error("CAPABILITY_UNAVAILABLE: Final Cut native title placement is not configured");
     return jsonResult(await options.nativeEditor.executeTitleAdd(previewToken));
+  });
+
+  server.registerTool("editor.native.picture-in-picture.preview", {
+    description: "Preview connecting selected Final Cut Browser video to a stable timeline occurrence with verified transform properties.",
+    inputSchema: nativePictureInPicturePreviewSchema,
+  }, async (request) => {
+    if (!options.nativeEditor) throw new Error("CAPABILITY_UNAVAILABLE: Final Cut native picture-in-picture placement is not configured");
+    await requireEditingRoute(runtime, options, "editor.native.picture-in-picture");
+    return jsonResult(await options.nativeEditor.previewPictureInPicture(request));
+  });
+
+  server.registerTool("editor.native.picture-in-picture.execute", {
+    description: "Execute a native Final Cut picture-in-picture preview and return transform readback, revision, and Undo verification.",
+    inputSchema: { previewToken: z.string().min(1) },
+  }, async ({ previewToken }) => {
+    if (!options.nativeEditor) throw new Error("CAPABILITY_UNAVAILABLE: Final Cut native picture-in-picture placement is not configured");
+    await requireEditingRoute(runtime, options, "editor.native.picture-in-picture");
+    return jsonResult(await options.nativeEditor.executePictureInPicture(previewToken));
   });
 
   server.registerTool("editor.native.transition.search", {
@@ -1552,6 +1590,7 @@ async function inspectMcpEditor(runtime: AgentVideoRuntime, options: McpServerOp
       mediaAppend: Boolean(native?.mediaAppend),
       mediaInsert: Boolean(native?.mediaInsert),
       titlePlacement: Boolean(native?.titlePlacement),
+      pictureInPicture: Boolean(native?.pictureInPicture),
       transitionDiscovery: Boolean(native?.transitionDiscovery),
       transitionPlacement: Boolean(native?.transitionPlacement),
       timelineFocus: Boolean(native?.timelineFocus),

--- a/docs/architecture/capability-model.md
+++ b/docs/architecture/capability-model.md
@@ -48,7 +48,8 @@ one operation at a time:
       "projectCreation": { "available": false, "backend": "final-cut-accessibility", "guarantee": "none", "unavailableReason": "native project creation is unavailable" },
       "clipInsertion": { "available": false, "backend": "final-cut-accessibility", "guarantee": "none", "unavailableReason": "native clip insertion is unavailable" },
       "clipMovement": { "available": false, "backend": "final-cut-accessibility", "guarantee": "none", "unavailableReason": "native clip movement is unavailable" },
-      "titlePlacement": { "available": false, "backend": "final-cut-accessibility", "guarantee": "none", "unavailableReason": "native title placement is unavailable" }
+      "titlePlacement": { "available": false, "backend": "final-cut-accessibility", "guarantee": "none", "unavailableReason": "native title placement is unavailable" },
+      "pictureInPicture": { "available": false, "backend": "final-cut-accessibility", "guarantee": "none", "unavailableReason": "native picture in picture is unavailable" }
     },
     "publishing": { "projectCreation": { "available": false, "backend": "fcpxml-publisher", "guarantee": "none", "unavailableReason": "new project publishing is unavailable" } },
     "export": { "timeline": { "available": false, "backend": "final-cut-native-export", "guarantee": "none", "unavailableReason": "timeline export is unavailable" } },

--- a/docs/final-cut/README.md
+++ b/docs/final-cut/README.md
@@ -15,6 +15,7 @@ Framekit uses two distinct Final Cut backends:
 - [Installation](./installation.md)
 - [Troubleshooting](./troubleshooting.md)
 - [Native media insertion breakthrough](./native-media-insertion-breakthrough.md)
+- [Native picture-in-picture](./picture-in-picture.md)
 
 The live bridge is deliberately narrower than the FCPXML adapter. It provides
 live state and change events; canonical reads, artifact edits, verification,

--- a/docs/final-cut/picture-in-picture.md
+++ b/docs/final-cut/picture-in-picture.md
@@ -13,10 +13,12 @@ target, a connected non-primary lane, a video media ID, an existing primary
 occurrence, frame-aligned timing, position, and scale. Optional crop and solid
 frame properties are validated before mutation.
 
-The FCPXML document backend writes the connected `asset-clip` and preserves the
-transform, crop, frame, and attachment properties in the canonical snapshot.
-Its preview is non-mutating; execute returns a verified transaction, diff, and
-Undo restoration digest.
+The FCPXML document backend writes the connected `asset-clip`, transform, and
+schema-compatible crop adjustment (`adjust-crop` / `crop-rect`) in the
+canonical snapshot. Solid frame styling is not an FCPXML document capability;
+artifact requests that include a frame fail closed and must use the native
+Final Cut provider. Its preview is non-mutating; execute returns a verified
+transaction, diff, and Undo restoration digest.
 
 The headed Final Cut backend uses the native tools:
 

--- a/docs/final-cut/picture-in-picture.md
+++ b/docs/final-cut/picture-in-picture.md
@@ -1,0 +1,59 @@
+# Native picture-in-picture
+
+Framekit supports picture-in-picture as a connected video placement with an
+explicit provider contract. The operation is separate from masking, tracking,
+and person cutout; those capabilities remain unavailable unless a provider
+advertises and verifies them independently.
+
+## Contract
+
+The deterministic timeline operation is
+`timeline.picture-in-picture.add`. It requires a stable project/sequence
+target, a connected non-primary lane, a video media ID, an existing primary
+occurrence, frame-aligned timing, position, and scale. Optional crop and solid
+frame properties are validated before mutation.
+
+The FCPXML document backend writes the connected `asset-clip` and preserves the
+transform, crop, frame, and attachment properties in the canonical snapshot.
+Its preview is non-mutating; execute returns a verified transaction, diff, and
+Undo restoration digest.
+
+The headed Final Cut backend uses the native tools:
+
+1. `editor.native.media.search` and `editor.native.media.select` identify and
+   bind the secondary Browser video.
+2. `editor.native.timeline.locate` identifies the primary occurrence.
+3. `editor.native.picture-in-picture.preview` binds both handles and the live
+   sequence revision without editing.
+4. `editor.native.picture-in-picture.execute` connects the video, applies the
+   transform/crop/frame through the Video Inspector, and reads those properties
+   back before returning success.
+5. `editor.native.undo` restores the operation through Final Cut's native Undo.
+
+If the Browser identity, occurrence, live revision, Inspector property, or
+Undo command cannot be verified, the operation fails closed. It never silently
+uses masking, tracking, a generated asset, or an external renderer.
+
+## Evidence tiers
+
+These results must remain distinct:
+
+- Fixture evidence proves the runtime contract and rollback semantics.
+- FCPXML evidence proves canonical connected placement and persisted properties.
+- Headed-native evidence proves Final Cut UI placement, Inspector readback,
+  revision advancement, and native Undo.
+
+The headed runner requires a disposable or explicitly approved project and
+these variables:
+
+```sh
+FRAMEKIT_FINAL_CUT_E2E_PROJECT="Framekit Native PIP E2E" \
+FRAMEKIT_FINAL_CUT_E2E_ANCHOR_QUERY="Primary" \
+FRAMEKIT_FINAL_CUT_E2E_PIP_QUERY="Guest" \
+FRAMEKIT_FINAL_CUT_E2E_PIP_START="2/1" \
+FRAMEKIT_FINAL_CUT_E2E_PIP_DURATION="4/1" \
+pnpm run test:final-cut-pip-headed
+```
+
+The output is a sanitized `headed-native-picture-in-picture` evidence record.
+It does not claim canonical snapshot or person-cutout support.

--- a/docs/mcp/capabilities-and-errors.md
+++ b/docs/mcp/capabilities-and-errors.md
@@ -66,7 +66,7 @@ The families are:
 | `observation` | `timeline`, `media` | Live metadata or canonical observation |
 | `canonicalDocument` | `read`, `write`, `artifactWrite` | Canonical timeline guarantees |
 | `editing` | `compositeTransactions`, `titlePlacement`, `pictureInPicture`, `masking` | Routed editing operations and explicit unsupported boundaries |
-| `native` | `selectionWrite`, `projectCreation`, `clipInsertion`, `clipMovement`, `titlePlacement` | Individual Final Cut Accessibility operations |
+| `native` | `selectionWrite`, `projectCreation`, `clipInsertion`, `clipMovement`, `titlePlacement`, `pictureInPicture` | Individual Final Cut Accessibility operations |
 | `publishing` | `projectCreation` | Importing a verified artifact as a new project |
 | `export` | `timeline` | Verified local video export |
 | `analyzers` | `speechTranscribe`, `speechVad`, `audioLoudness`, `visualTrack` | Configured analysis providers |
@@ -203,6 +203,7 @@ capabilities:
     "mediaImport": true,
     "mediaSelection": true,
     "timelineOccurrenceLocate": true,
+    "pictureInPicture": true,
     "bladeAtPlayhead": true,
     "deleteRange": true,
     "trimToDuration": true,
@@ -222,6 +223,14 @@ machine-readable form of this surface. They include every supported native
 operation plus explicit entries for unsupported project creation, clip
 insertion, and clip movement. The legacy `native` object above remains for
 compatibility.
+
+Native PIP is a headed-only operation. Its preview binds a selected Browser
+media handle, a unique timeline occurrence handle, the live sequence revision,
+and an explicit frame-aligned range. Execute connects the Browser video on a
+non-primary lane, applies the requested transform/crop/frame, reads those
+properties back from the Video Inspector, and retains Final Cut's native Undo
+command. A successful native PIP result is headed-native evidence; it is not a
+canonical snapshot, diff, or masking/person-cutout capability.
 
 `bladeAtPlayhead` splits the current uniquely identified occurrence but does not
 shorten the sequence. `deleteRange` ripple-deletes an explicit rational range

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -37,6 +37,8 @@ this routing tool.
 | `editor.native.edit` | Selection-scoped native Final Cut edit | Requires native writes opt-in and Final Cut frontmost |
 | `editor.native.title.add.preview` | Preview adding a discovered title at the live playhead or an explicit range | Requires a discovered `editor.assets` title, live sequence bounds, and native writes opt-in |
 | `editor.native.title.add.execute` | Add the previewed title, set its text, and verify placement | Requires unchanged sequence/playhead revision; returns a native Undo operation ID |
+| `editor.native.picture-in-picture.preview` | Preview connecting selected Browser video to a stable timeline occurrence | Requires native PIP capability, selected media and occurrence handles, frame-aligned timing, and explicit transform properties |
+| `editor.native.picture-in-picture.execute` | Connect the previewed video, apply transform/crop/frame, and verify Inspector readback | Requires unchanged sequence revision; returns headed-native placement evidence and a native Undo operation ID |
 | `editor.native.transition.search` | Search the visible Final Cut Transitions browser | Returns only transitions with stable native identities; native writes required |
 | `editor.native.transition.add.preview` | Preview adding a discovered transition between two adjacent timeline occurrences | Requires occurrence handles, exact rational timing, unchanged live revision, and native writes opt-in |
 | `editor.native.transition.add.execute` | Add the previewed transition and verify selection, revision, and Undo | Requires unchanged sequence and timeline revision; returns a native Undo operation ID |

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "test:watch": "tsx --test --watch tests/integration/*.test.ts tests/evaluation/*.test.ts tests/filler-removal/*.test.ts tests/golden/*.test.ts",
     "test:final-cut-disposable-headed": "node scripts/final-cut-disposable-native-headed-e2e.mjs",
     "test:final-cut-transition-headed": "node scripts/final-cut-transition-headed-e2e.mjs",
+    "test:final-cut-pip-headed": "node scripts/final-cut-picture-in-picture-headed-e2e.mjs",
     "hooks:install": "node scripts/install-git-hooks.mjs",
     "mcp": "tsx apps/mcp-server/src/main.ts",
     "framekit": "node ./bin/framekit.mjs",

--- a/packages/runtime/src/capabilities.ts
+++ b/packages/runtime/src/capabilities.ts
@@ -252,7 +252,7 @@ function editingFamily(
       "title placement is unavailable",
     ),
     pictureInPicture: descriptorFrom(
-      overrides.pictureInPicture ?? false,
+      overrides.pictureInPicture ?? Boolean(editor.pictureInPicture),
       backend,
       "verified",
       "picture-in-picture editing is unavailable",

--- a/packages/runtime/src/capabilities.ts
+++ b/packages/runtime/src/capabilities.ts
@@ -338,6 +338,7 @@ function nativeFamily(
     "clipMovement",
     "transitionDiscovery",
     "transitionPlacement",
+    "pictureInPicture",
   ];
   return Object.fromEntries(nativeOperations.map((operation) => [
     operation,

--- a/packages/runtime/src/domain/capabilities.ts
+++ b/packages/runtime/src/domain/capabilities.ts
@@ -103,7 +103,8 @@ export type NativeCapabilityOperation =
   | "clipInsertion"
   | "clipMovement"
   | "transitionDiscovery"
-  | "transitionPlacement";
+  | "transitionPlacement"
+  | "pictureInPicture";
 
 export interface CapabilityFamilies {
   connection: {

--- a/packages/runtime/src/domain/capabilities.ts
+++ b/packages/runtime/src/domain/capabilities.ts
@@ -36,6 +36,7 @@ export interface EditorCapabilities {
   videoExport?: boolean;
   mediaImport?: boolean;
   mediaPlacement?: boolean;
+  pictureInPicture?: boolean;
   titlePlacement?: boolean;
   clipMove?: boolean;
   clipReplace?: boolean;

--- a/packages/runtime/src/domain/editing.ts
+++ b/packages/runtime/src/domain/editing.ts
@@ -1,6 +1,12 @@
 import type { ContextRevision, RationalTime, TimeRange } from "./primitives.js";
 
-import type { Marker, ProjectSnapshot } from "./project.js";
+import type {
+  Marker,
+  PictureInPictureCrop,
+  PictureInPictureFrame,
+  PictureInPicturePosition,
+  ProjectSnapshot,
+} from "./project.js";
 
 import type { TimelineDiff } from "./diff.js";
 
@@ -95,6 +101,22 @@ export interface AddMediaOperation {
   targetLane?: "primary" | number;
 }
 
+export interface AddPictureInPictureOperation {
+  type: "timeline.picture-in-picture.add";
+  occurrenceId: string;
+  mediaId: string;
+  /** Existing primary-storyline occurrence that owns the connected clip. */
+  attachedTo: string;
+  start: number;
+  duration: number;
+  /** Connected lane; zero and the primary storyline are not valid. */
+  targetLane: number;
+  position: PictureInPicturePosition;
+  scale: number;
+  crop?: PictureInPictureCrop;
+  frame?: PictureInPictureFrame;
+}
+
 export interface SetAudioFadesOperation {
   type: "timeline.audio.fades";
   clipId: string;
@@ -187,6 +209,7 @@ export interface MixAudioOperation {
 export type WorkflowOperation = EditOperation
   | ImportMediaOperation
   | AddMediaOperation
+  | AddPictureInPictureOperation
   | SetAudioFadesOperation
   | AddTitleOperation
   | MoveMediaOperation

--- a/packages/runtime/src/domain/project.ts
+++ b/packages/runtime/src/domain/project.ts
@@ -13,6 +13,26 @@ export interface ColorCorrection {
   preset?: ColorCorrectionPreset;
 }
 
+export interface PictureInPicturePosition {
+  /** Horizontal and vertical offsets in timeline pixels from the canvas center. */
+  x: number;
+  y: number;
+}
+
+export interface PictureInPictureCrop {
+  /** Fractions of the source frame to crop from each edge. */
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+}
+
+export interface PictureInPictureFrame {
+  style: "solid";
+  color: string;
+  width: number;
+}
+
 export interface Clip {
   /** Stable identity of this timeline occurrence, never the media resource id. */
   id: string;
@@ -32,6 +52,10 @@ export interface Clip {
   enabled?: boolean;
   role?: "video" | "audio" | "music" | "title";
   attachedTo?: string;
+  position?: PictureInPicturePosition;
+  scale?: number;
+  crop?: PictureInPictureCrop;
+  frame?: PictureInPictureFrame;
   /** Authoritative exact timeline coordinates; start/duration are convenience seconds. */
   startTime: RationalTime;
   durationTime: RationalTime;
@@ -87,4 +111,8 @@ export interface StoryElement {
   attachedTo?: string;
   beforeClipId?: string;
   afterClipId?: string;
+  position?: PictureInPicturePosition;
+  scale?: number;
+  crop?: PictureInPictureCrop;
+  frame?: PictureInPictureFrame;
 }

--- a/packages/runtime/src/domain/skills.ts
+++ b/packages/runtime/src/domain/skills.ts
@@ -57,6 +57,7 @@ export type EditorSkillCapability =
   | "videoExport"
   | "mediaImport"
   | "mediaPlacement"
+  | "pictureInPicture"
   | "titlePlacement"
   | "clipMove"
   | "clipReplace"
@@ -86,6 +87,7 @@ export const SKILL_OPERATIONS = [
   "add-marker",
   "media.import",
   "timeline.media.add",
+  "timeline.picture-in-picture.add",
   "timeline.audio.fades",
   "timeline.title.add",
   "timeline.media.move",

--- a/packages/runtime/src/editing/edit-service.ts
+++ b/packages/runtime/src/editing/edit-service.ts
@@ -366,6 +366,9 @@ export class EditService {
     if (operations.some((operation) => operation.type === "timeline.media.add") && !capabilities.mediaPlacement) {
       throw new Error("CAPABILITY_UNAVAILABLE: timeline media placement");
     }
+    if (operations.some((operation) => operation.type === "timeline.picture-in-picture.add") && !capabilities.pictureInPicture) {
+      throw new Error("CAPABILITY_UNAVAILABLE: picture-in-picture placement");
+    }
     if (operations.some((operation) => operation.type === "timeline.title.add")
       && (!capabilities.titlePlacement || !capabilities.assetDiscovery)) {
       throw new Error("CAPABILITY_UNAVAILABLE: timeline title placement");

--- a/packages/runtime/src/skills/requirements.ts
+++ b/packages/runtime/src/skills/requirements.ts
@@ -34,6 +34,7 @@ export const SKILL_EDITOR_CAPABILITIES = [
   "videoExport",
   "mediaImport",
   "mediaPlacement",
+  "pictureInPicture",
   "titlePlacement",
   "clipMove",
   "clipReplace",

--- a/packages/runtime/src/verification/verification.ts
+++ b/packages/runtime/src/verification/verification.ts
@@ -682,6 +682,7 @@ function audioStateDetail(transaction: EditTransaction): string {
 function isConstructionOperation(operation: WorkflowOperation): boolean {
   return operation.type === "media.import"
     || operation.type === "timeline.media.add"
+    || operation.type === "timeline.picture-in-picture.add"
     || operation.type === "timeline.media.move"
     || operation.type === "timeline.media.replace"
     || operation.type === "timeline.media.remove"
@@ -744,6 +745,10 @@ interface ConstructionClipState {
   duration: number;
   track: number;
   attachedTo?: string;
+  position?: { x: number; y: number };
+  scale?: number;
+  crop?: { top: number; right: number; bottom: number; left: number };
+  frame?: { style: "solid"; color: string; width: number };
 }
 
 function expectedConstructionClips(transaction: EditTransaction): Map<string, ConstructionClipState> {
@@ -753,6 +758,10 @@ function expectedConstructionClips(transaction: EditTransaction): Map<string, Co
     duration: clip.duration,
     track: clip.track,
     attachedTo: clip.attachedTo,
+    position: clip.position,
+    scale: clip.scale,
+    crop: clip.crop,
+    frame: clip.frame,
   }]));
   const media = new Map(transaction.before.media.map((item) => [item.mediaId, item]));
 
@@ -767,6 +776,20 @@ function expectedConstructionClips(transaction: EditTransaction): Map<string, Co
         start: operation.start,
         duration: operation.duration,
         track: timelineTrack(operation.targetLane, 0),
+      });
+      continue;
+    }
+    if (operation.type === "timeline.picture-in-picture.add") {
+      clips.set(operation.occurrenceId, {
+        mediaId: operation.mediaId,
+        start: operation.start,
+        duration: operation.duration,
+        track: operation.targetLane,
+        attachedTo: operation.attachedTo,
+        position: operation.position,
+        scale: operation.scale,
+        crop: operation.crop,
+        frame: operation.frame,
       });
       continue;
     }
@@ -833,12 +856,16 @@ function expectedConstructionClips(transaction: EditTransaction): Map<string, Co
   return clips;
 }
 
-function sameConstructionClip(actual: { mediaId?: string; start: number; duration: number; track: number; attachedTo?: string }, expected: ConstructionClipState): boolean {
+function sameConstructionClip(actual: ConstructionClipState, expected: ConstructionClipState): boolean {
   return actual.mediaId === expected.mediaId
     && actual.start === expected.start
     && actual.duration === expected.duration
     && actual.track === expected.track
-    && actual.attachedTo === expected.attachedTo;
+    && actual.attachedTo === expected.attachedTo
+    && JSON.stringify(actual.position) === JSON.stringify(expected.position)
+    && actual.scale === expected.scale
+    && JSON.stringify(actual.crop) === JSON.stringify(expected.crop)
+    && JSON.stringify(actual.frame) === JSON.stringify(expected.frame);
 }
 
 function applyExpectedRippleDelete(clips: Map<string, ConstructionClipState>, start: number, end: number): void {

--- a/packages/runtime/src/verification/verification.ts
+++ b/packages/runtime/src/verification/verification.ts
@@ -735,6 +735,7 @@ function constructionStateIsValid(transaction: EditTransaction): boolean {
         && media.sourceDigest === operation.sourceDigest;
     }
     if (operation.type === "timeline.media.add"
+      || operation.type === "timeline.picture-in-picture.add"
       || operation.type === "timeline.media.move"
       || operation.type === "timeline.media.replace"
       || operation.type === "timeline.media.remove"

--- a/packages/testkit/src/in-memory-editor.ts
+++ b/packages/testkit/src/in-memory-editor.ts
@@ -112,6 +112,7 @@ export class InMemoryEditorAdapter implements EditorPort {
         compositeTransactions: true,
         mediaImport: true,
         mediaPlacement: true,
+        pictureInPicture: true,
         titlePlacement: true,
         clipMove: true,
         clipReplace: true,
@@ -131,6 +132,7 @@ export class InMemoryEditorAdapter implements EditorPort {
           "add-marker": true,
           "media.import": true,
           "timeline.media.add": true,
+          "timeline.picture-in-picture.add": true,
           "timeline.audio.fades": true,
           "timeline.title.add": true,
           "timeline.media.move": true,
@@ -343,6 +345,71 @@ export class InMemoryEditorAdapter implements EditorPort {
             lane: clip.track,
             mediaId: clip.mediaId,
             ...(clip.attachedTo ? { attachedTo: clip.attachedTo } : {}),
+          }],
+        },
+      };
+    }
+    if (operation.type === "timeline.picture-in-picture.add") {
+      const media = snapshot.media.find((candidate) => candidate.mediaId === operation.mediaId);
+      if (!media) throw new Error(`MEDIA_NOT_FOUND: ${operation.mediaId}`);
+      if (media.mediaKind !== undefined && media.mediaKind !== "video") {
+        throw new Error(`MEDIA_KIND_MISMATCH: ${operation.mediaId}`);
+      }
+      if (snapshot.timeline.clips.some((clip) => clip.id === operation.occurrenceId)) {
+        throw new Error(`OCCURRENCE_ALREADY_EXISTS: ${operation.occurrenceId}`);
+      }
+      const anchor = snapshot.timeline.clips.find((clip) => clip.id === operation.attachedTo);
+      if (!anchor) throw new Error(`CLIP_NOT_FOUND: ${operation.attachedTo}`);
+      if (anchor.role !== undefined && anchor.role !== "video") {
+        throw new Error("INVALID_OPERATION: PIP anchor must be a video occurrence");
+      }
+      if (!Number.isFinite(operation.start) || !Number.isFinite(operation.duration)
+        || operation.start < anchor.start
+        || operation.duration <= 0
+        || operation.start + operation.duration > anchor.start + anchor.duration
+        || !Number.isInteger(operation.targetLane)
+        || operation.targetLane === 0
+        || !Number.isFinite(operation.position.x)
+        || !Number.isFinite(operation.position.y)
+        || !Number.isFinite(operation.scale)
+        || operation.scale <= 0) {
+        throw new Error("INVALID_OPERATION: PIP timing, connected lane, position, and scale are invalid");
+      }
+      if (operation.crop) assertPictureInPictureCrop(operation.crop);
+      if (operation.frame) assertPictureInPictureFrame(operation.frame);
+      const clip = withClipTime({
+        id: operation.occurrenceId,
+        mediaId: operation.mediaId,
+        name: media.source.split("/").pop() || media.mediaId,
+        start: operation.start,
+        duration: operation.duration,
+        track: operation.targetLane,
+        role: "video",
+        attachedTo: operation.attachedTo,
+        position: structuredClone(operation.position),
+        scale: operation.scale,
+        ...(operation.crop ? { crop: structuredClone(operation.crop) } : {}),
+        ...(operation.frame ? { frame: structuredClone(operation.frame) } : {}),
+      });
+      return {
+        ...snapshot,
+        timeline: {
+          ...snapshot.timeline,
+          clips: [...snapshot.timeline.clips, clip],
+          storyElements: [...snapshot.timeline.storyElements, {
+            id: clip.id,
+            kind: "asset-clip",
+            start: clip.start,
+            duration: clip.duration,
+            startTime: clip.startTime,
+            durationTime: clip.durationTime,
+            lane: clip.track,
+            mediaId: clip.mediaId,
+            attachedTo: clip.attachedTo,
+            position: clip.position,
+            scale: clip.scale,
+            ...(clip.crop ? { crop: clip.crop } : {}),
+            ...(clip.frame ? { frame: clip.frame } : {}),
           }],
         },
       };
@@ -807,6 +874,10 @@ function createSnapshot(fixture: InMemoryProjectFixture): ProjectSnapshot {
         lane: clip.track,
         mediaId: clip.mediaId,
         ...(clip.attachedTo ? { attachedTo: clip.attachedTo } : {}),
+        ...(clip.position ? { position: structuredClone(clip.position) } : {}),
+        ...(clip.scale !== undefined ? { scale: clip.scale } : {}),
+        ...(clip.crop ? { crop: structuredClone(clip.crop) } : {}),
+        ...(clip.frame ? { frame: structuredClone(clip.frame) } : {}),
       })),
       markers: (fixture.markers ?? []).map((marker) => normalizeMarker(marker)),
       captions: (fixture.captions ?? []).map((caption) => normalizeCaption(caption)),
@@ -857,4 +928,20 @@ function isMediaCompatible(role: Clip["role"], mediaKind: MediaContext["mediaKin
   if (role === "audio" || role === "music") return mediaKind === undefined || mediaKind === "audio";
   if (role === "title") return false;
   return true;
+}
+
+function assertPictureInPictureCrop(crop: NonNullable<Clip["crop"]>): void {
+  const values = [crop.top, crop.right, crop.bottom, crop.left];
+  if (!values.every((value) => Number.isFinite(value) && value >= 0 && value < 1)
+    || crop.left + crop.right >= 1
+    || crop.top + crop.bottom >= 1) {
+    throw new Error("INVALID_OPERATION: PIP crop must leave a positive source rectangle");
+  }
+}
+
+function assertPictureInPictureFrame(frame: NonNullable<Clip["frame"]>): void {
+  if (frame.style !== "solid" || !/^#[0-9a-f]{6}$/i.test(frame.color)
+    || !Number.isFinite(frame.width) || frame.width < 0) {
+    throw new Error("INVALID_OPERATION: PIP frame must be a solid hex-colored non-negative width");
+  }
 }

--- a/packages/testkit/src/in-memory-editor.ts
+++ b/packages/testkit/src/in-memory-editor.ts
@@ -368,6 +368,7 @@ export class InMemoryEditorAdapter implements EditorPort {
         || operation.start < anchor.start
         || operation.duration <= 0
         || operation.start + operation.duration > anchor.start + anchor.duration
+        || media.duration !== undefined && operation.duration > media.duration
         || !Number.isInteger(operation.targetLane)
         || operation.targetLane === 0
         || !Number.isFinite(operation.position.x)

--- a/scripts/final-cut-picture-in-picture-headed-e2e.mjs
+++ b/scripts/final-cut-picture-in-picture-headed-e2e.mjs
@@ -1,0 +1,162 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { evidenceEnvironment } from "./final-cut-evidence.mjs";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const expectedProject = process.env.FRAMEKIT_FINAL_CUT_E2E_PROJECT;
+const anchorQuery = process.env.FRAMEKIT_FINAL_CUT_E2E_ANCHOR_QUERY;
+const pipQuery = process.env.FRAMEKIT_FINAL_CUT_E2E_PIP_QUERY;
+const start = rational(process.env.FRAMEKIT_FINAL_CUT_E2E_PIP_START, "FRAMEKIT_FINAL_CUT_E2E_PIP_START");
+const duration = rational(process.env.FRAMEKIT_FINAL_CUT_E2E_PIP_DURATION, "FRAMEKIT_FINAL_CUT_E2E_PIP_DURATION");
+
+if (process.argv.includes("--help")) {
+  process.stdout.write([
+    "Headed native Final Cut picture-in-picture E2E",
+    "",
+    "Required:",
+    "  FRAMEKIT_FINAL_CUT_E2E_PROJECT=exact-project-name",
+    "  FRAMEKIT_FINAL_CUT_E2E_ANCHOR_QUERY=unique-primary-browser-query",
+    "  FRAMEKIT_FINAL_CUT_E2E_PIP_QUERY=unique-secondary-video-browser-query",
+    "  FRAMEKIT_FINAL_CUT_E2E_PIP_START=integer/timescale",
+    "  FRAMEKIT_FINAL_CUT_E2E_PIP_DURATION=integer/timescale",
+  ].join("\n"));
+  process.stdout.write("\n");
+  process.exit(0);
+}
+
+if (!expectedProject || !anchorQuery || !pipQuery || !start || !duration) {
+  throw new Error("Set the Final Cut PIP headed E2E project, queries, start, and duration variables");
+}
+
+const transport = new StdioClientTransport({
+  command: process.execPath,
+  args: ["--import", "tsx", join(root, "apps/mcp-server/src/main.ts")],
+  env: {
+    ...process.env,
+    FRAMEKIT_EDITOR: "final-cut-live",
+    FRAMEKIT_AUTO_CONNECT: "0",
+    FRAMEKIT_FINAL_CUT_NATIVE_WRITES: "1",
+  },
+  stderr: "pipe",
+});
+const client = new Client({ name: "framekit-picture-in-picture-headed-e2e", version: "0.1.0" });
+
+try {
+  await client.connect(transport);
+  const editor = await callJson("editor.inspect");
+  if (editor.identity?.name !== "Final Cut Pro" && editor.identity?.backend !== "final-cut-live") {
+    throw new Error("FINAL_CUT_E2E_EDITOR_MISMATCH: expected the Final Cut live editor");
+  }
+  if (editor.native?.pictureInPicture !== true) {
+    throw new Error("CAPABILITY_UNAVAILABLE: headed native picture-in-picture is not advertised");
+  }
+
+  const focused = await callJson("editor.native.focus");
+  if (!focused.available || !focused.frontmost || !focused.timelineFocused) {
+    throw new Error(`FINAL_CUT_NATIVE_NOT_READY: ${focused.error?.code ?? "timeline focus failed"}`);
+  }
+  if (focused.project && focused.project !== expectedProject) {
+    throw new Error(`FINAL_CUT_E2E_PROJECT_MISMATCH: expected ${expectedProject}, observed ${focused.project}`);
+  }
+
+  const anchorMatches = await callJson("editor.native.media.search", { query: anchorQuery });
+  if (!Array.isArray(anchorMatches) || anchorMatches.length !== 1) {
+    throw new Error("FINAL_CUT_E2E_ANCHOR_MEDIA_AMBIGUOUS: anchor query must return exactly one Browser result");
+  }
+  const anchorMedia = anchorMatches[0];
+  await callJson("editor.native.media.select", { mediaHandle: anchorMedia.handle });
+  const located = await callJson("editor.native.timeline.locate", { mediaHandle: anchorMedia.handle });
+  if (located.status !== "unique" || located.occurrences?.length !== 1) {
+    throw new Error("FINAL_CUT_E2E_ANCHOR_OCCURRENCE_AMBIGUOUS: anchor query must locate exactly one timeline occurrence");
+  }
+  const anchorOccurrence = located.occurrences[0];
+
+  const pipMatches = await callJson("editor.native.media.search", { query: pipQuery });
+  if (!Array.isArray(pipMatches) || pipMatches.length !== 1) {
+    throw new Error("FINAL_CUT_E2E_PIP_MEDIA_AMBIGUOUS: PIP query must return exactly one Browser result");
+  }
+  const pipMedia = pipMatches[0];
+  await callJson("editor.native.media.select", { mediaHandle: pipMedia.handle });
+  const preview = await callJson("editor.native.picture-in-picture.preview", {
+    mediaHandle: pipMedia.handle,
+    anchorOccurrenceHandle: anchorOccurrence.handle,
+    start,
+    duration,
+    position: { x: 320, y: -180 },
+    scale: 0.35,
+    frame: { style: "solid", color: "#FFFFFF", width: 8 },
+  });
+  if (!preview.previewToken || preview.anchorOccurrence?.handle !== anchorOccurrence.handle) {
+    throw new Error("FINAL_CUT_E2E_PIP_PREVIEW_FAILED: preview did not preserve stable native bindings");
+  }
+
+  const executed = await callJson("editor.native.picture-in-picture.execute", { previewToken: preview.previewToken });
+  if (!executed.verification?.verified || executed.afterRevision?.id === executed.beforeRevision?.id) {
+    throw new Error("FINAL_CUT_E2E_PIP_EXECUTE_FAILED: native placement was not verified");
+  }
+  if (executed.observed?.position?.x !== 320 || executed.observed?.position?.y !== -180 || executed.observed?.scale !== 0.35) {
+    throw new Error("FINAL_CUT_E2E_PIP_READBACK_FAILED: transform readback did not match the request");
+  }
+  if (executed.observed?.frame?.color?.toUpperCase() !== "#FFFFFF") {
+    throw new Error("FINAL_CUT_E2E_PIP_FRAME_READBACK_FAILED: white frame was not read back");
+  }
+
+  const undone = await callJson("editor.native.undo", { operationId: executed.operationId });
+  if (!undone.undone || undone.verification?.verified !== true) {
+    throw new Error("FINAL_CUT_E2E_PIP_UNDO_FAILED: native Undo did not verify");
+  }
+
+  process.stdout.write(`${JSON.stringify({
+    schemaVersion: 1,
+    evidenceType: "headed-native-picture-in-picture",
+    passed: true,
+    recordedAt: new Date().toISOString(),
+    environment: await evidenceEnvironment(root),
+    editor: {
+      name: editor.identity?.name,
+      version: editor.identity?.version,
+      backend: editor.identity?.backend,
+    },
+    capabilities: {
+      nativePictureInPicture: editor.native.pictureInPicture,
+      nativeUndo: editor.native.undo,
+      nativeTimelineOccurrenceLocate: editor.native.timelineOccurrenceLocate,
+    },
+    placement: {
+      project: expectedProject,
+      anchorMedia: { name: anchorMedia.name, sourceIdentity: anchorMedia.sourceIdentity },
+      anchorOccurrence: { handle: anchorOccurrence.handle, start: anchorOccurrence.start, duration: anchorOccurrence.duration },
+      pipMedia: { name: pipMedia.name, sourceIdentity: pipMedia.sourceIdentity },
+      requested: { start, duration, position: { x: 320, y: -180 }, scale: 0.35, frame: { color: "#FFFFFF", width: 8 } },
+      observed: executed.observed,
+      beforeRevision: executed.beforeRevision,
+      afterRevision: executed.afterRevision,
+      operationId: executed.operationId,
+      undoOperationId: undone.operationId,
+      undoVerified: undone.verification,
+    },
+  }, null, 2)}\n`);
+} finally {
+  await client.close().catch(() => {});
+  await transport.close().catch(() => {});
+}
+
+function rational(value, label) {
+  if (!value) return undefined;
+  const match = value.match(/^(\d+)\/(\d+)$/);
+  if (!match || Number(match[2]) <= 0) throw new Error(`${label} must use integer/timescale form`);
+  return { value: match[1], timescale: match[2] };
+}
+
+async function callJson(name, arguments_ = {}) {
+  const result = await client.callTool({ name, arguments: arguments_ });
+  const output = result.content?.find((item) => item.type === "text")?.text ?? "";
+  if (result.isError) throw new Error(output || `${name} failed`);
+  try {
+    return JSON.parse(output);
+  } catch {
+    throw new Error(`${name} returned invalid JSON: ${output}`);
+  }
+}

--- a/tests/integration/capabilities.test.ts
+++ b/tests/integration/capabilities.test.ts
@@ -488,6 +488,7 @@ test("Workflow Extension capability payload defines the versioned family contrac
   assert.match(swift, /clipInsertion: CapabilityDescriptor/);
   assert.match(swift, /clipMovement: CapabilityDescriptor/);
   assert.match(swift, /titlePlacement: CapabilityDescriptor/);
+  assert.match(swift, /pictureInPicture: CapabilityDescriptor/);
   assert.match(swift, /projectCatalogRead: Bool/);
   assert.match(swift, /projectSelection: Bool/);
   assert.match(swift, /transitionDiscovery: CapabilityDescriptor/);

--- a/tests/integration/editor-first-routing.test.ts
+++ b/tests/integration/editor-first-routing.test.ts
@@ -60,6 +60,31 @@ test("routing selects the connected editor when required capabilities are availa
   assert.ok(route.requiredCapabilities.includes("editor.timelineWrite|editor.timelineArtifactWrite"));
 });
 
+test("routing selects native picture-in-picture only with native placement guarantees", () => {
+  const route = resolveEditingRoute({ operation: "editor.native.picture-in-picture" }, context({
+    native: {
+      pictureInPicture: true,
+      mediaSelection: true,
+      timelineOccurrenceLocate: true,
+      timelineFocus: true,
+      undo: true,
+    },
+  }));
+
+  assert.equal(route.status, "editor-selected");
+  assert.deepEqual(route.missingCapabilities, []);
+  assert.ok(route.requiredCapabilities.includes("native.pictureInPicture"));
+});
+
+test("routing fails closed when native picture-in-picture is unavailable", () => {
+  const route = resolveEditingRoute({ operation: "editor.native.picture-in-picture" }, context({
+    native: { mediaSelection: true, timelineOccurrenceLocate: true, timelineFocus: true, undo: true },
+  }));
+
+  assert.equal(route.status, "unavailable");
+  assert.ok(route.missingCapabilities.includes("native.pictureInPicture"));
+});
+
 test("routing fails closed when the expected editor is unavailable", () => {
   const route = resolveEditingRoute({ operation: "timeline.edit" }, context({
     connection: {

--- a/tests/integration/finalcut-mcp.test.ts
+++ b/tests/integration/finalcut-mcp.test.ts
@@ -282,6 +282,108 @@ test("Final Cut MCP exposes guarded native title preview and execute tools", asy
   }
 });
 
+test("Final Cut MCP routes native picture-in-picture through preview and execute", async () => {
+  const requests: unknown[] = [];
+  const preview = {
+    previewToken: "pip-preview-1",
+    media: { handle: "media-guest", name: "Guest", sourceIdentity: "guest-source" },
+    anchorOccurrence: { handle: "occurrence-primary", mediaHandle: "media-primary", name: "Primary", start: "0/1", duration: "10/1" },
+    start: { value: "2", timescale: "1" },
+    end: { value: "6", timescale: "1" },
+    duration: { value: "4", timescale: "1" },
+    position: { x: 320, y: -180 },
+    scale: 0.35,
+    command: "Add native picture-in-picture" as const,
+    revision: "rev-1",
+    expiresAt: "9999-12-31T23:59:59.999Z",
+  };
+  const result = {
+    ...preview,
+    operationId: "native-pip-1",
+    observed: { position: { x: 320, y: -180 }, scale: 0.35 },
+    before: {},
+    after: {},
+    beforeRevision: { id: "rev-1", sequence: 1, timestamp: new Date(1).toISOString() },
+    afterRevision: { id: "rev-2", sequence: 2, timestamp: new Date(2).toISOString() },
+    verification: { verified: true, detail: "verified" },
+    undoAvailable: true,
+    undoCommand: "Undo Native Picture-in-Picture",
+  };
+  const nativeEditor = {
+    capabilities: () => ({
+      selectionEdit: true,
+      undo: true,
+      mediaLibrarySearch: true,
+      mediaImport: false,
+      mediaSelection: true,
+      mediaAppendSelected: false,
+      timelineOccurrenceLocate: true,
+      bladeAtPlayhead: false,
+      deleteRange: false,
+      trimToDuration: false,
+      mediaAppend: false,
+      mediaInsert: false,
+      titlePlacement: false,
+      pictureInPicture: true,
+      timelineFocus: true,
+      requiresAccessibility: true as const,
+      requiresFinalCutFrontmost: true as const,
+    }),
+    previewPictureInPicture: async (request: unknown) => {
+      requests.push(request);
+      return preview;
+    },
+    executePictureInPicture: async () => result,
+  } as unknown as NativeFinalCutEditor;
+  const runtime = new AgentVideoRuntime(new InMemoryEditorAdapter({
+    projectId: "project-1",
+    projectName: "MCP PIP Test",
+    timelineId: "timeline-1",
+    timelineName: "Main Edit",
+    clips: [],
+  }));
+  const server = createMcpServer(runtime, { nativeEditor });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "pip-mcp-test", version: "0.1.0" });
+
+  try {
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    const tools = await client.listTools();
+    assert.ok(tools.tools.find((tool) => tool.name === "editor.native.picture-in-picture.preview"));
+    assert.ok(tools.tools.find((tool) => tool.name === "editor.native.picture-in-picture.execute"));
+    const pipPreview = JSON.parse(textFrom(await client.callTool({
+      name: "editor.native.picture-in-picture.preview",
+      arguments: {
+        mediaHandle: "media-guest",
+        anchorOccurrenceHandle: "occurrence-primary",
+        start: { value: "2", timescale: "1" },
+        duration: { value: "4", timescale: "1" },
+        position: { x: 320, y: -180 },
+        scale: 0.35,
+      },
+    })));
+    assert.equal(pipPreview.command, "Add native picture-in-picture");
+    assert.deepEqual(requests, [{
+      mediaHandle: "media-guest",
+      anchorOccurrenceHandle: "occurrence-primary",
+      start: { value: "2", timescale: "1" },
+      duration: { value: "4", timescale: "1" },
+      position: { x: 320, y: -180 },
+      scale: 0.35,
+    }]);
+    const pipResult = JSON.parse(textFrom(await client.callTool({
+      name: "editor.native.picture-in-picture.execute",
+      arguments: { previewToken: pipPreview.previewToken },
+    })));
+    assert.equal(pipResult.verification.verified, true);
+    assert.equal(pipResult.afterRevision.id, "rev-2");
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
+
 test("Final Cut MCP resolves transition search ids back through native discovery", async () => {
   const registryAsset = {
     id: "transition-registry-cross-dissolve",

--- a/tests/integration/finalcut-routing.test.ts
+++ b/tests/integration/finalcut-routing.test.ts
@@ -159,7 +159,8 @@ test("editor inspection exposes actionable artifact preflight provenance", async
     assert.equal(payload.preflight.capabilities.editing.compositeTransactions.backend, "fcpxml-document");
     assert.equal(payload.preflight.capabilities.editing.compositeTransactions.guarantee, "verified");
     assert.equal(payload.preflight.capabilities.editing.titlePlacement.available, false);
-    assert.match(payload.preflight.capabilities.editing.pictureInPicture.unavailableReason, /unavailable/);
+    assert.equal(payload.preflight.capabilities.editing.pictureInPicture.available, true);
+    assert.equal(payload.preflight.capabilities.editing.pictureInPicture.backend, "fcpxml-document");
     assert.match(payload.preflight.capabilities.editing.masking.unavailableReason, /unavailable/);
     assert.equal(payload.preflight.capabilities.analyzers.speechTranscribe.available, false);
     assert.match(payload.preflight.capabilities.analyzers.audioLoudness.unavailableReason, /unavailable/);

--- a/tests/integration/mcp.test.ts
+++ b/tests/integration/mcp.test.ts
@@ -65,6 +65,8 @@ test("Phase 0 exposes read/write/diff through MCP stdio", async () => {
         "editor.native.edit",
         "editor.native.focus",
         "editor.native.inspect",
+        "editor.native.picture-in-picture.execute",
+        "editor.native.picture-in-picture.preview",
         "editor.native.media.append.execute",
         "editor.native.media.append.preview",
         "editor.native.media.append.selected.execute",

--- a/tests/integration/native.test.ts
+++ b/tests/integration/native.test.ts
@@ -234,6 +234,99 @@ test("native Final Cut adapter previews and inserts a title at the playhead with
   assert.equal(scripts.some((script) => script.includes('click menu item "Undo Native Title" of menu "Edit"')), true);
 });
 
+test("native Final Cut adapter places PIP with transform readback and undo", async () => {
+  let revision = 1;
+  let playhead = "0";
+  let pipAdded = false;
+  const scripts: string[] = [];
+  const liveState = async () => ({
+    project: { id: "project-1", name: "Edit" },
+    sequence: {
+      id: "sequence-1",
+      name: "Edit",
+      startTime: { value: "0", timescale: "1" },
+      duration: { value: "20", timescale: "1" },
+      frameDuration: { value: "1", timescale: "24" },
+    },
+    playheadTime: { value: playhead, timescale: "1" },
+    sequenceTimeRange: {
+      start: { value: "0", timescale: "1" },
+      duration: { value: "20", timescale: "1" },
+    },
+    revision: { id: `rev-${revision}`, sequence: revision, timestamp: new Date(revision).toISOString() },
+  });
+  const adapter = new FinalCutNativeAutomationAdapter({
+    enabled: true,
+    liveState,
+    sleep: async () => {},
+    executor: async (script) => {
+      scripts.push(script);
+      if (script.includes('set searchQuery to "Anchor"')) {
+        return `Anchor${separator}AXBrowserMedia${separator}browser-anchor${separator}media-anchor${String.fromCharCode(30)}`;
+      }
+      if (script.includes('set searchQuery to "Guest"')) {
+        return `Guest${separator}AXBrowserMedia${separator}browser-guest${separator}media-guest${String.fromCharCode(30)}`;
+      }
+      if (script.includes("collectTimelineClipMatches")) {
+        return `Anchor${separator}AXRow${separator}media-anchor${separator}800${separator}0/1${separator}10/1${String.fromCharCode(30)}`;
+      }
+      if (script.includes("00:00:02:00")) playhead = "2";
+      if (script.includes("00:00:06:00")) playhead = "6";
+      if (script.includes('keystroke "q"')) {
+        pipAdded = true;
+        revision = 2;
+      }
+      if (script.includes('click menu item "Undo Native Picture-in-Picture"')) {
+        pipAdded = false;
+        revision = 3;
+      }
+      if (script.includes("FRAMEKIT_NATIVE_PIP_READBACK")) {
+        return ["320", "-180", "35", "solid", "#FFFFFF", "8", "0.1", "0.05", "0.1", "0.05"].join(separator);
+      }
+      return script.includes("timelineWindowAvailable") || script.includes('set frontWindow to window "Final Cut Pro"')
+        ? context(true, "Final Cut Pro", pipAdded ? "Guest" : "Anchor", 1, true, true, true, "timeline", 1, pipAdded ? "Undo Native Picture-in-Picture" : "Undo")
+        : "";
+    },
+  });
+
+  const [anchorMedia] = await adapter.searchMedia("Anchor");
+  const anchorOccurrences = await adapter.locateOccurrence(anchorMedia.handle);
+  const anchor = anchorOccurrences.occurrences[0];
+  assert.ok(anchor);
+  const [guestMedia] = await adapter.searchMedia("Guest");
+  await adapter.selectMedia(guestMedia.handle);
+
+  const preview = await adapter.previewPictureInPicture({
+    mediaHandle: guestMedia.handle,
+    anchorOccurrenceHandle: anchor.handle,
+    start: { value: "2", timescale: "1" },
+    duration: { value: "4", timescale: "1" },
+    position: { x: 320, y: -180 },
+    scale: 0.35,
+    crop: { top: 0.1, right: 0.05, bottom: 0.1, left: 0.05 },
+    frame: { style: "solid", color: "#FFFFFF", width: 8 },
+  });
+  assert.deepEqual(preview.start, { value: "2", timescale: "1" });
+  assert.deepEqual(preview.end, { value: "6", timescale: "1" });
+  assert.equal(preview.anchorOccurrence.handle, anchor.handle);
+
+  const result = await adapter.executePictureInPicture(preview.previewToken);
+  assert.equal(result.verification.verified, true);
+  assert.deepEqual(result.observed.position, { x: 320, y: -180 });
+  assert.equal(result.observed.scale, 0.35);
+  assert.deepEqual(result.observed.frame, { style: "solid", color: "#FFFFFF", width: 8 });
+  assert.deepEqual(result.observed.crop, { top: 0.1, right: 0.05, bottom: 0.1, left: 0.05 });
+  assert.equal(result.afterRevision.id, "rev-2");
+  assert.equal(scripts.some((script) => script.includes('keystroke "q"')), true);
+  assert.equal(scripts.some((script) => script.includes("FRAMEKIT_NATIVE_PIP_READBACK")), true);
+  assert.equal(scripts.some((script) => script.includes("set value of positionXField")), true);
+
+  const undone = await adapter.undo(result.operationId);
+  assert.equal(undone.undone, true);
+  assert.equal(undone.verification.verified, true);
+  assert.equal(scripts.some((script) => script.includes('click menu item "Undo Native Picture-in-Picture" of menu "Edit"')), true);
+});
+
 test("native title previews bind explicit selected ranges and reject incompatible or out-of-bounds assets", async () => {
   const liveState = async () => ({
     project: { id: "project-1", name: "Edit" },

--- a/tests/integration/native.test.ts
+++ b/tests/integration/native.test.ts
@@ -330,6 +330,12 @@ test("native Final Cut adapter places PIP with transform readback and undo", asy
   assert.equal(scripts.some((script) => script.includes('keystroke "q"')), true);
   assert.equal(scripts.some((script) => script.includes("FRAMEKIT_NATIVE_PIP_READBACK")), true);
   assert.equal(scripts.some((script) => script.includes("set value of positionXField")), true);
+  const transformScript = scripts.find((script) => script.includes("set value of positionXField"));
+  const readbackScript = scripts.find((script) => script.includes("FRAMEKIT_NATIVE_PIP_READBACK"));
+  assert.ok(transformScript);
+  assert.ok(readbackScript);
+  assert.ok(transformScript.indexOf("on findInspectorField") < transformScript.indexOf('tell application "System Events"'));
+  assert.ok(readbackScript.indexOf("on readInspectorField") < readbackScript.indexOf('tell application "System Events"'));
 
   const undone = await adapter.undo(result.operationId);
   assert.equal(undone.undone, true);

--- a/tests/integration/native.test.ts
+++ b/tests/integration/native.test.ts
@@ -268,7 +268,9 @@ test("native Final Cut adapter places PIP with transform readback and undo", asy
         return `Guest${separator}AXBrowserMedia${separator}browser-guest${separator}media-guest${String.fromCharCode(30)}`;
       }
       if (script.includes("collectTimelineClipMatches")) {
-        return `Anchor${separator}AXRow${separator}media-anchor${separator}800${separator}0/1${separator}10/1${separator}anchor-occurrence${String.fromCharCode(30)}`;
+        return pipAdded
+          ? `Guest${separator}AXRow${separator}media-guest${separator}800${separator}2/1${separator}4/1${separator}pip-occurrence${String.fromCharCode(30)}`
+          : `Anchor${separator}AXRow${separator}media-anchor${separator}800${separator}0/1${separator}10/1${separator}anchor-occurrence${String.fromCharCode(30)}`;
       }
       if (script.includes("00:00:02:00")) playhead = "2";
       if (script.includes("00:00:06:00")) playhead = "6";
@@ -316,6 +318,9 @@ test("native Final Cut adapter places PIP with transform readback and undo", asy
   assert.equal(result.observed.scale, 0.35);
   assert.deepEqual(result.observed.frame, { style: "solid", color: "#FFFFFF", width: 8 });
   assert.deepEqual(result.observed.crop, { top: 0.1, right: 0.05, bottom: 0.1, left: 0.05 });
+  assert.equal(result.occurrence.identity, "pip-occurrence");
+  assert.equal(result.occurrence.start, "2/1");
+  assert.equal(result.occurrence.duration, "4/1");
   assert.equal(result.afterRevision.id, "rev-2");
   assert.equal(scripts.some((script) => script.includes('keystroke "q"')), true);
   assert.equal(scripts.some((script) => script.includes("FRAMEKIT_NATIVE_PIP_READBACK")), true);
@@ -360,7 +365,9 @@ test("native PIP rolls back when transform fails after connect", async () => {
         return `Guest${separator}AXBrowserMedia${separator}browser-guest${separator}media-guest${String.fromCharCode(30)}`;
       }
       if (script.includes("collectTimelineClipMatches")) {
-        return `Anchor${separator}AXRow${separator}media-anchor${separator}800${separator}0/1${separator}10/1${separator}anchor-occurrence${String.fromCharCode(30)}`;
+        return pipAdded
+          ? `Guest${separator}AXRow${separator}media-guest${separator}800${separator}2/1${separator}4/1${separator}pip-occurrence${String.fromCharCode(30)}`
+          : `Anchor${separator}AXRow${separator}media-anchor${separator}800${separator}0/1${separator}10/1${separator}anchor-occurrence${String.fromCharCode(30)}`;
       }
       if (script.includes("00:00:02:00")) playhead = "2";
       if (script.includes("00:00:06:00")) playhead = "6";

--- a/tests/integration/native.test.ts
+++ b/tests/integration/native.test.ts
@@ -327,6 +327,85 @@ test("native Final Cut adapter places PIP with transform readback and undo", asy
   assert.equal(scripts.some((script) => script.includes('click menu item "Undo Native Picture-in-Picture" of menu "Edit"')), true);
 });
 
+test("native PIP rolls back when transform fails after connect", async () => {
+  let revision = 1;
+  let playhead = "0";
+  let pipAdded = false;
+  let undoCalls = 0;
+  const liveState = async () => ({
+    project: { id: "project-1", name: "Edit" },
+    sequence: {
+      id: "sequence-1",
+      name: "Edit",
+      startTime: { value: "0", timescale: "1" },
+      duration: { value: "20", timescale: "1" },
+      frameDuration: { value: "1", timescale: "24" },
+    },
+    playheadTime: { value: playhead, timescale: "1" },
+    sequenceTimeRange: {
+      start: { value: "0", timescale: "1" },
+      duration: { value: "20", timescale: "1" },
+    },
+    revision: { id: `rev-${revision}`, sequence: revision, timestamp: new Date(revision).toISOString() },
+  });
+  const adapter = new FinalCutNativeAutomationAdapter({
+    enabled: true,
+    liveState,
+    sleep: async () => {},
+    executor: async (script) => {
+      if (script.includes('set searchQuery to "Anchor"')) {
+        return `Anchor${separator}AXBrowserMedia${separator}browser-anchor${separator}media-anchor${String.fromCharCode(30)}`;
+      }
+      if (script.includes('set searchQuery to "Guest"')) {
+        return `Guest${separator}AXBrowserMedia${separator}browser-guest${separator}media-guest${String.fromCharCode(30)}`;
+      }
+      if (script.includes("collectTimelineClipMatches")) {
+        return `Anchor${separator}AXRow${separator}media-anchor${separator}800${separator}0/1${separator}10/1${String.fromCharCode(30)}`;
+      }
+      if (script.includes("00:00:02:00")) playhead = "2";
+      if (script.includes("00:00:06:00")) playhead = "6";
+      if (script.includes('keystroke "q"')) {
+        pipAdded = true;
+        revision = 2;
+      }
+      if (script.includes("set value of positionXField")) {
+        throw new Error("FINAL_CUT_NATIVE_PICTURE_IN_PICTURE_TRANSFORM_UNAVAILABLE: Inspector transform failed");
+      }
+      if (script.includes('click menu item "Undo Native Picture-in-Picture"')) {
+        undoCalls += 1;
+        pipAdded = false;
+        revision = 3;
+      }
+      return script.includes("timelineWindowAvailable") || script.includes('set frontWindow to window "Final Cut Pro"')
+        ? context(true, "Final Cut Pro", pipAdded ? "Guest" : "Anchor", 1, true, true, true, "timeline", 1, pipAdded ? "Undo Native Picture-in-Picture" : "Undo")
+        : "";
+    },
+  });
+
+  const [anchorMedia] = await adapter.searchMedia("Anchor");
+  const anchorOccurrences = await adapter.locateOccurrence(anchorMedia.handle);
+  const anchor = anchorOccurrences.occurrences[0];
+  assert.ok(anchor);
+  const [guestMedia] = await adapter.searchMedia("Guest");
+  await adapter.selectMedia(guestMedia.handle);
+  const preview = await adapter.previewPictureInPicture({
+    mediaHandle: guestMedia.handle,
+    anchorOccurrenceHandle: anchor.handle,
+    start: { value: "2", timescale: "1" },
+    duration: { value: "4", timescale: "1" },
+    position: { x: 320, y: -180 },
+    scale: 0.35,
+  });
+
+  await assert.rejects(
+    adapter.executePictureInPicture(preview.previewToken),
+    /picture-in-picture placement was rolled back/,
+  );
+  assert.equal(pipAdded, false);
+  assert.equal(undoCalls, 1);
+  assert.equal(revision, 3);
+});
+
 test("native title previews bind explicit selected ranges and reject incompatible or out-of-bounds assets", async () => {
   const liveState = async () => ({
     project: { id: "project-1", name: "Edit" },

--- a/tests/integration/native.test.ts
+++ b/tests/integration/native.test.ts
@@ -268,7 +268,7 @@ test("native Final Cut adapter places PIP with transform readback and undo", asy
         return `Guest${separator}AXBrowserMedia${separator}browser-guest${separator}media-guest${String.fromCharCode(30)}`;
       }
       if (script.includes("collectTimelineClipMatches")) {
-        return `Anchor${separator}AXRow${separator}media-anchor${separator}800${separator}0/1${separator}10/1${String.fromCharCode(30)}`;
+        return `Anchor${separator}AXRow${separator}media-anchor${separator}800${separator}0/1${separator}10/1${separator}anchor-occurrence${String.fromCharCode(30)}`;
       }
       if (script.includes("00:00:02:00")) playhead = "2";
       if (script.includes("00:00:06:00")) playhead = "6";
@@ -284,7 +284,7 @@ test("native Final Cut adapter places PIP with transform readback and undo", asy
         return ["320", "-180", "35", "solid", "#FFFFFF", "8", "0.1", "0.05", "0.1", "0.05"].join(separator);
       }
       return script.includes("timelineWindowAvailable") || script.includes('set frontWindow to window "Final Cut Pro"')
-        ? context(true, "Final Cut Pro", pipAdded ? "Guest" : "Anchor", 1, true, true, true, "timeline", 1, pipAdded ? "Undo Native Picture-in-Picture" : "Undo")
+        ? context(true, "Final Cut Pro", pipAdded ? "Guest" : "Anchor", 1, true, true, true, "timeline", 1, pipAdded ? "Undo Native Picture-in-Picture" : "Undo", pipAdded ? "pip-occurrence" : "anchor-occurrence")
         : "";
     },
   });
@@ -360,7 +360,7 @@ test("native PIP rolls back when transform fails after connect", async () => {
         return `Guest${separator}AXBrowserMedia${separator}browser-guest${separator}media-guest${String.fromCharCode(30)}`;
       }
       if (script.includes("collectTimelineClipMatches")) {
-        return `Anchor${separator}AXRow${separator}media-anchor${separator}800${separator}0/1${separator}10/1${String.fromCharCode(30)}`;
+        return `Anchor${separator}AXRow${separator}media-anchor${separator}800${separator}0/1${separator}10/1${separator}anchor-occurrence${String.fromCharCode(30)}`;
       }
       if (script.includes("00:00:02:00")) playhead = "2";
       if (script.includes("00:00:06:00")) playhead = "6";
@@ -377,7 +377,7 @@ test("native PIP rolls back when transform fails after connect", async () => {
         revision = 3;
       }
       return script.includes("timelineWindowAvailable") || script.includes('set frontWindow to window "Final Cut Pro"')
-        ? context(true, "Final Cut Pro", pipAdded ? "Guest" : "Anchor", 1, true, true, true, "timeline", 1, pipAdded ? "Undo Native Picture-in-Picture" : "Undo")
+        ? context(true, "Final Cut Pro", pipAdded ? "Guest" : "Anchor", 1, true, true, true, "timeline", 1, pipAdded ? "Undo Native Picture-in-Picture" : "Undo", pipAdded ? "pip-occurrence" : "anchor-occurrence")
         : "";
     },
   });
@@ -404,6 +404,70 @@ test("native PIP rolls back when transform fails after connect", async () => {
   assert.equal(pipAdded, false);
   assert.equal(undoCalls, 1);
   assert.equal(revision, 3);
+});
+
+test("native PIP rejects a same-name anchor with a different identity", async () => {
+  let playhead = "0";
+  let connected = false;
+  const liveState = async () => ({
+    project: { id: "project-1", name: "Edit" },
+    sequence: {
+      id: "sequence-1",
+      name: "Edit",
+      startTime: { value: "0", timescale: "1" },
+      duration: { value: "20", timescale: "1" },
+      frameDuration: { value: "1", timescale: "24" },
+    },
+    playheadTime: { value: playhead, timescale: "1" },
+    sequenceTimeRange: {
+      start: { value: "0", timescale: "1" },
+      duration: { value: "20", timescale: "1" },
+    },
+    revision: { id: connected ? "rev-2" : "rev-1", sequence: connected ? 2 : 1, timestamp: new Date(1).toISOString() },
+  });
+  const adapter = new FinalCutNativeAutomationAdapter({
+    enabled: true,
+    liveState,
+    sleep: async () => {},
+    executor: async (script) => {
+      if (script.includes('set searchQuery to "Anchor"')) {
+        return `Anchor${separator}AXBrowserMedia${separator}browser-anchor${separator}media-anchor${String.fromCharCode(30)}`;
+      }
+      if (script.includes('set searchQuery to "Guest"')) {
+        return `Guest${separator}AXBrowserMedia${separator}browser-guest${separator}media-guest${String.fromCharCode(30)}`;
+      }
+      if (script.includes("collectTimelineClipMatches")) {
+        return `Anchor${separator}AXRow${separator}media-anchor${separator}800${separator}0/1${separator}10/1${separator}anchor-occurrence${String.fromCharCode(30)}`;
+      }
+      if (script.includes("00:00:02:00")) playhead = "2";
+      if (script.includes("00:00:06:00")) playhead = "6";
+      if (script.includes('keystroke "q"')) connected = true;
+      return script.includes("timelineWindowAvailable") || script.includes('set frontWindow to window "Final Cut Pro"')
+        ? context(true, "Final Cut Pro", "Anchor", 1, true, true, true, "timeline", 1, "Undo", "different-anchor")
+        : "";
+    },
+  });
+
+  const [anchorMedia] = await adapter.searchMedia("Anchor");
+  const anchorOccurrences = await adapter.locateOccurrence(anchorMedia.handle);
+  const anchor = anchorOccurrences.occurrences[0];
+  assert.ok(anchor);
+  const [guestMedia] = await adapter.searchMedia("Guest");
+  await adapter.selectMedia(guestMedia.handle);
+  const preview = await adapter.previewPictureInPicture({
+    mediaHandle: guestMedia.handle,
+    anchorOccurrenceHandle: anchor.handle,
+    start: { value: "2", timescale: "1" },
+    duration: { value: "4", timescale: "1" },
+    position: { x: 320, y: -180 },
+    scale: 0.35,
+  });
+
+  await assert.rejects(
+    adapter.executePictureInPicture(preview.previewToken),
+    /selected timeline occurrence does not match the requested anchor/,
+  );
+  assert.equal(connected, false);
 });
 
 test("native title previews bind explicit selected ranges and reject incompatible or out-of-bounds assets", async () => {

--- a/tests/integration/native.test.ts
+++ b/tests/integration/native.test.ts
@@ -311,7 +311,7 @@ test("native Final Cut adapter places PIP with transform readback and undo", asy
     position: { x: 320, y: -180 },
     scale: 0.35,
     crop: { top: 0.1, right: 0.05, bottom: 0.1, left: 0.05 },
-    frame: { style: "solid", color: "#FFFFFF", width: 8 },
+    frame: { style: "solid", color: "#ffffff", width: 8 },
   });
   assert.deepEqual(preview.start, { value: "2", timescale: "1" });
   assert.deepEqual(preview.end, { value: "6", timescale: "1" });

--- a/tests/integration/picture-in-picture-evidence.test.ts
+++ b/tests/integration/picture-in-picture-evidence.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import test from "node:test";
+
+test("headed PIP runner preserves native evidence boundaries", async () => {
+  const runner = await readFile(join(process.cwd(), "scripts/final-cut-picture-in-picture-headed-e2e.mjs"), "utf8");
+  assert.match(runner, /editor\.native\.picture-in-picture\.preview/);
+  assert.match(runner, /editor\.native\.picture-in-picture\.execute/);
+  assert.match(runner, /editor\.native\.undo/);
+  assert.match(runner, /headed-native-picture-in-picture/);
+  assert.match(runner, /FRAMEKIT_FINAL_CUT_E2E_ANCHOR_QUERY/);
+  assert.match(runner, /FRAMEKIT_FINAL_CUT_E2E_PIP_QUERY/);
+  assert.match(runner, /observed.*position/);
+  assert.match(runner, /observed.*frame/);
+  assert.doesNotMatch(runner, /masking|cutout|tracking/);
+});
+
+test("PIP documentation separates canonical, artifact, and headed-native evidence", async () => {
+  const documentation = await readFile(join(process.cwd(), "docs/final-cut/picture-in-picture.md"), "utf8");
+  assert.match(documentation, /Fixture evidence/);
+  assert.match(documentation, /FCPXML evidence/);
+  assert.match(documentation, /Headed-native evidence/);
+  assert.match(documentation, /masking, tracking/);
+  assert.match(documentation, /test:final-cut-pip-headed/);
+});

--- a/tests/integration/picture-in-picture.test.ts
+++ b/tests/integration/picture-in-picture.test.ts
@@ -59,6 +59,11 @@ function pipOperation(): Extract<WorkflowOperation, { type: "timeline.picture-in
   };
 }
 
+function fcpxmlPipOperation(): Extract<WorkflowOperation, { type: "timeline.picture-in-picture.add" }> {
+  const { frame: _frame, ...operation } = pipOperation();
+  return operation;
+}
+
 function textFrom(result: unknown): string {
   const content = (result as { content?: unknown }).content;
   assert.ok(Array.isArray(content));
@@ -222,9 +227,18 @@ test("FCPXML PIP preview and undo preserve canonical artifact state", async () =
 
   const preview = await runtime.previewArtifactEdit(artifactPath, {
     baseRevision: before.revision,
-    operations: [pipOperation()],
+    operations: [fcpxmlPipOperation()],
   });
   assert.equal(preview.expectedDiff.added[0]?.itemId, "guest-pip");
+  assert.equal(await readFile(artifactPath, "utf8"), originalXml);
+
+  await assert.rejects(
+    runtime.previewArtifactEdit(artifactPath, {
+      baseRevision: before.revision,
+      operations: [pipOperation()],
+    }),
+    /CAPABILITY_UNAVAILABLE: FCPXML picture-in-picture frame/,
+  );
   assert.equal(await readFile(artifactPath, "utf8"), originalXml);
 
   const transaction = await runtime.executeEdit(preview.previewToken);
@@ -234,11 +248,12 @@ test("FCPXML PIP preview and undo preserve canonical artifact state", async () =
   assert.deepEqual(pip.position, { x: 320, y: -180 });
   assert.equal(pip.scale, 0.35);
   assert.deepEqual(pip.crop, { top: 0.1, right: 0.05, bottom: 0.1, left: 0.05 });
-  assert.deepEqual(pip.frame, { style: "solid", color: "#FFFFFF", width: 8 });
+  assert.equal(pip.frame, undefined);
   const writtenXml = await readFile(artifactPath, "utf8");
   assert.match(writtenXml, /adjust-transform/);
-  assert.match(writtenXml, /adjust-crop/);
-  assert.match(writtenXml, /#FFFFFF/);
+  assert.match(writtenXml, /<adjust-crop mode="crop">/);
+  assert.match(writtenXml, /<crop-rect top="10%" right="5%" bottom="10%" left="5%"><\/crop-rect>/);
+  assert.doesNotMatch(writtenXml, /frame-style|frame-color|frame-width/);
 
   await runtime.undo(transaction.id);
   assert.equal(canonicalSnapshotDigest(await runtime.inspectProject()), beforeDigest);

--- a/tests/integration/picture-in-picture.test.ts
+++ b/tests/integration/picture-in-picture.test.ts
@@ -1,0 +1,189 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { AgentVideoRuntime, canonicalSnapshotDigest } from "@framekit/runtime";
+import type { WorkflowOperation } from "@framekit/runtime";
+import { InMemoryEditorAdapter } from "@framekit/testkit";
+import { createMcpServer } from "../../apps/mcp-server/src/server.js";
+
+const fixture = {
+  projectId: "pip-project",
+  projectName: "Picture in Picture Fixture",
+  timelineId: "pip-sequence",
+  timelineName: "Main Edit",
+  clips: [{
+    id: "primary-occurrence",
+    mediaId: "primary-media",
+    name: "Presenter",
+    start: 0,
+    duration: 10,
+    track: 0,
+    role: "video" as const,
+  }],
+  media: [
+    {
+      mediaId: "primary-media",
+      source: "/fixtures/presenter.mov",
+      mediaKind: "video" as const,
+      duration: 10,
+      sourceDigest: "sha256:presenter",
+    },
+    {
+      mediaId: "pip-media",
+      source: "/fixtures/guest.mov",
+      mediaKind: "video" as const,
+      duration: 6,
+      sourceDigest: "sha256:guest",
+    },
+  ],
+};
+
+function pipOperation(): Extract<WorkflowOperation, { type: "timeline.picture-in-picture.add" }> {
+  return {
+    type: "timeline.picture-in-picture.add",
+    occurrenceId: "guest-pip",
+    mediaId: "pip-media",
+    attachedTo: "primary-occurrence",
+    start: 2,
+    duration: 4,
+    targetLane: 1,
+    position: { x: 320, y: -180 },
+    scale: 0.35,
+    crop: { top: 0.1, right: 0.05, bottom: 0.1, left: 0.05 },
+    frame: { style: "solid", color: "#FFFFFF", width: 8 },
+  };
+}
+
+function textFrom(result: unknown): string {
+  const content = (result as { content?: unknown }).content;
+  assert.ok(Array.isArray(content));
+  const first = content[0] as { text?: unknown } | undefined;
+  assert.ok(first);
+  assert.equal(typeof first?.text, "string");
+  return first.text as string;
+}
+
+function jsonFrom(result: unknown): any {
+  const text = textFrom(result);
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(`MCP tool failed: ${text}`);
+  }
+}
+
+test("PIP preview is non-mutating and execute verifies transform and frame state", async () => {
+  const adapter = new InMemoryEditorAdapter(fixture);
+  const runtime = new AgentVideoRuntime(adapter);
+  const before = await runtime.inspectProject();
+  const beforeDigest = canonicalSnapshotDigest(before);
+
+  const preview = await runtime.previewEdit({
+    baseRevision: before.revision,
+    operations: [pipOperation()],
+  });
+
+  assert.equal(preview.expectedDiff.added.length, 1);
+  assert.deepEqual(await runtime.inspectProject(), before);
+
+  const transaction = await runtime.executeEdit(preview.previewToken);
+
+  assert.equal(transaction.status, "VERIFIED");
+  const pip = transaction.after.timeline.clips.find((clip) => clip.id === "guest-pip");
+  assert.ok(pip);
+  assert.equal(pip.track, 1);
+  assert.equal(pip.attachedTo, "primary-occurrence");
+  assert.deepEqual(pip.position, { x: 320, y: -180 });
+  assert.equal(pip.scale, 0.35);
+  assert.deepEqual(pip.crop, { top: 0.1, right: 0.05, bottom: 0.1, left: 0.05 });
+  assert.deepEqual(pip.frame, { style: "solid", color: "#FFFFFF", width: 8 });
+  assert.equal(transaction.diff.added[0]?.itemId, "guest-pip");
+  assert.equal((await runtime.verifyTransaction(transaction.id)).passed, true);
+
+  const undone = await runtime.undo(transaction.id);
+  assert.equal(canonicalSnapshotDigest(undone), beforeDigest);
+});
+
+test("PIP remains available independently when masking is unavailable", async () => {
+  const adapter = new InMemoryEditorAdapter(fixture);
+  const runtime = new AgentVideoRuntime(adapter);
+  const capabilities = await runtime.inspectEditor();
+
+  assert.equal(capabilities.capabilities.families?.editing.pictureInPicture.available, true);
+  assert.equal(capabilities.capabilities.families?.editing.masking.available, false);
+});
+
+test("MCP exposes the complete deterministic PIP preview, execute, diff, verify, undo loop", async () => {
+  const runtime = new AgentVideoRuntime(new InMemoryEditorAdapter(fixture));
+  const server = createMcpServer(runtime);
+  const client = new Client({ name: "picture-in-picture-test", version: "1.0.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  try {
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    const before = jsonFrom(await client.callTool({ name: "project.inspect", arguments: {} }));
+    const preview = jsonFrom(await client.callTool({
+      name: "editor.timeline.edit.preview",
+      arguments: {
+        projectId: before.projectId,
+        sequenceId: before.timeline.id,
+        baseRevision: before.revision,
+        operations: [pipOperation()],
+      },
+    }));
+    assert.equal(preview.expectedDiff.added[0].itemId, "guest-pip");
+
+    const transaction = jsonFrom(await client.callTool({
+      name: "editor.timeline.edit.execute",
+      arguments: { previewToken: preview.previewToken },
+    }));
+    assert.equal(transaction.status, "VERIFIED");
+    assert.equal(jsonFrom(await client.callTool({
+      name: "edit.diff",
+      arguments: { transactionId: transaction.id },
+    })).added[0].itemId, "guest-pip");
+    assert.equal(jsonFrom(await client.callTool({
+      name: "edit.verify",
+      arguments: { transactionId: transaction.id },
+    })).passed, true);
+    const undone = jsonFrom(await client.callTool({
+      name: "edit.undo",
+      arguments: { transactionId: transaction.id },
+    }));
+    assert.equal(undone.timeline.clips.length, 1);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
+
+test("PIP rejects invalid connected lanes, crops, and non-video media", async () => {
+  const adapter = new InMemoryEditorAdapter(fixture);
+  const runtime = new AgentVideoRuntime(adapter);
+  const before = await runtime.inspectProject();
+
+  await assert.rejects(
+    runtime.previewEdit({
+      baseRevision: before.revision,
+      operations: [{ ...pipOperation(), targetLane: 0 }],
+    }),
+    /INVALID_OPERATION/,
+  );
+  await assert.rejects(
+    runtime.previewEdit({
+      baseRevision: before.revision,
+      operations: [{ ...pipOperation(), crop: { top: 0.6, right: 0, bottom: 0.5, left: 0 } }],
+    }),
+    /INVALID_OPERATION/,
+  );
+  await assert.rejects(
+    runtime.previewEdit({
+      baseRevision: before.revision,
+      operations: [{ ...pipOperation(), mediaId: "missing-media" }],
+    }),
+    /MEDIA_NOT_FOUND/,
+  );
+  assert.equal(canonicalSnapshotDigest(await runtime.inspectProject()), canonicalSnapshotDigest(before));
+});

--- a/tests/integration/picture-in-picture.test.ts
+++ b/tests/integration/picture-in-picture.test.ts
@@ -218,6 +218,13 @@ test("PIP rejects invalid connected lanes, crops, and non-video media", async ()
   await assert.rejects(
     runtime.previewEdit({
       baseRevision: before.revision,
+      operations: [{ ...pipOperation(), duration: 7 }],
+    }),
+    /INVALID_OPERATION/,
+  );
+  await assert.rejects(
+    runtime.previewEdit({
+      baseRevision: before.revision,
       operations: [{ ...pipOperation(), mediaId: "missing-media" }],
     }),
     /MEDIA_NOT_FOUND/,

--- a/tests/integration/picture-in-picture.test.ts
+++ b/tests/integration/picture-in-picture.test.ts
@@ -7,7 +7,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { FcpxmlDocumentAdapter } from "@framekit/final-cut";
 import { AgentVideoRuntime, canonicalSnapshotDigest } from "@framekit/runtime";
-import type { WorkflowOperation } from "@framekit/runtime";
+import type { ContextRevision, ProjectSnapshot, WorkflowOperation } from "@framekit/runtime";
 import { InMemoryEditorAdapter } from "@framekit/testkit";
 import { createMcpServer } from "../../apps/mcp-server/src/server.js";
 
@@ -79,6 +79,34 @@ function jsonFrom(result: unknown): any {
     return JSON.parse(text);
   } catch {
     throw new Error(`MCP tool failed: ${text}`);
+  }
+}
+
+class MismatchedPipAdapter extends InMemoryEditorAdapter {
+  private reportMismatchedPip = false;
+
+  public override async applyTransaction(operations: WorkflowOperation[], expectedRevision: ContextRevision): Promise<void> {
+    await super.applyTransaction(operations, expectedRevision);
+    this.reportMismatchedPip = true;
+  }
+
+  public override async readProject(): Promise<ProjectSnapshot> {
+    const snapshot = await super.readProject();
+    if (!this.reportMismatchedPip) return snapshot;
+    return {
+      ...snapshot,
+      timeline: {
+        ...snapshot.timeline,
+        clips: snapshot.timeline.clips.map((clip) => clip.id === "guest-pip"
+          ? { ...clip, attachedTo: "wrong-anchor" }
+          : clip),
+      },
+    };
+  }
+
+  public override async restore(snapshot: ProjectSnapshot, expectedRevision: ContextRevision): Promise<void> {
+    await super.restore(snapshot, expectedRevision);
+    this.reportMismatchedPip = false;
   }
 }
 
@@ -195,6 +223,22 @@ test("PIP rejects invalid connected lanes, crops, and non-video media", async ()
     /MEDIA_NOT_FOUND/,
   );
   assert.equal(canonicalSnapshotDigest(await runtime.inspectProject()), canonicalSnapshotDigest(before));
+});
+
+test("PIP verification rejects a mismatched construction attachment", async () => {
+  const adapter = new MismatchedPipAdapter(fixture);
+  const runtime = new AgentVideoRuntime(adapter);
+  const before = await runtime.inspectProject();
+  const beforeDigest = canonicalSnapshotDigest(before);
+  const preview = await runtime.previewEdit({
+    baseRevision: before.revision,
+    operations: [pipOperation()],
+  });
+
+  const transaction = await runtime.executeEdit(preview.previewToken);
+  assert.equal(transaction.status, "ROLLED_BACK");
+  assert.equal(transaction.verification?.checks.find((check) => check.name === "construction-state")?.passed, false);
+  assert.equal(canonicalSnapshotDigest(await runtime.inspectProject()), beforeDigest);
 });
 
 test("FCPXML PIP preview and undo preserve canonical artifact state", async () => {

--- a/tests/integration/picture-in-picture.test.ts
+++ b/tests/integration/picture-in-picture.test.ts
@@ -258,3 +258,41 @@ test("FCPXML PIP preview and undo preserve canonical artifact state", async () =
   await runtime.undo(transaction.id);
   assert.equal(canonicalSnapshotDigest(await runtime.inspectProject()), beforeDigest);
 });
+
+test("FCPXML transactions restore artifact state after a later operation fails", async () => {
+  const directory = await mkdtemp(join(os.tmpdir(), "framekit-pip-fcpxml-rollback-"));
+  const artifactPath = join(directory, "pip.fcpxml");
+  const originalXml = `<?xml version="1.0" encoding="UTF-8"?>
+<fcpxml version="1.11">
+  <resources>
+    <asset id="primary-media" name="Presenter" src="file:///fixtures/presenter.mov" duration="10s" />
+    <asset id="pip-media" name="Guest" src="file:///fixtures/guest.mov" duration="6s" />
+  </resources>
+  <library>
+    <event name="PIP Event">
+      <project uid="project-pip" name="PIP Project">
+        <sequence uid="sequence-pip" name="Main Edit" duration="10s" format="r-format">
+          <spine>
+            <asset-clip id="primary-occurrence" name="Presenter" ref="primary-media" offset="0s" start="0s" duration="10s" />
+          </spine>
+        </sequence>
+      </project>
+    </event>
+  </library>
+</fcpxml>
+`;
+  await writeFile(artifactPath, originalXml, "utf8");
+  const adapter = new FcpxmlDocumentAdapter(artifactPath);
+  const before = await adapter.readProject();
+
+  await assert.rejects(
+    adapter.applyTransaction([
+      fcpxmlPipOperation(),
+      { ...fcpxmlPipOperation(), occurrenceId: "guest-pip-2", attachedTo: "missing-anchor" },
+    ], before.revision),
+    /CLIP_NOT_FOUND: missing-anchor/,
+  );
+
+  assert.equal(await readFile(artifactPath, "utf8"), originalXml);
+  assert.deepEqual(await adapter.readProject(), before);
+});

--- a/tests/integration/picture-in-picture.test.ts
+++ b/tests/integration/picture-in-picture.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { FcpxmlDocumentAdapter } from "@framekit/final-cut";
 import { AgentVideoRuntime, canonicalSnapshotDigest } from "@framekit/runtime";
 import type { WorkflowOperation } from "@framekit/runtime";
 import { InMemoryEditorAdapter } from "@framekit/testkit";
@@ -186,4 +190,56 @@ test("PIP rejects invalid connected lanes, crops, and non-video media", async ()
     /MEDIA_NOT_FOUND/,
   );
   assert.equal(canonicalSnapshotDigest(await runtime.inspectProject()), canonicalSnapshotDigest(before));
+});
+
+test("FCPXML PIP preview and undo preserve canonical artifact state", async () => {
+  const directory = await mkdtemp(join(os.tmpdir(), "framekit-pip-fcpxml-"));
+  const artifactPath = join(directory, "pip.fcpxml");
+  const originalXml = `<?xml version="1.0" encoding="UTF-8"?>
+<fcpxml version="1.11">
+  <resources>
+    <asset id="primary-media" name="Presenter" src="file:///fixtures/presenter.mov" duration="10s" />
+    <asset id="pip-media" name="Guest" src="file:///fixtures/guest.mov" duration="6s" />
+  </resources>
+  <library>
+    <event name="PIP Event">
+      <project uid="project-pip" name="PIP Project">
+        <sequence uid="sequence-pip" name="Main Edit" duration="10s" format="r-format">
+          <spine>
+            <asset-clip id="primary-occurrence" name="Presenter" ref="primary-media" offset="0s" start="0s" duration="10s" />
+          </spine>
+        </sequence>
+      </project>
+    </event>
+  </library>
+</fcpxml>
+`;
+  await writeFile(artifactPath, originalXml, "utf8");
+  const adapter = new FcpxmlDocumentAdapter(artifactPath);
+  const runtime = new AgentVideoRuntime(adapter);
+  const before = await runtime.inspectProject();
+  const beforeDigest = canonicalSnapshotDigest(before);
+
+  const preview = await runtime.previewArtifactEdit(artifactPath, {
+    baseRevision: before.revision,
+    operations: [pipOperation()],
+  });
+  assert.equal(preview.expectedDiff.added[0]?.itemId, "guest-pip");
+  assert.equal(await readFile(artifactPath, "utf8"), originalXml);
+
+  const transaction = await runtime.executeEdit(preview.previewToken);
+  assert.equal(transaction.status, "VERIFIED");
+  const pip = transaction.after.timeline.clips.find((clip) => clip.id === "guest-pip");
+  assert.ok(pip);
+  assert.deepEqual(pip.position, { x: 320, y: -180 });
+  assert.equal(pip.scale, 0.35);
+  assert.deepEqual(pip.crop, { top: 0.1, right: 0.05, bottom: 0.1, left: 0.05 });
+  assert.deepEqual(pip.frame, { style: "solid", color: "#FFFFFF", width: 8 });
+  const writtenXml = await readFile(artifactPath, "utf8");
+  assert.match(writtenXml, /adjust-transform/);
+  assert.match(writtenXml, /adjust-crop/);
+  assert.match(writtenXml, /#FFFFFF/);
+
+  await runtime.undo(transaction.id);
+  assert.equal(canonicalSnapshotDigest(await runtime.inspectProject()), beforeDigest);
 });


### PR DESCRIPTION
Closes #166

## Summary

- Adds first-class `timeline.picture-in-picture.add` workflow support with connected-lane placement, transform, crop, frame, preview, execute, verification, and Undo.
- Adds deterministic fixture and FCPXML implementations with canonical diff/digest restoration coverage.
- Adds native Final Cut preview/execute routing with stable Browser media and timeline occurrence bindings, Inspector transform readback, revision checks, and native Undo rollback.
- Adds explicit capability reporting, MCP tools, Workflow Extension metadata boundaries, documentation, and an opt-in headed-native evidence runner.

Masking, tracking, and person cutout remain separate unavailable capabilities; no silent fallback asset or external renderer is used.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm run test` — 551 passed
- `pnpm run check:boundaries`
- `pnpm run xcode:check`
- `xcodebuild -project adapters/final-cut/swift-bridge/FinalCutWorkflowExtension/FramekitFinalCutWorkflow.xcodeproj -list`
- Native Xcode Debug build with `CODE_SIGNING_ALLOWED=NO`

The headed runner is implemented and deterministic native tests pass; a real Final Cut placement run requires an explicitly configured disposable project and media queries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added picture-in-picture support across the app, including preview and apply workflows.
  - Picture-in-picture is now reflected in capability checks and routing, so supported editors can expose it consistently.
  - Added support for position, scale, crop, and optional frame styling in picture-in-picture placements.

- **Bug Fixes**
  - Added validation to reject unsupported or invalid picture-in-picture placements more reliably.
  - Improved undo and verification behavior after picture-in-picture changes.

- **Documentation**
  - Added and updated Final Cut Pro and MCP documentation for picture-in-picture workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->