### PR TITLE
[Improvement] Add the v0.1.6 native-editing release gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,23 @@ jobs:
       - name: Validate MCP server version
         run: node scripts/validate-mcp-server-version.mjs
 
+      - name: Install Codex CLI for plugin validation
+        run: npm install --global @openai/codex@0.144.1
+
+      - name: Validate package and plugin alignment
+        run: pnpm run test:codex-plugin
+
+      - name: Run v0.1.6 native-editing release gate
+        run: pnpm run release-gate --output-dir artifacts/release-gate/${{ github.run_id }}
+
+      - name: Upload release gate evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: release-gate-${{ github.run_id }}
+          path: artifacts/release-gate/${{ github.run_id }}
+          if-no-files-found: warn
+
       - id: npm-status
         name: Check npm publication status
         env:
@@ -193,6 +210,31 @@ jobs:
           done
           cat "${error_log}" >&2
           exit 1
+
+      - name: Verify native release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          RELEASE_TAG: ${{ needs.tagpr.outputs.release-tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected_version="${RELEASE_TAG#v}"
+          archive_name="FramekitFinalCutWorkflow-${expected_version}.zip"
+          checksum_name="${archive_name}.sha256"
+          native_dir="${RUNNER_TEMP}/framekit-native-release"
+          mkdir -p "${native_dir}"
+          gh release download "${RELEASE_TAG}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --pattern "${archive_name}" \
+            --pattern "${checksum_name}" \
+            --dir "${native_dir}"
+          test -s "${native_dir}/${archive_name}"
+          test -s "${native_dir}/${checksum_name}"
+          (
+            cd "${native_dir}"
+            shasum -a 256 -c "${checksum_name}"
+          )
 
       - name: Publish GitHub release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,6 +251,14 @@ jobs:
             gh release edit "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" --draft=false
           fi
 
+      - name: Verify complete release provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          RELEASE_TAG: ${{ needs.tagpr.outputs.release-tag }}
+          RELEASE_PROVENANCE_OUTPUT_DIR: artifacts/release-gate/${{ github.run_id }}
+        run: pnpm run verify-release-provenance
+
   validate-codex-plugin:
     if: needs.tagpr.outputs.release-tag != ''
     needs: tagpr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,9 @@ jobs:
 
   publish-npm:
     if: needs.tagpr.outputs.release-tag != ''
-    needs: tagpr
+    needs:
+      - tagpr
+      - validate-codex-plugin
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -119,12 +121,6 @@ jobs:
 
       - name: Validate MCP server version
         run: node scripts/validate-mcp-server-version.mjs
-
-      - name: Install Codex CLI for plugin validation
-        run: npm install --global @openai/codex@0.144.1
-
-      - name: Validate package and plugin alignment
-        run: pnpm run test:codex-plugin
 
       - name: Run v0.1.6 native-editing release gate
         run: pnpm run release-gate --output-dir artifacts/release-gate/${{ github.run_id }}
@@ -254,3 +250,31 @@ jobs:
           else
             gh release edit "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" --draft=false
           fi
+
+  validate-codex-plugin:
+    if: needs.tagpr.outputs.release-tag != ''
+    needs: tagpr
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.tagpr.outputs.release-tag }}
+          persist-credentials: false
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24.21.0
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate package and plugin alignment
+        run: pnpm run test:codex-plugin

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -89,7 +89,7 @@ jobs:
           path: artifacts/filler-removal/${{ github.run_id }}
           if-no-files-found: warn
 
-      - name: Run v0.0.3 release gate
+      - name: Run v0.1.6 native-editing release gate
         run: pnpm run release-gate --output-dir artifacts/release-gate/${{ github.run_id }}
 
       - name: Upload release gate evidence

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -62,9 +62,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install Codex CLI
-        run: npm install --global @openai/codex@0.144.1
-
       - name: Validate clean Codex plugin installation
         run: pnpm run test:codex-plugin
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -4,6 +4,20 @@ Phase 0, Phase 1, and Phase 2 are local runtime spikes. Capability declarations 
 authoritative at runtime; unsupported operations must fail with an explicit
 `CAPABILITY_UNAVAILABLE` error.
 
+## v0.1.6 native-editing release gate
+
+The current repository-owned gate covers five separate evidence tiers:
+deterministic fixture edits, FCPXML artifact writes, metadata-only bridge
+observations, canonical live capability, and opt-in headed-native Final Cut
+verification. Its workflow matrix covers canonical live editing,
+picture-in-picture, built-in title discovery, masking, filler removal, and
+dialogue normalization. `unsupported` and `unrun` remain distinct from
+`verified` in the report.
+
+Release provenance also checks package, MCP server, plugin, tag, GitHub release,
+workflow, npm, native archive, and checksum alignment. A release is not complete
+until the external checks and both native assets are verified.
+
 ## v0.0.3 release gate
 
 The repository-owned deterministic corpus verifies both v0.0.3 Skills through

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,7 +41,7 @@ Repository-local GitHub agent playbooks are documented in
 - [Local speech analysis](./speech-analysis.md): the executable wrapper,
   JSON contract, provenance, and capability boundaries.
 - [Rough-cut duration policy](./rough-cut/duration-policy.md): explicit duration tradeoffs and safety defaults.
-- [Tests](./tests/README.md): reproducible checks and evidence, including the [golden workflow corpus](./tests/golden-corpus.md), [deterministic MCP evaluation](./tests/mcp-evaluation.md), and [v0.0.3 release gate](./tests/release-gate.md).
+- [Tests](./tests/README.md): reproducible checks and evidence, including the [golden workflow corpus](./tests/golden-corpus.md), [deterministic MCP evaluation](./tests/mcp-evaluation.md), and [v0.1.6 native-editing release gate](./tests/release-gate.md).
 - [Generic MCP Skills](./mcp/skills.md): versioned Skill discovery and execution.
 - [Skill authoring](./mcp/skill-authoring.md): public manifests, handlers, plans, and lifecycle boundaries.
 - [v0.0.2 Skill conformance](./tests/skill-conformance.md): deterministic gate and adapter evidence.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -34,12 +34,14 @@ repository. The workflow uses GitHub's OIDC identity and does not require an
 2. The `tagpr` job creates the version tag and a draft GitHub release with
    generated notes. If the merge already placed the release tag on `HEAD`,
    the workflow reuses that tag instead of trying to create it again.
-3. The `publish-npm` job installs npm 11.5.1, publishes the matching package,
-   and verifies the version on the public registry.
-4. The v0.1.6 release gate verifies the repository checks, artifact evidence,
-   capability boundaries, and release provenance before completion.
-5. Only after npm, native asset/checksum, and gate verification succeeds, the
-   workflow publishes the GitHub release and its notes.
+3. The `publish-npm` job installs npm 11.5.1, runs the v0.1.6 repository gate,
+   publishes the matching package, and verifies the version on the public
+   registry.
+4. The workflow verifies the native archive and checksum, then publishes the
+   GitHub release and its notes.
+5. A final provenance gate verifies package, MCP server, plugin, tag, workflow,
+   GitHub release, npm, native archive, and checksum alignment before the
+   workflow can succeed.
 
 If npm publishing fails, the GitHub release remains a draft so the failure can
 be repaired without presenting an incomplete release as public.
@@ -82,6 +84,8 @@ pnpm run test
 pnpm run check:boundaries
 npm pack --dry-run
 pnpm run release-gate --output-dir artifacts/release-gate/local-run
+RELEASE_TAG=v0.1.6 GITHUB_REPOSITORY=morshoto/framekit \
+  pnpm run verify-release-provenance
 ```
 
 For the v0.1.6 release, attach the release gate `report.json` and
@@ -97,4 +101,5 @@ archive before the GitHub release is made public. Missing assets or a malformed
 checksum keep release completion blocked.
 
 The release workflow performs the registry and GitHub release steps on GitHub's
-hosted runner; OIDC authentication cannot be fully reproduced locally.
+hosted runner; OIDC authentication cannot be fully reproduced locally. The
+final provenance command is therefore an authenticated post-publication check.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -36,8 +36,10 @@ repository. The workflow uses GitHub's OIDC identity and does not require an
    the workflow reuses that tag instead of trying to create it again.
 3. The `publish-npm` job installs npm 11.5.1, publishes the matching package,
    and verifies the version on the public registry.
-4. Only after npm verification succeeds, the workflow publishes the GitHub
-   release and its notes.
+4. The v0.1.6 release gate verifies the repository checks, artifact evidence,
+   capability boundaries, and release provenance before completion.
+5. Only after npm, native asset/checksum, and gate verification succeeds, the
+   workflow publishes the GitHub release and its notes.
 
 If npm publishing fails, the GitHub release remains a draft so the failure can
 be repaired without presenting an incomplete release as public.
@@ -82,11 +84,17 @@ npm pack --dry-run
 pnpm run release-gate --output-dir artifacts/release-gate/local-run
 ```
 
-For the v0.0.3 release, attach the release gate `report.json` and
-`manifest.json` as evidence. The deterministic fixture gate, FCPXML adapter
-coverage, opt-in live Final Cut evidence, and unsupported capabilities must be
-reported separately. Fixture success does not establish autonomous open-project
-Final Cut support; that claim requires the documented disposable headed run.
+For the v0.1.6 release, attach the release gate `report.json` and
+`manifest.json` as evidence. The deterministic, FCPXML artifact,
+metadata-only, canonical-live, and opt-in headed-native tiers must be reported
+separately. Fixture success does not establish autonomous open-project Final
+Cut support; that claim requires the documented disposable headed run.
+
+The native release assets must be named
+`FramekitFinalCutWorkflow-<version>.zip` and
+`FramekitFinalCutWorkflow-<version>.zip.sha256`. The checksum must match the
+archive before the GitHub release is made public. Missing assets or a malformed
+checksum keep release completion blocked.
 
 The release workflow performs the registry and GitHub release steps on GitHub's
 hosted runner; OIDC authentication cannot be fully reproduced locally.

--- a/docs/tests/release-gate.md
+++ b/docs/tests/release-gate.md
@@ -1,57 +1,86 @@
-# v0.0.3 Closed-Loop Speech Editing Release Gate
+# v0.1.6 Native-Editing Release Gate
 
-The release gate exercises the `filler-removal` and
-`dialogue-normalization` Skills through the generic MCP surface. Its controlled
-corpus is repository-owned and contains no private media.
+The repository-owned v0.1.6 gate records native-editing evidence without
+confusing deterministic fixtures, FCPXML artifacts, metadata-only bridge
+observations, canonical live edits, and headed Final Cut proof. Its versioned
+manifest is [`tests/release-gate/manifest.json`](../../tests/release-gate/manifest.json).
 
 ## Local commands
 
-Run the focused tests with:
+Run the focused contract tests with:
 
 ```sh
 pnpm run test:release-gate
 ```
 
-Run the executable gate and retain an immutable evidence bundle with:
+Run the reproducible gate and retain an immutable evidence bundle with:
 
 ```sh
 pnpm run release-gate --output-dir artifacts/release-gate/local-run
 ```
 
-The output contains `report.json` with sanitized workflow results, plans,
-operations, canonical diffs, digests, and capability boundaries, plus
-`manifest.json` with the corpus version, report hash, workflow count, and gate
-status. Reusing an evidence directory is rejected.
+This command runs `pnpm install --frozen-lockfile`, `pnpm run build`,
+`pnpm run test`, the deterministic MCP evaluation (`pnpm run evaluate`), and
+`pnpm run check:boundaries` as separate repository checks. Reusing an evidence
+directory is rejected.
 
-## Controlled corpus
+Headed native evidence is opt-in and must target a disposable project:
 
-Filler-removal cases cover obvious and multi-filler speech, low confidence,
-unsafe and overlapping boundaries, protected segments, and induced verification
-rollback. Dialogue-normalization cases cover quiet, loud, already-normalized,
-silent, no-dialogue, peak-risk, gain-clamp, and induced verification rollback.
+```sh
+pnpm run release-gate \
+  --output-dir artifacts/release-gate/headed-run \
+  --headed-evidence-dir artifacts/final-cut-headed
+```
 
-Safe filler cases are measured against the 95% successful-verification target.
-Skipped and rolled-back cases remain in the attempted report and must preserve
-the original canonical digest.
+The headed runners must be invoked separately with the required disposable
+project and consent configuration. Their JSON output can then be supplied to
+the gate; no headed UI mutation occurs by default.
 
-## Capability evidence
+## Evidence tiers
 
-The deterministic fixture result is separate from adapter and live evidence.
-The combined v0.0.3 report still marks the FCPXML speech-editing family
-unsupported because filler-removal requires timeline write guarantees. The
-dialogue-normalization Skill has separate deterministic artifact coverage for
-clip-level `set-gain`; that result is FCPXML evidence, not proof of a headed
-open-project Final Cut edit. Live Final Cut remains unsupported unless a
-documented opt-in headed run is requested; the bundled Workflow Extension is
-metadata-only and never supplies fixture data. An unsupported capability is not
-a passing proof of autonomous open-project Final Cut support.
+| Tier | Mode | Guarantee | Default status |
+| --- | --- | --- | --- |
+| deterministic | headless | verified fixture preview, execute, readback, and Undo | verified |
+| FCPXML artifact | headless | verified artifact write and restoration | verified when supported |
+| metadata-only | headless | observed bridge identity and capability payload | verified observation |
+| canonical-live | headless | canonical timeline read/write contract | unsupported for the bundled bridge |
+| headed-native | headed | disposable Final Cut readback and native Undo | unrun unless opted in |
 
-The CI report keeps deterministic correctness, adapter coverage, live Final Cut
-evidence, and unsupported capabilities in separate fields.
+Each tier has an independent status: `verified`, `failed`, `unsupported`, or
+`unrun`. An unsupported capability is not treated as a successful native edit,
+and an unrun headed tier is not treated as headed proof.
 
-The Basic Final Cut Editing MVP has a separate executable fixture gate. Run it
-with `pnpm exec tsx --test tests/integration/basic-editing-mvp.test.ts` to
-verify import, placement, preview, execute, verification, transaction-bound
-export evidence, and Undo without Final Cut. CI reports this gate separately
-from the broad unit/integration suite; its fixture results do not promote live
-Final Cut capability.
+The workflow matrix covers canonical live editing, picture-in-picture, built-in
+title discovery and placement, masking, filler removal, and dialogue
+normalization. The deterministic corpus retains the filler-removal cases
+`obvious`, `low-confidence`, `unsafe-boundary`, `overlapping-speech`,
+`protected-segment`, `multi-filler`, and `verification-rollback`, plus the
+dialogue cases `quiet`, `loud`, `already-normalized`, `silent`, `no-dialogue`,
+`peak-risk`, `gain-clamp`, and `verification-rollback`.
+
+Canonical live Final Cut support remains distinct from metadata-only bridge
+observations and requires a provider that advertises complete timeline
+read/write guarantees.
+
+## Artifacts and provenance
+
+`report.json` contains the sanitized workflow matrix, tier records, capability
+preflight payloads, revisions, verification and restoration results, repository
+check statuses, and release provenance. `manifest.json` contains the report
+hash, v0.1.6 manifest and release versions, tier summaries, workflow coverage,
+repository-check statuses, and provenance status.
+
+Headed records must include the disposable target identity, Final Cut and
+Framekit versions, the before/after/restored revisions, and verified execute and
+Undo results. Published summaries omit private paths, credentials, native
+handles, operation IDs, source identities, and raw diagnostics. Raw machine
+evidence remains an operator-local input rather than a committed artifact.
+
+Release provenance keeps package, MCP server, plugin, tag, GitHub release,
+workflow, npm, and native archive/checksum checks separate. Missing external
+state is `unrun`; release completion is not reported until every required
+provenance check is verified.
+
+The Basic Final Cut Editing MVP remains a separate executable fixture gate. Its
+results do not promote metadata-only or fixture evidence into headed Final Cut
+support.

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@openai/codex": "0.144.1",
     "@types/node": "24.13.3",
     "tsc-alias": "1.9.4",
     "tsx": "4.23.13",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test:golden": "tsx --test tests/golden/*.test.ts",
     "test:release-gate": "tsx --test tests/release-gate/*.test.ts",
     "release-gate": "tsx scripts/run-release-gate.ts",
+    "verify-release-provenance": "tsx scripts/verify-release-provenance.ts",
     "test:codex-plugin": "node scripts/codex-plugin-smoke.mjs",
     "test:clean-mcp-clients": "node scripts/clean-mcp-client-smoke.mjs",
     "evaluate": "tsx scripts/run-mcp-evaluation.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
         specifier: ^3.25.76
         version: 3.25.76
     devDependencies:
+      '@openai/codex':
+        specifier: 0.144.1
+        version: 0.144.1
       '@types/node':
         specifier: 24.13.3
         version: 24.13.3
@@ -448,6 +451,47 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@openai/codex@0.144.1':
+    resolution: {integrity: sha512-Xir1zqPfpenhdoAoshN53uonzbBXj18COyzRkFlVZpSNyEl5XtkuYu9oddELePFN7K/0sXUcSO34Ad5IeCXPbw==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  '@openai/codex@0.144.1-darwin-arm64':
+    resolution: {integrity: sha512-dABeDK+ATqMG54MGBd3VjpKfh5EOoqx9PKVQB2QYDaEXx3F6CdUCXue5QIMfr4OxziUj8pUcLAQyd+KFqiTUFw==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@openai/codex@0.144.1-darwin-x64':
+    resolution: {integrity: sha512-K2g3Q3tNxzFhV0SuzO6HcsYK7EQrp/o4HyeReyhkwVrwwUPoYwyIbB0IRjHIiDzRhbKriDccid2iyF5aPqdTcg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@openai/codex@0.144.1-linux-arm64':
+    resolution: {integrity: sha512-451o15+XtaXCCb35t/KCyyPqXHnTPxPxtdqEYOnE3e4sH5AfnI/uVJwfdjOksMG6vRLy6R+fLvSDOMguRFLmQw==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@openai/codex@0.144.1-linux-x64':
+    resolution: {integrity: sha512-HNGVI+BulrOaC/0IzBvd6EL62j7LrlbFKibrhw6hZjjCjAeUYzRB2jB4qDzXN1NfqDi6Xrvniof3kwbwab24lg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@openai/codex@0.144.1-win32-arm64':
+    resolution: {integrity: sha512-L4aDVEh9o1u7WYoxpSyv3un9Bz26YZYocOFqE2oHdEQDL2s6/LdtutLQc3oUZruLlEbkNsjSU0HI1OKsP0+Ctg==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@openai/codex@0.144.1-win32-x64':
+    resolution: {integrity: sha512-qv2HOp6v/nVP31p5I5GxYyL0wa79PMzim1+W9CKSV0UldjFV9AMbualA8PeXcYhbvvh9Y1UASXxwjuQdlyfAvw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
 
   '@simple-libs/stream-utils@2.0.0':
     resolution: {integrity: sha512-fCTuZK4QBa+39Oz9l4OGfJfz+GpwCp3AqO7Zch3to99xHPgstVsRFpeQ8LNd2o1Gv8raL2mCFwiaHh7bFSp5DQ==}
@@ -1720,6 +1764,33 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.3
+
+  '@openai/codex@0.144.1':
+    optionalDependencies:
+      '@openai/codex-darwin-arm64': '@openai/codex@0.144.1-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.144.1-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.144.1-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.144.1-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.144.1-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.144.1-win32-x64'
+
+  '@openai/codex@0.144.1-darwin-arm64':
+    optional: true
+
+  '@openai/codex@0.144.1-darwin-x64':
+    optional: true
+
+  '@openai/codex@0.144.1-linux-arm64':
+    optional: true
+
+  '@openai/codex@0.144.1-linux-x64':
+    optional: true
+
+  '@openai/codex@0.144.1-win32-arm64':
+    optional: true
+
+  '@openai/codex@0.144.1-win32-x64':
+    optional: true
 
   '@simple-libs/stream-utils@2.0.0':
     optional: true

--- a/scripts/final-cut-picture-in-picture-headed-e2e.mjs
+++ b/scripts/final-cut-picture-in-picture-headed-e2e.mjs
@@ -124,6 +124,10 @@ try {
       nativeUndo: editor.native.undo,
       nativeTimelineOccurrenceLocate: editor.native.timelineOccurrenceLocate,
     },
+    target: {
+      sequenceId: anchorOccurrence.sequenceId,
+      occurrenceName: anchorOccurrence.name,
+    },
     placement: {
       project: expectedProject,
       anchorMedia: { name: anchorMedia.name, sourceIdentity: anchorMedia.sourceIdentity },

--- a/scripts/final-cut-picture-in-picture-headed-e2e.mjs
+++ b/scripts/final-cut-picture-in-picture-headed-e2e.mjs
@@ -136,6 +136,7 @@ try {
       operationId: executed.operationId,
       undoOperationId: undone.operationId,
       undoVerified: undone.verification,
+      undoRevision: undone.context?.revision?.id,
     },
   }, null, 2)}\n`);
 } finally {

--- a/scripts/final-cut-title-discovery-headed-e2e.mjs
+++ b/scripts/final-cut-title-discovery-headed-e2e.mjs
@@ -119,6 +119,7 @@ try {
       backend: title.metadata.discovery.backend,
       guarantee: title.metadata.discovery.guarantee,
     },
+    target: { sequenceId: preview.sequenceId },
     placement: {
       text: titleText,
       target: preview.target,

--- a/scripts/final-cut-title-discovery-headed-e2e.mjs
+++ b/scripts/final-cut-title-discovery-headed-e2e.mjs
@@ -126,6 +126,7 @@ try {
       duration: preview.duration,
       beforeRevision: executed.beforeRevision.id,
       afterRevision: executed.afterRevision.id,
+      restoredRevision: undone.context?.revision?.id,
       verified: executed.verification.verified,
       undo: { command: executed.undoCommand, verified: undone.verification.verified },
     },

--- a/scripts/final-cut-title-discovery-headed-e2e.mjs
+++ b/scripts/final-cut-title-discovery-headed-e2e.mjs
@@ -127,7 +127,7 @@ try {
       duration: preview.duration,
       beforeRevision: executed.beforeRevision.id,
       afterRevision: executed.afterRevision.id,
-      restoredRevision: undone.context?.revision?.id,
+      undoRevision: undone.context?.revision?.id,
       verified: executed.verification.verified,
       undo: { command: executed.undoCommand, verified: undone.verification.verified },
     },

--- a/scripts/run-release-gate-args.ts
+++ b/scripts/run-release-gate-args.ts
@@ -1,21 +1,52 @@
-export function parseReleaseGateOutputDirectory(
+export interface ReleaseGateCliOptions {
+  outputDirectory: string;
+  headedEvidenceDirectory?: string;
+}
+
+export function parseReleaseGateArgs(
   args: string[],
   defaultOutputDirectory: string,
-): string {
+): ReleaseGateCliOptions {
   let outputDirectory: string | undefined;
+  let headedEvidenceDirectory: string | undefined;
 
   for (let index = 0; index < args.length; index += 1) {
     const argument = args[index];
-    const value = argument === "--output-dir"
+    const outputValue = argument === "--output-dir"
       ? args[++index]
       : argument.startsWith("--output-dir=")
         ? argument.slice("--output-dir=".length)
         : undefined;
-    if (value === undefined) throw new Error("USAGE: only --output-dir is supported");
-    if (!value || value.startsWith("--")) throw new Error("USAGE: --output-dir requires a path");
-    if (outputDirectory !== undefined) throw new Error("USAGE: specify --output-dir once");
-    outputDirectory = value;
+    const headedValue = argument === "--headed-evidence-dir"
+      ? args[++index]
+      : argument.startsWith("--headed-evidence-dir=")
+        ? argument.slice("--headed-evidence-dir=".length)
+        : undefined;
+
+    if (outputValue !== undefined) {
+      if (!outputValue || outputValue.startsWith("--")) throw new Error("USAGE: --output-dir requires a path");
+      if (outputDirectory !== undefined) throw new Error("USAGE: specify --output-dir once");
+      outputDirectory = outputValue;
+      continue;
+    }
+    if (headedValue !== undefined) {
+      if (!headedValue || headedValue.startsWith("--")) throw new Error("USAGE: --headed-evidence-dir requires a path");
+      if (headedEvidenceDirectory !== undefined) throw new Error("USAGE: specify --headed-evidence-dir once");
+      headedEvidenceDirectory = headedValue;
+      continue;
+    }
+    throw new Error("USAGE: only --output-dir and --headed-evidence-dir are supported");
   }
 
-  return outputDirectory ?? defaultOutputDirectory;
+  return {
+    outputDirectory: outputDirectory ?? defaultOutputDirectory,
+    ...(headedEvidenceDirectory ? { headedEvidenceDirectory } : {}),
+  };
+}
+
+export function parseReleaseGateOutputDirectory(
+  args: string[],
+  defaultOutputDirectory: string,
+): string {
+  return parseReleaseGateArgs(args, defaultOutputDirectory).outputDirectory;
 }

--- a/scripts/run-release-gate-args.ts
+++ b/scripts/run-release-gate-args.ts
@@ -12,24 +12,22 @@ export function parseReleaseGateArgs(
 
   for (let index = 0; index < args.length; index += 1) {
     const argument = args[index];
-    const outputValue = argument === "--output-dir"
-      ? args[++index]
-      : argument.startsWith("--output-dir=")
-        ? argument.slice("--output-dir=".length)
-        : undefined;
-    const headedValue = argument === "--headed-evidence-dir"
-      ? args[++index]
-      : argument.startsWith("--headed-evidence-dir=")
-        ? argument.slice("--headed-evidence-dir=".length)
-        : undefined;
+    const isOutputOption = argument === "--output-dir" || argument.startsWith("--output-dir=");
+    const isHeadedOption = argument === "--headed-evidence-dir" || argument.startsWith("--headed-evidence-dir=");
+    const outputValue = isOutputOption
+      ? argument === "--output-dir" ? args[++index] : argument.slice("--output-dir=".length)
+      : undefined;
+    const headedValue = isHeadedOption
+      ? argument === "--headed-evidence-dir" ? args[++index] : argument.slice("--headed-evidence-dir=".length)
+      : undefined;
 
-    if (outputValue !== undefined) {
+    if (isOutputOption) {
       if (!outputValue || outputValue.startsWith("--")) throw new Error("USAGE: --output-dir requires a path");
       if (outputDirectory !== undefined) throw new Error("USAGE: specify --output-dir once");
       outputDirectory = outputValue;
       continue;
     }
-    if (headedValue !== undefined) {
+    if (isHeadedOption) {
       if (!headedValue || headedValue.startsWith("--")) throw new Error("USAGE: --headed-evidence-dir requires a path");
       if (headedEvidenceDirectory !== undefined) throw new Error("USAGE: specify --headed-evidence-dir once");
       headedEvidenceDirectory = headedValue;

--- a/scripts/run-release-gate.ts
+++ b/scripts/run-release-gate.ts
@@ -1,12 +1,18 @@
 import { join, resolve } from "node:path";
 import { renderReleaseGateReport, runReleaseGate } from "../tests/release-gate/runner.js";
 import { writeReleaseGateArtifacts } from "../tests/release-gate/artifacts.js";
-import { parseReleaseGateOutputDirectory } from "./run-release-gate-args.js";
+import { runRepositoryChecks } from "../tests/release-gate/repository-checks.js";
+import { parseReleaseGateArgs } from "./run-release-gate-args.js";
 
 const defaultRunId = `${new Date().toISOString().replace(/[^0-9]/g, "")}-${process.pid}`;
 const defaultOutputDirectory = join(process.cwd(), "artifacts", "release-gate", defaultRunId);
-const outputDirectory = parseReleaseGateOutputDirectory(process.argv.slice(2), defaultOutputDirectory);
-const report = await runReleaseGate();
+const options = parseReleaseGateArgs(process.argv.slice(2), defaultOutputDirectory);
+const repositoryChecks = await runRepositoryChecks({ rootDirectory: process.cwd() });
+const report = await runReleaseGate({
+  headedEvidenceDirectory: options.headedEvidenceDirectory,
+  repositoryChecks,
+});
+const outputDirectory = options.outputDirectory;
 const artifacts = await writeReleaseGateArtifacts(report, outputDirectory);
 
 console.log(renderReleaseGateReport(report));
@@ -14,4 +20,4 @@ console.log(`output_directory=${resolve(artifacts.outputDirectory)}`);
 console.log(`report=${resolve(artifacts.reportPath)}`);
 console.log(`manifest=${resolve(artifacts.manifestPath)}`);
 
-if (!report.deterministic.passed) process.exitCode = 1;
+if (!report.deterministic.passed || !report.repositoryChecks.passed) process.exitCode = 1;

--- a/scripts/verify-release-provenance.ts
+++ b/scripts/verify-release-provenance.ts
@@ -1,0 +1,123 @@
+import { createHash } from "node:crypto";
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import { join, resolve } from "node:path";
+import { promisify } from "node:util";
+import {
+  assessReleaseProvenance,
+  type ReleaseProvenanceInput,
+} from "../tests/release-gate/native-editing.js";
+import { FRAMEKIT_VERSION } from "../apps/mcp-server/src/version.js";
+
+const exec = promisify(execFile);
+const repositoryRoot = resolve(new URL("..", import.meta.url).pathname);
+const releaseTag = requireEnvironment("RELEASE_TAG");
+const githubRepository = requireEnvironment("GITHUB_REPOSITORY");
+const outputDirectory = process.env.RELEASE_PROVENANCE_OUTPUT_DIR
+  ?? join(repositoryRoot, "artifacts", "release-provenance");
+
+assertReleaseIdentity(releaseTag, githubRepository);
+
+const packageManifest = JSON.parse(await readFile(join(repositoryRoot, "package.json"), "utf8")) as {
+  name?: string;
+  version?: string;
+  private?: boolean;
+};
+const pluginManifest = JSON.parse(
+  await readFile(join(repositoryRoot, "plugins/framekit/.codex-plugin/plugin.json"), "utf8"),
+) as { name?: string; version?: string };
+const headSha = await command("git", ["rev-parse", "HEAD"]);
+const tagSha = await command("git", ["rev-list", "--verify", "-n", "1", `refs/tags/${releaseTag}^{commit}`]);
+const githubRelease = JSON.parse(await command("gh", [
+  "api",
+  `repos/${githubRepository}/releases/tags/${releaseTag}`,
+])) as { tag_name?: string; draft?: boolean };
+const npmVersion = await command("npm", [
+  "view",
+  "--prefer-online",
+  `${packageManifest.name}@${packageManifest.version}`,
+  "version",
+]);
+
+const temporaryDirectory = await mkdtemp(join(os.tmpdir(), "framekit-release-provenance-"));
+try {
+  const archiveName = `FramekitFinalCutWorkflow-${packageManifest.version}.zip`;
+  const checksumName = `${archiveName}.sha256`;
+  await command("gh", [
+    "release",
+    "download",
+    releaseTag,
+    "--repo",
+    githubRepository,
+    "--pattern",
+    archiveName,
+    "--pattern",
+    checksumName,
+    "--dir",
+    temporaryDirectory,
+  ]);
+  const archiveBytes = await readFile(join(temporaryDirectory, archiveName));
+  const checksumContent = await readFile(join(temporaryDirectory, checksumName), "utf8");
+  const provenanceInput: ReleaseProvenanceInput = {
+    packageManifest,
+    pluginManifest,
+    serverVersion: FRAMEKIT_VERSION,
+    releaseTag,
+    githubRelease: {
+      tagName: githubRelease.tag_name,
+      draft: githubRelease.draft,
+    },
+    workflow: {
+      status: "completed",
+      conclusion: "success",
+      headSha,
+      tagSha,
+    },
+    npmVersion,
+    nativeAssets: [
+      { name: archiveName, sha256: sha256(archiveBytes) },
+      { name: checksumName, sha256: sha256(Buffer.from(checksumContent)), content: checksumContent },
+    ],
+  };
+  const report = assessReleaseProvenance(provenanceInput);
+  await mkdir(outputDirectory, { recursive: true });
+  await writeFile(join(outputDirectory, "provenance.json"), `${JSON.stringify({
+    schemaVersion: 1,
+    gate: "v0.1.6-native-editing",
+    releaseTag,
+    releaseReady: report.releaseReady,
+    checks: report.checks.map(({ name, status, detail }) => ({ name, status, detail })),
+    summary: report.summary,
+  }, null, 2)}\n`, "utf8");
+  console.log(`provenance_ready=${report.releaseReady}`);
+  console.log(`provenance_checks=${report.checks.map((check) => `${check.name}:${check.status}`).join(",")}`);
+  if (!report.releaseReady) process.exitCode = 1;
+} finally {
+  await rm(temporaryDirectory, { recursive: true, force: true });
+}
+
+async function command(file: string, args: string[]): Promise<string> {
+  const { stdout } = await exec(file, args, {
+    cwd: repositoryRoot,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  return stdout.trim();
+}
+
+function sha256(value: Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function requireEnvironment(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`RELEASE_PROVENANCE_ENV_REQUIRED: ${name}`);
+  return value;
+}
+
+function assertReleaseIdentity(tag: string, repository: string): void {
+  if (!/^v\d+\.\d+\.\d+$/.test(tag)) throw new Error("RELEASE_PROVENANCE_INVALID_TAG");
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) {
+    throw new Error("RELEASE_PROVENANCE_INVALID_REPOSITORY");
+  }
+}

--- a/tests/integration/codex-plugin.test.ts
+++ b/tests/integration/codex-plugin.test.ts
@@ -76,8 +76,8 @@ test("CI runs the clean Codex plugin installation smoke test", async () => {
   assert.equal(packageManifest.scripts?.["test:codex-plugin"], "node scripts/codex-plugin-smoke.mjs");
 
   const workflow = await readFile(resolve(repository, ".github/workflows/typescript.yml"), "utf8");
-  assert.match(workflow, /npm install --global @openai\/codex@0\.144\.1/);
   assert.match(workflow, /pnpm run test:codex-plugin/);
+  assert.doesNotMatch(workflow, /npm install --global @openai\/codex/);
 
   const smoke = await readFile(resolve(repository, "scripts/codex-plugin-smoke.mjs"), "utf8");
   assert.match(smoke, /package\.json/);

--- a/tests/integration/native-title-discovery.test.ts
+++ b/tests/integration/native-title-discovery.test.ts
@@ -9,7 +9,7 @@ const recordSeparator = String.fromCharCode(30);
 
 test("headed title evidence records the revision restored by Undo", async () => {
   const runner = await readFile(join(process.cwd(), "scripts/final-cut-title-discovery-headed-e2e.mjs"), "utf8");
-  assert.match(runner, /restoredRevision:\s*undone\.context\?\.revision\?\.id/);
+  assert.match(runner, /undoRevision:\s*undone\.context\?\.revision\?\.id/);
   assert.match(runner, /target:\s*\{\s*sequenceId:\s*preview\.sequenceId/);
 });
 

--- a/tests/integration/native-title-discovery.test.ts
+++ b/tests/integration/native-title-discovery.test.ts
@@ -1,9 +1,16 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { FinalCutNativeAutomationAdapter } from "@framekit/final-cut";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
 
 const fieldSeparator = String.fromCharCode(31);
 const recordSeparator = String.fromCharCode(30);
+
+test("headed title evidence records the revision restored by Undo", async () => {
+  const runner = await readFile(join(process.cwd(), "scripts/final-cut-title-discovery-headed-e2e.mjs"), "utf8");
+  assert.match(runner, /restoredRevision:\s*undone\.context\?\.revision\?\.id/);
+});
 
 function context(frontmost = true): string {
   return [

--- a/tests/integration/native-title-discovery.test.ts
+++ b/tests/integration/native-title-discovery.test.ts
@@ -10,6 +10,7 @@ const recordSeparator = String.fromCharCode(30);
 test("headed title evidence records the revision restored by Undo", async () => {
   const runner = await readFile(join(process.cwd(), "scripts/final-cut-title-discovery-headed-e2e.mjs"), "utf8");
   assert.match(runner, /restoredRevision:\s*undone\.context\?\.revision\?\.id/);
+  assert.match(runner, /target:\s*\{\s*sequenceId:\s*preview\.sequenceId/);
 });
 
 function context(frontmost = true): string {

--- a/tests/integration/picture-in-picture-evidence.test.ts
+++ b/tests/integration/picture-in-picture-evidence.test.ts
@@ -13,6 +13,7 @@ test("headed PIP runner preserves native evidence boundaries", async () => {
   assert.match(runner, /FRAMEKIT_FINAL_CUT_E2E_PIP_QUERY/);
   assert.match(runner, /observed.*position/);
   assert.match(runner, /observed.*frame/);
+  assert.match(runner, /undoRevision:\s*undone\.context\?\.revision\?\.id/);
   assert.doesNotMatch(runner, /masking|cutout|tracking/);
 });
 

--- a/tests/integration/picture-in-picture-evidence.test.ts
+++ b/tests/integration/picture-in-picture-evidence.test.ts
@@ -14,6 +14,7 @@ test("headed PIP runner preserves native evidence boundaries", async () => {
   assert.match(runner, /observed.*position/);
   assert.match(runner, /observed.*frame/);
   assert.match(runner, /undoRevision:\s*undone\.context\?\.revision\?\.id/);
+  assert.match(runner, /target:\s*\{\s*sequenceId:\s*anchorOccurrence\.sequenceId/);
   assert.doesNotMatch(runner, /masking|cutout|tracking/);
 });
 

--- a/tests/integration/release-gate-ci.test.ts
+++ b/tests/integration/release-gate-ci.test.ts
@@ -12,6 +12,7 @@ test("release gate is wired into local and CI validation", async () => {
   assert.match(packageJson.scripts?.test ?? "", /tests\/release-gate\/\*\.test\.ts/);
   assert.equal(packageJson.scripts?.["test:release-gate"], "tsx --test tests/release-gate/*.test.ts");
   assert.equal(packageJson.scripts?.["release-gate"], "tsx scripts/run-release-gate.ts");
+  assert.equal(packageJson.scripts?.["verify-release-provenance"], "tsx scripts/verify-release-provenance.ts");
   assert.match(workflow, /name: Run v0\.1\.6 native-editing release gate/);
   assert.match(runner, /runRepositoryChecks/);
   assert.match(runner, /repositoryChecks/);

--- a/tests/integration/release-gate-ci.test.ts
+++ b/tests/integration/release-gate-ci.test.ts
@@ -7,10 +7,14 @@ test("release gate is wired into local and CI validation", async () => {
     scripts?: Record<string, string>;
   };
   const workflow = await readFile(".github/workflows/typescript.yml", "utf8");
+  const runner = await readFile("scripts/run-release-gate.ts", "utf8");
 
   assert.match(packageJson.scripts?.test ?? "", /tests\/release-gate\/\*\.test\.ts/);
   assert.equal(packageJson.scripts?.["test:release-gate"], "tsx --test tests/release-gate/*.test.ts");
   assert.equal(packageJson.scripts?.["release-gate"], "tsx scripts/run-release-gate.ts");
+  assert.match(workflow, /name: Run v0\.1\.6 native-editing release gate/);
+  assert.match(runner, /runRepositoryChecks/);
+  assert.match(runner, /repositoryChecks/);
   assert.match(workflow, /pnpm run release-gate --output-dir artifacts\/release-gate\/\$\{\{ github\.run_id \}\}/);
   assert.match(workflow, /name: release-gate-\$\{\{ github\.run_id \}\}/);
   assert.match(workflow, /path: artifacts\/release-gate\/\$\{\{ github\.run_id \}\}/);

--- a/tests/integration/release-gate-docs.test.ts
+++ b/tests/integration/release-gate-docs.test.ts
@@ -7,6 +7,15 @@ test("release gate documentation records commands and evidence boundaries", asyn
 
   assert.match(documentation, /pnpm run test:release-gate/);
   assert.match(documentation, /pnpm run release-gate --output-dir/);
+  assert.match(documentation, /--headed-evidence-dir/);
+  assert.match(documentation, /pnpm install --frozen-lockfile/);
+  assert.match(documentation, /check:boundaries/);
+  assert.match(documentation, /mcp evaluation/i);
+  for (const tier of ["deterministic", "FCPXML artifact", "metadata-only", "canonical-live", "headed-native"]) {
+    assert.match(documentation, new RegExp(tier, "i"));
+  }
+  assert.match(documentation, /unrun/i);
+  assert.match(documentation, /provenance/i);
   assert.match(documentation, /deterministic/i);
   assert.match(documentation, /FCPXML/);
   assert.match(documentation, /live Final Cut/i);
@@ -36,15 +45,18 @@ test("Skill documentation describes only the generic MCP workflow", async () => 
   assert.match(documentation, /candidate provenance/);
 });
 
-test("compatibility and release documentation identify the v0.0.3 gate", async () => {
+test("compatibility and release documentation identify the v0.1.6 gate", async () => {
   const compatibility = await readFile("docs/COMPATIBILITY.md", "utf8");
   const release = await readFile("docs/releasing.md", "utf8");
   const readme = await readFile("docs/README.md", "utf8");
 
   assert.match(compatibility, /v0\.0\.3/);
+  assert.match(compatibility, /v0\.1\.6/);
   assert.match(compatibility, /fixture/i);
   assert.match(compatibility, /metadata-only/i);
   assert.match(release, /release gate/i);
   assert.match(release, /pnpm run release-gate --output-dir/);
+  assert.match(release, /v0\.1\.6/);
+  assert.match(release, /checksum/i);
   assert.match(readme, /release-gate/);
 });

--- a/tests/integration/release-workflow.test.ts
+++ b/tests/integration/release-workflow.test.ts
@@ -112,6 +112,7 @@ test("release workflow gates publication on v0.1.6 evidence and native checksums
   assert.notEqual(gate, -1);
   assert.ok(gate < npmPublish, "release gate must run before npm publication");
   assert.notEqual(assetVerification, -1);
+  assert.notEqual(npmVerification, -1);
   assert.ok(npmVerification < assetVerification, "native assets follow npm verification");
   assert.ok(assetVerification < githubRelease, "native assets must precede public release");
   assert.match(workflow, /FramekitFinalCutWorkflow-\$\{expected_version\}\.zip/);

--- a/tests/integration/release-workflow.test.ts
+++ b/tests/integration/release-workflow.test.ts
@@ -101,6 +101,25 @@ test("release workflow validates the package before publishing", async () => {
   assert.match(workflow, /releases\/\$\{release_id\}/);
 });
 
+test("release workflow gates publication on v0.1.6 evidence and native checksums", async () => {
+  const workflow = await readFile(resolve(repository, ".github/workflows/release.yml"), "utf8");
+  const gate = workflow.indexOf("pnpm run release-gate --output-dir");
+  const npmPublish = workflow.indexOf("npm publish --access public");
+  const npmVerification = workflow.indexOf("name: Verify npm publication");
+  const assetVerification = workflow.indexOf("name: Verify native release assets");
+  const githubRelease = workflow.indexOf("name: Publish GitHub release");
+
+  assert.notEqual(gate, -1);
+  assert.ok(gate < npmPublish, "release gate must run before npm publication");
+  assert.notEqual(assetVerification, -1);
+  assert.ok(npmVerification < assetVerification, "native assets follow npm verification");
+  assert.ok(assetVerification < githubRelease, "native assets must precede public release");
+  assert.match(workflow, /FramekitFinalCutWorkflow-\$\{expected_version\}\.zip/);
+  assert.match(workflow, /gh release download "\$\{RELEASE_TAG\}"/);
+  assert.match(workflow, /shasum -a 256 -c/);
+  assert.match(workflow, /pnpm run test:codex-plugin/);
+});
+
 test("release workflow can retry an exact existing tag", async () => {
   const workflow = await readFile(resolve(repository, ".github/workflows/release.yml"), "utf8");
 

--- a/tests/integration/release-workflow.test.ts
+++ b/tests/integration/release-workflow.test.ts
@@ -108,6 +108,7 @@ test("release workflow gates publication on v0.1.6 evidence and native checksums
   const npmVerification = workflow.indexOf("name: Verify npm publication");
   const assetVerification = workflow.indexOf("name: Verify native release assets");
   const githubRelease = workflow.indexOf("name: Publish GitHub release");
+  const finalProvenance = workflow.indexOf("name: Verify complete release provenance");
 
   assert.notEqual(gate, -1);
   assert.ok(gate < npmPublish, "release gate must run before npm publication");
@@ -115,6 +116,7 @@ test("release workflow gates publication on v0.1.6 evidence and native checksums
   assert.notEqual(npmVerification, -1);
   assert.ok(npmVerification < assetVerification, "native assets follow npm verification");
   assert.ok(assetVerification < githubRelease, "native assets must precede public release");
+  assert.ok(githubRelease < finalProvenance, "complete provenance follows public release");
   assert.match(workflow, /FramekitFinalCutWorkflow-\$\{expected_version\}\.zip/);
   assert.match(workflow, /gh release download "\$\{RELEASE_TAG\}"/);
   assert.match(workflow, /shasum -a 256 -c/);
@@ -122,6 +124,7 @@ test("release workflow gates publication on v0.1.6 evidence and native checksums
   assert.match(workflow, /validate-codex-plugin:[\s\S]*?permissions:\s+contents: read[\s\S]*?pnpm install --frozen-lockfile[\s\S]*?pnpm run test:codex-plugin/);
   assert.match(workflow, /publish-npm:[\s\S]*?needs:\s*\n\s+- tagpr\n\s+- validate-codex-plugin/);
   assert.doesNotMatch(workflow, /npm install --global @openai\/codex/);
+  assert.match(workflow, /RELEASE_PROVENANCE_OUTPUT_DIR: artifacts\/release-gate\/\$\{\{ github\.run_id \}\}/);
 });
 
 test("release workflow can retry an exact existing tag", async () => {

--- a/tests/integration/release-workflow.test.ts
+++ b/tests/integration/release-workflow.test.ts
@@ -119,6 +119,9 @@ test("release workflow gates publication on v0.1.6 evidence and native checksums
   assert.match(workflow, /gh release download "\$\{RELEASE_TAG\}"/);
   assert.match(workflow, /shasum -a 256 -c/);
   assert.match(workflow, /pnpm run test:codex-plugin/);
+  assert.match(workflow, /validate-codex-plugin:[\s\S]*?permissions:\s+contents: read[\s\S]*?pnpm install --frozen-lockfile[\s\S]*?pnpm run test:codex-plugin/);
+  assert.match(workflow, /publish-npm:[\s\S]*?needs:\s*\n\s+- tagpr\n\s+- validate-codex-plugin/);
+  assert.doesNotMatch(workflow, /npm install --global @openai\/codex/);
 });
 
 test("release workflow can retry an exact existing tag", async () => {

--- a/tests/release-gate/artifacts.test.ts
+++ b/tests/release-gate/artifacts.test.ts
@@ -49,6 +49,6 @@ test("release gate artifacts retain the report and an auditable manifest", async
   assert.equal(manifest.repositoryChecks.passed, report.repositoryChecks.passed);
   assert.deepEqual(manifest.repositoryChecks.checks.map((check) => check.status), report.repositoryChecks.checks.map((check) => check.status));
   assert.deepEqual(JSON.parse(await readFile(paths.reportPath, "utf8")), report);
-  assert.doesNotMatch(await readFile(paths.reportPath, "utf8"), /\/private\/|operationId|sourceIdentity/);
+  assert.doesNotMatch(await readFile(paths.reportPath, "utf8"), /\/private\/|\/Users\/|\/home\/|operationId|sourceIdentity/);
   await assert.rejects(writeReleaseGateArtifacts(report, outputDirectory), /RELEASE_GATE_ARTIFACT_EXISTS/);
 });

--- a/tests/release-gate/artifacts.test.ts
+++ b/tests/release-gate/artifacts.test.ts
@@ -23,6 +23,7 @@ test("release gate artifacts retain the report and an auditable manifest", async
     evidenceTiers: Record<string, { status: string; attempted: boolean; passed: boolean }>;
     workflowMatrix: Array<{ workflowId: string }>;
     provenance: { releaseReady: boolean; checks: Array<{ name: string; status: string }> };
+    repositoryChecks: { passed: boolean; checks: Array<{ name: string; status: string }> };
   };
 
   assert.equal(manifest.schemaVersion, 2);
@@ -45,6 +46,8 @@ test("release gate artifacts retain the report and an auditable manifest", async
   assert.deepEqual(manifest.workflowMatrix.map((workflow) => workflow.workflowId), report.workflowMatrix.map((workflow) => workflow.workflowId));
   assert.equal(manifest.provenance.releaseReady, report.provenance.releaseReady);
   assert.deepEqual(manifest.provenance.checks.map((check) => check.name), report.provenance.checks.map((check) => check.name));
+  assert.equal(manifest.repositoryChecks.passed, report.repositoryChecks.passed);
+  assert.deepEqual(manifest.repositoryChecks.checks.map((check) => check.status), report.repositoryChecks.checks.map((check) => check.status));
   assert.deepEqual(JSON.parse(await readFile(paths.reportPath, "utf8")), report);
   assert.doesNotMatch(await readFile(paths.reportPath, "utf8"), /\/private\/|operationId|sourceIdentity/);
   await assert.rejects(writeReleaseGateArtifacts(report, outputDirectory), /RELEASE_GATE_ARTIFACT_EXISTS/);

--- a/tests/release-gate/artifacts.test.ts
+++ b/tests/release-gate/artifacts.test.ts
@@ -15,16 +15,37 @@ test("release gate artifacts retain the report and an auditable manifest", async
   const manifest = JSON.parse(await readFile(paths.manifestPath, "utf8")) as {
     schemaVersion: number;
     gate: string;
+    manifestVersion: string;
+    releaseVersion: string;
     reportFile: string;
     reportSha256: string;
     workflowCount: number;
+    evidenceTiers: Record<string, { status: string; attempted: boolean; passed: boolean }>;
+    workflowMatrix: Array<{ workflowId: string }>;
+    provenance: { releaseReady: boolean; checks: Array<{ name: string; status: string }> };
   };
 
-  assert.equal(manifest.schemaVersion, 1);
+  assert.equal(manifest.schemaVersion, 2);
   assert.equal(manifest.gate, report.gate);
+  assert.equal(manifest.manifestVersion, report.manifestVersion);
+  assert.equal(manifest.releaseVersion, report.releaseVersion);
   assert.equal(manifest.reportFile, "report.json");
   assert.equal(manifest.workflowCount, report.deterministic.workflows.length);
   assert.match(manifest.reportSha256, /^[a-f0-9]{64}$/);
+  assert.deepEqual(Object.keys(manifest.evidenceTiers), [
+    "deterministic",
+    "fcpxml-artifact",
+    "metadata-only",
+    "canonical-live",
+    "headed-native",
+  ]);
+  assert.equal(manifest.evidenceTiers.deterministic.status, "verified");
+  assert.equal(manifest.evidenceTiers["canonical-live"].status, "unsupported");
+  assert.equal(manifest.evidenceTiers["headed-native"].status, "unrun");
+  assert.deepEqual(manifest.workflowMatrix.map((workflow) => workflow.workflowId), report.workflowMatrix.map((workflow) => workflow.workflowId));
+  assert.equal(manifest.provenance.releaseReady, report.provenance.releaseReady);
+  assert.deepEqual(manifest.provenance.checks.map((check) => check.name), report.provenance.checks.map((check) => check.name));
   assert.deepEqual(JSON.parse(await readFile(paths.reportPath, "utf8")), report);
+  assert.doesNotMatch(await readFile(paths.reportPath, "utf8"), /\/private\/|operationId|sourceIdentity/);
   await assert.rejects(writeReleaseGateArtifacts(report, outputDirectory), /RELEASE_GATE_ARTIFACT_EXISTS/);
 });

--- a/tests/release-gate/artifacts.ts
+++ b/tests/release-gate/artifacts.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import type { ReleaseGateReport } from "./runner.js";
+import type { ReleaseGateEvidenceTiers, ReleaseGateReport } from "./runner.js";
 
 export interface ReleaseGateArtifactPaths {
   outputDirectory: string;
@@ -10,8 +10,10 @@ export interface ReleaseGateArtifactPaths {
 }
 
 export interface ReleaseGateArtifactManifest {
-  schemaVersion: 1;
+  schemaVersion: 2;
   gate: ReleaseGateReport["gate"];
+  manifestVersion: string;
+  releaseVersion: ReleaseGateReport["releaseVersion"];
   corpusVersion: string;
   generatedAt: string;
   reportFile: "report.json";
@@ -19,6 +21,23 @@ export interface ReleaseGateArtifactManifest {
   workflowCount: number;
   deterministicPassed: boolean;
   liveStatus: ReleaseGateReport["live"]["status"];
+  evidenceTiers: {
+    [K in keyof ReleaseGateEvidenceTiers]: {
+      status: ReleaseGateEvidenceTiers[K]["status"];
+      attempted: boolean;
+      passed: boolean;
+      mode: ReleaseGateEvidenceTiers[K]["mode"];
+      backend: string;
+      guarantee: string;
+      workflowCount: number;
+    };
+  };
+  workflowMatrix: ReleaseGateReport["workflowMatrix"];
+  provenance: {
+    releaseReady: boolean;
+    checks: Array<{ name: string; status: string }>;
+    summary: string;
+  };
 }
 
 export async function writeReleaseGateArtifacts(
@@ -39,8 +58,10 @@ export async function writeReleaseGateArtifacts(
   const manifestPath = join(outputDirectory, "manifest.json");
   const reportBody = `${JSON.stringify(report, null, 2)}\n`;
   const manifest: ReleaseGateArtifactManifest = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     gate: report.gate,
+    manifestVersion: report.manifestVersion,
+    releaseVersion: report.releaseVersion,
     corpusVersion: report.corpusVersion,
     generatedAt: report.generatedAt,
     reportFile: "report.json",
@@ -48,6 +69,23 @@ export async function writeReleaseGateArtifacts(
     workflowCount: report.deterministic.workflows.length,
     deterministicPassed: report.deterministic.passed,
     liveStatus: report.live.status,
+    evidenceTiers: Object.fromEntries(
+      Object.entries(report.evidenceTiers).map(([tier, evidence]) => [tier, {
+        status: evidence.status,
+        attempted: evidence.attempted,
+        passed: evidence.passed,
+        mode: evidence.mode,
+        backend: evidence.backend,
+        guarantee: evidence.guarantee,
+        workflowCount: evidence.workflows.length,
+      }]),
+    ) as ReleaseGateArtifactManifest["evidenceTiers"],
+    workflowMatrix: report.workflowMatrix,
+    provenance: {
+      releaseReady: report.provenance.releaseReady,
+      checks: report.provenance.checks.map(({ name, status }) => ({ name, status })),
+      summary: report.provenance.summary,
+    },
   };
 
   await writeFile(reportPath, reportBody, { encoding: "utf8", flag: "wx" });

--- a/tests/release-gate/artifacts.ts
+++ b/tests/release-gate/artifacts.ts
@@ -38,6 +38,10 @@ export interface ReleaseGateArtifactManifest {
     checks: Array<{ name: string; status: string }>;
     summary: string;
   };
+  repositoryChecks: {
+    passed: boolean;
+    checks: Array<{ name: string; status: string }>;
+  };
 }
 
 export async function writeReleaseGateArtifacts(
@@ -85,6 +89,10 @@ export async function writeReleaseGateArtifacts(
       releaseReady: report.provenance.releaseReady,
       checks: report.provenance.checks.map(({ name, status }) => ({ name, status })),
       summary: report.provenance.summary,
+    },
+    repositoryChecks: {
+      passed: report.repositoryChecks.passed,
+      checks: report.repositoryChecks.checks.map(({ name, status }) => ({ name, status })),
     },
   };
 

--- a/tests/release-gate/cli.test.ts
+++ b/tests/release-gate/cli.test.ts
@@ -18,4 +18,12 @@ test("release gate CLI rejects duplicate or unknown options", () => {
     () => parseReleaseGateArgs(["--unknown"], "default"),
     /only --output-dir and --headed-evidence-dir are supported/,
   );
+  assert.throws(
+    () => parseReleaseGateArgs(["--output-dir"], "default"),
+    /--output-dir requires a path/,
+  );
+  assert.throws(
+    () => parseReleaseGateArgs(["--headed-evidence-dir"], "default"),
+    /--headed-evidence-dir requires a path/,
+  );
 });

--- a/tests/release-gate/cli.test.ts
+++ b/tests/release-gate/cli.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseReleaseGateArgs } from "../../scripts/run-release-gate-args.js";
+
+test("release gate CLI accepts an opt-in headed evidence directory", () => {
+  assert.deepEqual(
+    parseReleaseGateArgs(["--output-dir", "artifacts/run", "--headed-evidence-dir=headed"], "default"),
+    { outputDirectory: "artifacts/run", headedEvidenceDirectory: "headed" },
+  );
+});
+
+test("release gate CLI rejects duplicate or unknown options", () => {
+  assert.throws(
+    () => parseReleaseGateArgs(["--headed-evidence-dir", "one", "--headed-evidence-dir", "two"], "default"),
+    /specify --headed-evidence-dir once/,
+  );
+  assert.throws(
+    () => parseReleaseGateArgs(["--unknown"], "default"),
+    /only --output-dir and --headed-evidence-dir are supported/,
+  );
+});

--- a/tests/release-gate/corpus.json
+++ b/tests/release-gate/corpus.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "corpusVersion": "2026-08-30",
-  "runtimeContract": "v0.0.3",
+  "corpusVersion": "2026-09-11",
+  "runtimeContract": "v0.1.6",
   "workflows": [
     { "id": "filler.obvious", "family": "filler-removal", "scenario": "obvious", "expectedOutcome": "verified", "fixture": { "kind": "filler", "case": "obvious" } },
     { "id": "filler.low-confidence", "family": "filler-removal", "scenario": "low-confidence", "expectedOutcome": "verified", "fixture": { "kind": "filler", "case": "low-confidence" } },

--- a/tests/release-gate/manifest.json
+++ b/tests/release-gate/manifest.json
@@ -56,7 +56,7 @@
       "id": "dialogue-normalization",
       "operation": "dialogue-normalization",
       "capability": "canonicalDocument.write + analyzers.audioLoudness",
-      "evidenceTiers": ["deterministic", "fcpxml-artifact", "canonical-live", "headed-native"],
+      "evidenceTiers": ["deterministic", "fcpxml-artifact", "canonical-live"],
       "evidenceTypes": []
     }
   ]

--- a/tests/release-gate/manifest.json
+++ b/tests/release-gate/manifest.json
@@ -1,0 +1,63 @@
+{
+  "schemaVersion": 1,
+  "manifestVersion": "2026-09-11",
+  "gate": "v0.1.6-native-editing",
+  "releaseVersion": "0.1.6",
+  "runtimeContract": "v0.1.6",
+  "evidenceTiers": [
+    { "id": "deterministic", "mode": "headless", "guarantee": "verified", "required": true },
+    { "id": "fcpxml-artifact", "mode": "headless", "guarantee": "artifact-write", "required": false },
+    { "id": "metadata-only", "mode": "headless", "guarantee": "observed", "required": false },
+    { "id": "canonical-live", "mode": "headless", "guarantee": "canonical-write", "required": false },
+    { "id": "headed-native", "mode": "headed", "guarantee": "native-verified", "required": false }
+  ],
+  "workflows": [
+    {
+      "id": "canonical-live",
+      "operation": "editor.timeline.edit",
+      "capability": "canonicalDocument.write",
+      "evidenceTiers": ["canonical-live", "headed-native"],
+      "headedRunner": "scripts/final-cut-canonical-headed-e2e.mjs",
+      "evidenceTypes": ["headed-native-canonical-mutation"]
+    },
+    {
+      "id": "picture-in-picture",
+      "operation": "timeline.picture-in-picture.add",
+      "capability": "editing.pictureInPicture",
+      "evidenceTiers": ["deterministic", "fcpxml-artifact", "headed-native"],
+      "headedRunner": "scripts/final-cut-picture-in-picture-headed-e2e.mjs",
+      "evidenceTypes": ["headed-native-picture-in-picture"]
+    },
+    {
+      "id": "built-in-title-discovery",
+      "operation": "editor.assets + editor.native.title.add",
+      "capability": "native.titleDiscovery",
+      "evidenceTiers": ["deterministic", "headed-native"],
+      "headedRunner": "scripts/final-cut-title-discovery-headed-e2e.mjs",
+      "evidenceTypes": ["headed-native-title-discovery-and-placement"]
+    },
+    {
+      "id": "masking",
+      "operation": "timeline.mask.add",
+      "capability": "editing.masking",
+      "evidenceTiers": ["deterministic", "headed-native"],
+      "headedRunner": "scripts/final-cut-masking-headed-e2e.mjs",
+      "evidenceTypes": ["headed-native-mask-placement"]
+    },
+    {
+      "id": "filler-removal",
+      "operation": "filler-removal",
+      "capability": "canonicalDocument.write + analyzers.speechTranscribe",
+      "evidenceTiers": ["deterministic", "canonical-live", "headed-native"],
+      "headedRunner": "scripts/final-cut-filler-removal-headed-e2e.mjs",
+      "evidenceTypes": ["headed-native-filler-removal"]
+    },
+    {
+      "id": "dialogue-normalization",
+      "operation": "dialogue-normalization",
+      "capability": "canonicalDocument.write + analyzers.audioLoudness",
+      "evidenceTiers": ["deterministic", "fcpxml-artifact", "canonical-live", "headed-native"],
+      "evidenceTypes": []
+    }
+  ]
+}

--- a/tests/release-gate/native-editing.test.ts
+++ b/tests/release-gate/native-editing.test.ts
@@ -81,6 +81,32 @@ test("headed evidence is reduced to a target, revision, verification, and restor
   assert.doesNotMatch(JSON.stringify(summary), /private-occurrence|sourceIdentity|operationId|diagnostic/i);
 });
 
+test("headed evidence omits path-like target identities", () => {
+  const workflow = loadNativeEditingManifest().workflows.find((candidate) => candidate.id === "picture-in-picture");
+  assert.ok(workflow);
+
+  const summary = summarizeHeadedEvidence({
+    evidenceType: "headed-native-picture-in-picture",
+    passed: true,
+    environment: { framekitVersion: "0.1.6", finalCutVersion: "10.7.1", gitCommit: "a".repeat(40) },
+    project: "/Users/example/Disposable PIP.fcpbundle",
+    target: {
+      sequenceId: "/home/example/sequence",
+      occurrenceId: "C:\\Users\\example\\clip",
+      occurrenceName: "Guest",
+    },
+    placement: {
+      beforeRevision: "rev-1",
+      afterRevision: "rev-2",
+      undoRevision: "rev-3",
+      observed: { position: { x: 320, y: -180 }, scale: 0.35 },
+      undoVerified: { verified: true },
+    },
+  }, workflow);
+
+  assert.deepEqual(summary.target, { occurrenceName: "Guest" });
+});
+
 test("headed evidence requires a verified rollback for mutating workflows", () => {
   const workflow = loadNativeEditingManifest().workflows.find((candidate) => candidate.id === "masking");
   assert.ok(workflow);

--- a/tests/release-gate/native-editing.test.ts
+++ b/tests/release-gate/native-editing.test.ts
@@ -165,6 +165,19 @@ test("missing external release state is unrun and cannot be release success", ()
   assert.doesNotMatch(report.summary, /release ready/i);
 });
 
+test("release gate keeps repository-owned provenance values authoritative", async () => {
+  const report = await runReleaseGate({
+    provenance: {
+      packageManifest: { version: "9.9.9" },
+      pluginManifest: { version: "9.9.9" },
+      serverVersion: "9.9.9",
+    } as never,
+  });
+
+  assert.match(report.provenance.checks.find((check) => check.name === "package-plugin-versions")?.detail ?? "", /0\.1\.5/);
+  assert.match(report.provenance.checks.find((check) => check.name === "mcp-server-version")?.detail ?? "", /0\.1\.5/);
+});
+
 test("release gate reports each v0.1.6 evidence tier independently", async () => {
   const report = await runReleaseGate({ generatedAt: "2026-09-11T00:00:00.000Z" });
 

--- a/tests/release-gate/native-editing.test.ts
+++ b/tests/release-gate/native-editing.test.ts
@@ -107,12 +107,35 @@ test("release provenance verifies aligned versions, tag, workflow, npm, and chec
     npmVersion: "0.1.6",
     nativeAssets: [
       { name: "FramekitFinalCutWorkflow-0.1.6.zip", sha256: "d".repeat(64) },
-      { name: "FramekitFinalCutWorkflow-0.1.6.zip.sha256", sha256: "e".repeat(64) },
+      {
+        name: "FramekitFinalCutWorkflow-0.1.6.zip.sha256",
+        sha256: "e".repeat(64),
+        content: `${"d".repeat(64)}  FramekitFinalCutWorkflow-0.1.6.zip\n`,
+      },
     ],
   });
 
   assert.equal(report.releaseReady, true);
   assert.ok(report.checks.every((check) => check.status === "verified"));
+});
+
+test("release provenance rejects a checksum file for a different archive", () => {
+  const report = assessReleaseProvenance({
+    packageManifest: { version: "0.1.6" },
+    pluginManifest: { version: "0.1.6" },
+    serverVersion: "0.1.6",
+    nativeAssets: [
+      { name: "FramekitFinalCutWorkflow-0.1.6.zip", sha256: "d".repeat(64) },
+      {
+        name: "FramekitFinalCutWorkflow-0.1.6.zip.sha256",
+        sha256: "e".repeat(64),
+        content: `${"f".repeat(64)}  FramekitFinalCutWorkflow-0.1.6.zip\n`,
+      },
+    ],
+  });
+
+  assert.equal(report.checks.find((check) => check.name === "native-assets")?.status, "failed");
+  assert.match(report.checks.find((check) => check.name === "native-assets")?.detail ?? "", /checksum/i);
 });
 
 test("missing external release state is unrun and cannot be release success", () => {

--- a/tests/release-gate/native-editing.test.ts
+++ b/tests/release-gate/native-editing.test.ts
@@ -5,6 +5,7 @@ import {
   loadNativeEditingManifest,
   summarizeHeadedEvidence,
 } from "./native-editing.js";
+import { runReleaseGate } from "./runner.js";
 
 test("v0.1.6 manifest names every evidence tier and workflow", () => {
   const manifest = loadNativeEditingManifest();
@@ -125,4 +126,30 @@ test("missing external release state is unrun and cannot be release success", ()
   assert.ok(report.checks.some((check) => check.name === "github-release" && check.status === "unrun"));
   assert.ok(report.checks.some((check) => check.name === "native-assets" && check.status === "unrun"));
   assert.doesNotMatch(report.summary, /release ready/i);
+});
+
+test("release gate reports each v0.1.6 evidence tier independently", async () => {
+  const report = await runReleaseGate({ generatedAt: "2026-09-11T00:00:00.000Z" });
+
+  assert.equal(report.gate, "v0.1.6-native-editing");
+  assert.equal(report.manifestVersion, "2026-09-11");
+  assert.equal(report.deterministic.passed, true);
+  assert.equal(report.evidenceTiers.deterministic.status, "verified");
+  assert.equal(report.evidenceTiers["fcpxml-artifact"].status, "verified");
+  assert.equal(report.evidenceTiers["metadata-only"].status, "verified");
+  assert.equal(report.evidenceTiers["canonical-live"].status, "unsupported");
+  assert.equal(report.evidenceTiers["headed-native"].status, "unrun");
+  assert.deepEqual(
+    report.workflowMatrix.map((workflow) => workflow.workflowId),
+    [
+      "canonical-live",
+      "picture-in-picture",
+      "built-in-title-discovery",
+      "masking",
+      "filler-removal",
+      "dialogue-normalization",
+    ],
+  );
+  assert.ok(report.evidenceTiers["metadata-only"].preflight.unavailableReason);
+  assert.doesNotMatch(JSON.stringify(report), /operationId|sourceIdentity|\/private\/media/i);
 });

--- a/tests/release-gate/native-editing.test.ts
+++ b/tests/release-gate/native-editing.test.ts
@@ -35,6 +35,10 @@ test("v0.1.6 manifest names every evidence tier and workflow", () => {
     manifest.workflows.find((workflow) => workflow.id === "picture-in-picture")?.headedRunner,
     "scripts/final-cut-picture-in-picture-headed-e2e.mjs",
   );
+  const dialogue = manifest.workflows.find((workflow) => workflow.id === "dialogue-normalization");
+  assert.deepEqual(dialogue?.evidenceTiers, ["deterministic", "fcpxml-artifact", "canonical-live"]);
+  assert.deepEqual(dialogue?.evidenceTypes, []);
+  assert.equal(dialogue?.headedRunner, undefined);
 });
 
 test("headed evidence is reduced to a target, revision, verification, and restoration summary", () => {

--- a/tests/release-gate/native-editing.test.ts
+++ b/tests/release-gate/native-editing.test.ts
@@ -106,7 +106,7 @@ test("release provenance verifies aligned versions, tag, workflow, npm, and chec
     serverVersion: "0.1.6",
     releaseTag: "v0.1.6",
     githubRelease: { tagName: "v0.1.6", draft: false },
-    workflow: { status: "completed", conclusion: "success", headSha: "c".repeat(40) },
+    workflow: { status: "completed", conclusion: "success", headSha: "c".repeat(40), tagSha: "c".repeat(40) },
     npmVersion: "0.1.6",
     nativeAssets: [
       { name: "FramekitFinalCutWorkflow-0.1.6.zip", sha256: "d".repeat(64) },
@@ -120,6 +120,17 @@ test("release provenance verifies aligned versions, tag, workflow, npm, and chec
 
   assert.equal(report.releaseReady, true);
   assert.ok(report.checks.every((check) => check.status === "verified"));
+});
+
+test("release provenance rejects workflow evidence without a tag commit", () => {
+  const report = assessReleaseProvenance({
+    packageManifest: { version: "0.1.6" },
+    pluginManifest: { version: "0.1.6" },
+    serverVersion: "0.1.6",
+    workflow: { status: "completed", conclusion: "success", headSha: "c".repeat(40) },
+  });
+
+  assert.equal(report.checks.find((check) => check.name === "release-workflow")?.status, "failed");
 });
 
 test("release provenance rejects a checksum file for a different archive", () => {

--- a/tests/release-gate/native-editing.test.ts
+++ b/tests/release-gate/native-editing.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  assessReleaseProvenance,
+  loadNativeEditingManifest,
+  summarizeHeadedEvidence,
+} from "./native-editing.js";
+
+test("v0.1.6 manifest names every evidence tier and workflow", () => {
+  const manifest = loadNativeEditingManifest();
+
+  assert.equal(manifest.schemaVersion, 1);
+  assert.equal(manifest.gate, "v0.1.6-native-editing");
+  assert.equal(manifest.releaseVersion, "0.1.6");
+  assert.deepEqual(
+    manifest.evidenceTiers.map((tier) => tier.id),
+    ["deterministic", "fcpxml-artifact", "metadata-only", "canonical-live", "headed-native"],
+  );
+  assert.deepEqual(
+    manifest.workflows.map((workflow) => workflow.id),
+    [
+      "canonical-live",
+      "picture-in-picture",
+      "built-in-title-discovery",
+      "masking",
+      "filler-removal",
+      "dialogue-normalization",
+    ],
+  );
+  assert.equal(
+    manifest.workflows.find((workflow) => workflow.id === "picture-in-picture")?.headedRunner,
+    "scripts/final-cut-picture-in-picture-headed-e2e.mjs",
+  );
+});
+
+test("headed evidence is reduced to a target, revision, verification, and restoration summary", () => {
+  const workflow = loadNativeEditingManifest().workflows.find((candidate) => candidate.id === "picture-in-picture");
+  assert.ok(workflow);
+
+  const summary = summarizeHeadedEvidence({
+    schemaVersion: 1,
+    evidenceType: "headed-native-picture-in-picture",
+    passed: true,
+    recordedAt: "2026-09-11T00:00:00.000Z",
+    environment: {
+      framekitVersion: "0.1.6",
+      finalCutVersion: "10.7.1",
+      gitCommit: "a".repeat(40),
+      nodeVersion: "v22.14.0",
+      platform: "darwin",
+      architecture: "arm64",
+      osVersion: "Darwin",
+    },
+    editor: { name: "Final Cut Pro", version: "10.7.1", backend: "final-cut-live" },
+    capabilities: { nativePictureInPicture: true, nativeUndo: true },
+    placement: {
+      project: "Disposable PIP",
+      anchorOccurrence: { handle: "private-occurrence-handle", start: "0/1", duration: "10/1" },
+      pipMedia: { name: "Guest", sourceIdentity: "/private/media/guest.mov" },
+      beforeRevision: "rev-1",
+      afterRevision: "rev-2",
+      undoRevision: "rev-3",
+      operationId: "private-operation-id",
+      undoOperationId: "private-undo-id",
+      undoVerified: { verified: true },
+      observed: { position: { x: 320, y: -180 }, scale: 0.35 },
+    },
+  }, workflow);
+
+  assert.equal(summary.workflowId, "picture-in-picture");
+  assert.equal(summary.evidenceType, "headed-native-picture-in-picture");
+  assert.equal(summary.status, "verified");
+  assert.deepEqual(summary.target, { project: "Disposable PIP" });
+  assert.deepEqual(summary.revision, { before: "rev-1", after: "rev-2", restored: "rev-3" });
+  assert.deepEqual(summary.verification, { execute: true, undo: true });
+  assert.equal(summary.environment.gitCommit, "a".repeat(40));
+  assert.doesNotMatch(JSON.stringify(summary), /private-occurrence|sourceIdentity|operationId|diagnostic/i);
+});
+
+test("headed evidence requires a verified rollback for mutating workflows", () => {
+  const workflow = loadNativeEditingManifest().workflows.find((candidate) => candidate.id === "masking");
+  assert.ok(workflow);
+
+  assert.throws(
+    () => summarizeHeadedEvidence({
+      evidenceType: "headed-native-mask-placement",
+      passed: true,
+      environment: { framekitVersion: "0.1.6", finalCutVersion: "10.7.1", gitCommit: "b".repeat(40) },
+      project: "Disposable Mask",
+      target: { occurrenceId: "clip-1" },
+      revisions: { before: "rev-1", after: "rev-2", restored: "rev-3" },
+      verification: { execute: { verified: true } },
+    }, workflow),
+    /rollback|undo/i,
+  );
+});
+
+test("release provenance verifies aligned versions, tag, workflow, npm, and checksums", () => {
+  const report = assessReleaseProvenance({
+    packageManifest: { name: "@morshoto/framekit", version: "0.1.6", private: false },
+    pluginManifest: { name: "framekit", version: "0.1.6" },
+    serverVersion: "0.1.6",
+    releaseTag: "v0.1.6",
+    githubRelease: { tagName: "v0.1.6", draft: false },
+    workflow: { status: "completed", conclusion: "success", headSha: "c".repeat(40) },
+    npmVersion: "0.1.6",
+    nativeAssets: [
+      { name: "FramekitFinalCutWorkflow-0.1.6.zip", sha256: "d".repeat(64) },
+      { name: "FramekitFinalCutWorkflow-0.1.6.zip.sha256", sha256: "e".repeat(64) },
+    ],
+  });
+
+  assert.equal(report.releaseReady, true);
+  assert.ok(report.checks.every((check) => check.status === "verified"));
+});
+
+test("missing external release state is unrun and cannot be release success", () => {
+  const report = assessReleaseProvenance({
+    packageManifest: { name: "@morshoto/framekit", version: "0.1.5", private: false },
+    pluginManifest: { name: "framekit", version: "0.1.5" },
+    serverVersion: "0.1.5",
+  });
+
+  assert.equal(report.releaseReady, false);
+  assert.ok(report.checks.some((check) => check.name === "github-release" && check.status === "unrun"));
+  assert.ok(report.checks.some((check) => check.name === "native-assets" && check.status === "unrun"));
+  assert.doesNotMatch(report.summary, /release ready/i);
+});

--- a/tests/release-gate/native-editing.test.ts
+++ b/tests/release-gate/native-editing.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 import {
   assessReleaseProvenance,
@@ -175,4 +178,32 @@ test("release gate reports each v0.1.6 evidence tier independently", async () =>
   );
   assert.ok(report.evidenceTiers["metadata-only"].preflight.unavailableReason);
   assert.doesNotMatch(JSON.stringify(report), /operationId|sourceIdentity|\/private\/media/i);
+});
+
+test("partial headed evidence cannot promote the headed tier", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "framekit-headed-evidence-"));
+  try {
+    await writeFile(join(directory, "pip.json"), JSON.stringify({
+      evidenceType: "headed-native-picture-in-picture",
+      passed: true,
+      environment: { framekitVersion: "0.1.6", finalCutVersion: "10.7.1", gitCommit: "a".repeat(40) },
+      placement: {
+        project: "Disposable PIP",
+        beforeRevision: "rev-1",
+        afterRevision: "rev-2",
+        undoRevision: "rev-3",
+        observed: { position: { x: 320, y: -180 }, scale: 0.35 },
+        undoVerified: { verified: true },
+      },
+    }), "utf8");
+
+    const report = await runReleaseGate({ headedEvidenceDirectory: directory });
+
+    assert.equal(report.evidenceTiers["headed-native"].status, "failed");
+    assert.equal(report.evidenceTiers["headed-native"].passed, false);
+    assert.equal(report.evidenceTiers["headed-native"].workflows.find((workflow) => workflow.workflowId === "picture-in-picture")?.status, "verified");
+    assert.equal(report.evidenceTiers["headed-native"].workflows.find((workflow) => workflow.workflowId === "masking")?.status, "unrun");
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
 });

--- a/tests/release-gate/native-editing.ts
+++ b/tests/release-gate/native-editing.ts
@@ -192,7 +192,11 @@ export function assessReleaseProvenance(input: ReleaseProvenanceInput): ReleaseP
 
   if (input.workflow) {
     const successful = input.workflow.status === "completed" && input.workflow.conclusion === "success";
-    const tagMatches = !input.workflow.tagSha || input.workflow.tagSha === input.workflow.headSha;
+    const tagMatches = Boolean(
+      input.workflow.headSha
+      && input.workflow.tagSha
+      && input.workflow.tagSha === input.workflow.headSha,
+    );
     checks.push(successful && tagMatches
       ? verified("release-workflow", "release workflow completed successfully")
       : failed("release-workflow", "release workflow is incomplete, failed, or points at a different commit"));

--- a/tests/release-gate/native-editing.ts
+++ b/tests/release-gate/native-editing.ts
@@ -56,6 +56,7 @@ export interface HeadedEvidenceSummary {
     projectId?: string;
     sequenceId?: string;
     occurrenceId?: string;
+    occurrenceName?: string;
   };
   revision: { before: string; after: string; restored: string };
   verification: { execute: true; undo: true };
@@ -249,11 +250,13 @@ function extractTarget(raw: Record<string, any>): HeadedEvidenceSummary["target"
   const projectId = typeof project === "object" ? project?.id : undefined;
   const sequenceId = typeof project === "object" ? project?.sequenceId : target?.sequenceId;
   const occurrenceId = target?.occurrenceId;
+  const occurrenceName = target?.occurrenceName ?? target?.name;
   return {
     ...(typeof projectValue === "string" ? { project: projectValue } : {}),
     ...(typeof projectId === "string" ? { projectId } : {}),
     ...(typeof sequenceId === "string" ? { sequenceId } : {}),
     ...(typeof occurrenceId === "string" ? { occurrenceId } : {}),
+    ...(typeof occurrenceName === "string" ? { occurrenceName } : {}),
   };
 }
 

--- a/tests/release-gate/native-editing.ts
+++ b/tests/release-gate/native-editing.ts
@@ -1,0 +1,314 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const manifestPath = fileURLToPath(new URL("./manifest.json", import.meta.url));
+const expectedTierIds = ["deterministic", "fcpxml-artifact", "metadata-only", "canonical-live", "headed-native"] as const;
+const expectedWorkflowIds = [
+  "canonical-live",
+  "picture-in-picture",
+  "built-in-title-discovery",
+  "masking",
+  "filler-removal",
+  "dialogue-normalization",
+] as const;
+
+export type NativeEditingEvidenceTier = (typeof expectedTierIds)[number];
+export type EvidenceStatus = "verified" | "failed" | "unsupported" | "unrun";
+export type EvidenceMode = "headless" | "headed";
+
+export interface NativeEditingManifest {
+  schemaVersion: 1;
+  manifestVersion: string;
+  gate: "v0.1.6-native-editing";
+  releaseVersion: "0.1.6";
+  runtimeContract: "v0.1.6";
+  evidenceTiers: Array<{
+    id: NativeEditingEvidenceTier;
+    mode: EvidenceMode;
+    guarantee: string;
+    required: boolean;
+  }>;
+  workflows: Array<{
+    id: (typeof expectedWorkflowIds)[number];
+    operation: string;
+    capability: string;
+    evidenceTiers: NativeEditingEvidenceTier[];
+    headedRunner?: string;
+    evidenceTypes: string[];
+  }>;
+}
+
+export interface HeadedEvidenceSummary {
+  schemaVersion: 1;
+  workflowId: string;
+  evidenceType: string;
+  status: "verified";
+  recordedAt?: string;
+  environment: {
+    framekitVersion: string;
+    finalCutVersion: string;
+    gitCommit: string;
+  };
+  editor?: { name: string; version: string; backend: string };
+  target: {
+    project?: string;
+    projectId?: string;
+    sequenceId?: string;
+    occurrenceId?: string;
+  };
+  revision: { before: string; after: string; restored: string };
+  verification: { execute: true; undo: true };
+}
+
+export interface ReleaseProvenanceInput {
+  packageManifest: { name?: string; version?: string; private?: boolean };
+  pluginManifest: { name?: string; version?: string };
+  serverVersion?: string;
+  releaseTag?: string;
+  githubRelease?: { tagName?: string; draft?: boolean };
+  workflow?: { status?: string; conclusion?: string; headSha?: string; tagSha?: string };
+  npmVersion?: string;
+  nativeAssets?: Array<{ name: string; sha256?: string }>;
+}
+
+export interface ReleaseProvenanceReport {
+  releaseReady: boolean;
+  checks: Array<{
+    name: string;
+    status: EvidenceStatus;
+    detail: string;
+  }>;
+  summary: string;
+}
+
+export function loadNativeEditingManifest(): NativeEditingManifest {
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as NativeEditingManifest;
+  assert.equal(manifest.schemaVersion, 1, "unsupported native editing manifest schema");
+  assert.equal(manifest.gate, "v0.1.6-native-editing");
+  assert.equal(manifest.releaseVersion, "0.1.6");
+  assert.equal(manifest.runtimeContract, "v0.1.6");
+  assert.deepEqual(manifest.evidenceTiers.map((tier) => tier.id), expectedTierIds);
+  const tierIds = new Set(manifest.evidenceTiers.map((tier) => tier.id));
+  assert.equal(manifest.evidenceTiers.filter((tier) => tier.required).length, 1);
+  for (const tier of manifest.evidenceTiers) {
+    assert.equal(tier.mode === "headless" || tier.mode === "headed", true);
+    assert.equal(typeof tier.guarantee, "string");
+  }
+  assert.deepEqual(manifest.workflows.map((workflow) => workflow.id), expectedWorkflowIds);
+  const workflowIds = new Set<string>();
+  for (const workflow of manifest.workflows) {
+    assert.equal(workflowIds.has(workflow.id), false, `duplicate native workflow ${workflow.id}`);
+    workflowIds.add(workflow.id);
+    assert.ok(workflow.operation);
+    assert.ok(workflow.capability);
+    assert.ok(workflow.evidenceTiers.length > 0);
+    for (const tier of workflow.evidenceTiers) assert.equal(tierIds.has(tier), true);
+    if (workflow.evidenceTypes.length > 0) assert.match(workflow.headedRunner ?? "", /^scripts\/final-cut-.*-e2e\.mjs$/);
+  }
+  return manifest;
+}
+
+export function summarizeHeadedEvidence(
+  value: unknown,
+  workflow: NativeEditingManifest["workflows"][number],
+): HeadedEvidenceSummary {
+  assert(value && typeof value === "object" && !Array.isArray(value), "headed evidence must be an object");
+  const raw = value as Record<string, any>;
+  assert.equal(raw.passed, true, `${workflow.id}: headed evidence did not pass`);
+  const evidenceType = requireString(raw.evidenceType, "headed evidence type");
+  assert.equal(workflow.evidenceTypes.includes(evidenceType), true, `${workflow.id}: unexpected headed evidence type`);
+
+  const environment = raw.environment as Record<string, unknown> | undefined;
+  const sanitizedEnvironment = {
+    framekitVersion: requireString(environment?.framekitVersion, "headed framekit version"),
+    finalCutVersion: requireString(environment?.finalCutVersion, "headed Final Cut version"),
+    gitCommit: requireSha(environment?.gitCommit, "headed git commit"),
+  };
+  const editor = raw.editor && typeof raw.editor === "object"
+    ? {
+        name: requireString(raw.editor.name, "headed editor name"),
+        version: requireString(raw.editor.version, "headed editor version"),
+        backend: requireString(raw.editor.backend, "headed editor backend"),
+      }
+    : undefined;
+  const target = extractTarget(raw);
+  const revision = extractRevisions(raw);
+  const verification = extractVerification(raw);
+
+  return {
+    schemaVersion: 1,
+    workflowId: workflow.id,
+    evidenceType,
+    status: "verified",
+    ...(typeof raw.recordedAt === "string" ? { recordedAt: raw.recordedAt } : {}),
+    environment: sanitizedEnvironment,
+    ...(editor ? { editor } : {}),
+    target,
+    revision,
+    verification,
+  };
+}
+
+export function assessReleaseProvenance(input: ReleaseProvenanceInput): ReleaseProvenanceReport {
+  const checks: ReleaseProvenanceReport["checks"] = [];
+  const packageVersion = input.packageManifest.version;
+  const pluginVersion = input.pluginManifest.version;
+
+  if (packageVersion && pluginVersion && packageVersion === pluginVersion) {
+    checks.push(verified("package-plugin-versions", `package and plugin are ${packageVersion}`));
+  } else {
+    checks.push(failed("package-plugin-versions", "package and plugin versions do not align"));
+  }
+
+  if (input.serverVersion && packageVersion && input.serverVersion === packageVersion) {
+    checks.push(verified("mcp-server-version", `MCP server reports ${input.serverVersion}`));
+  } else if (input.serverVersion) {
+    checks.push(failed("mcp-server-version", "MCP server version does not match package version"));
+  } else {
+    checks.push(unrun("mcp-server-version", "runtime MCP server version was not probed"));
+  }
+
+  if (input.releaseTag) {
+    if (packageVersion && input.releaseTag === `v${packageVersion}`) {
+      checks.push(verified("release-tag", `${input.releaseTag} matches package version`));
+    } else {
+      checks.push(failed("release-tag", "release tag does not match package version"));
+    }
+  } else {
+    checks.push(unrun("release-tag", "no release tag was supplied"));
+  }
+
+  if (input.githubRelease) {
+    const matches = input.githubRelease.tagName === input.releaseTag
+      && input.githubRelease.draft === false;
+    checks.push(matches
+      ? verified("github-release", "published GitHub release matches the release tag")
+      : failed("github-release", "GitHub release is missing, draft, or tagged differently"));
+  } else {
+    checks.push(unrun("github-release", "GitHub release state was not supplied"));
+  }
+
+  if (input.workflow) {
+    const successful = input.workflow.status === "completed" && input.workflow.conclusion === "success";
+    const tagMatches = !input.workflow.tagSha || input.workflow.tagSha === input.workflow.headSha;
+    checks.push(successful && tagMatches
+      ? verified("release-workflow", "release workflow completed successfully")
+      : failed("release-workflow", "release workflow is incomplete, failed, or points at a different commit"));
+  } else {
+    checks.push(unrun("release-workflow", "release workflow state was not supplied"));
+  }
+
+  if (input.npmVersion) {
+    checks.push(input.npmVersion === packageVersion
+      ? verified("npm-publication", `npm publishes ${input.npmVersion}`)
+      : failed("npm-publication", "npm publication does not match package version"));
+  } else {
+    checks.push(unrun("npm-publication", "npm registry publication was not probed"));
+  }
+
+  checks.push(assessNativeAssets(input.nativeAssets, packageVersion));
+  const releaseReady = checks.every((check) => check.status === "verified");
+  const blockers = checks.filter((check) => check.status !== "verified").map((check) => check.name);
+  return {
+    releaseReady,
+    checks,
+    summary: releaseReady
+      ? "release provenance is complete"
+      : `release completion is blocked by ${blockers.join(", ")}`,
+  };
+}
+
+function assessNativeAssets(
+  assets: ReleaseProvenanceInput["nativeAssets"],
+  packageVersion: string | undefined,
+): ReleaseProvenanceReport["checks"][number] {
+  if (!assets) return unrun("native-assets", "native release assets were not supplied");
+  const archiveName = `FramekitFinalCutWorkflow-${packageVersion}.zip`;
+  const checksumName = `${archiveName}.sha256`;
+  const archive = assets.find((asset) => asset.name === archiveName);
+  const checksum = assets.find((asset) => asset.name === checksumName);
+  const valid = Boolean(archive && checksum)
+    && Boolean(archive?.sha256 && /^[a-f0-9]{64}$/i.test(archive.sha256))
+    && Boolean(checksum?.sha256 && /^[a-f0-9]{64}$/i.test(checksum.sha256));
+  return valid
+    ? verified("native-assets", `native archive and checksum exist for ${packageVersion}`)
+    : failed("native-assets", "native archive or checksum is missing or malformed");
+}
+
+function extractTarget(raw: Record<string, any>): HeadedEvidenceSummary["target"] {
+  const project = raw.project;
+  const target = raw.target ?? raw.placement?.target;
+  const projectValue = typeof project === "string" ? project : project?.name ?? raw.placement?.project;
+  const projectId = typeof project === "object" ? project?.id : undefined;
+  const sequenceId = typeof project === "object" ? project?.sequenceId : target?.sequenceId;
+  const occurrenceId = target?.occurrenceId;
+  return {
+    ...(typeof projectValue === "string" ? { project: projectValue } : {}),
+    ...(typeof projectId === "string" ? { projectId } : {}),
+    ...(typeof sequenceId === "string" ? { sequenceId } : {}),
+    ...(typeof occurrenceId === "string" ? { occurrenceId } : {}),
+  };
+}
+
+function extractRevisions(raw: Record<string, any>): HeadedEvidenceSummary["revision"] {
+  const source = raw.revisions ?? raw.placement ?? raw.removal ?? raw.mutation;
+  const before = revisionId(source?.before ?? source?.beforeRevision);
+  const after = revisionId(source?.after ?? source?.afterRevision);
+  const restored = revisionId(source?.restored ?? raw.restoration?.restoredRevision ?? raw.placement?.undoRevision);
+  return {
+    before: requireString(before, "headed before revision"),
+    after: requireString(after, "headed after revision"),
+    restored: requireString(restored, "headed restored revision"),
+  };
+}
+
+function extractVerification(raw: Record<string, any>): HeadedEvidenceSummary["verification"] {
+  const execute = raw.placement?.observed !== undefined
+    || raw.mask?.observed !== undefined
+    || raw.placement?.verified === true
+    || raw.removal?.continuityVerified === true
+    || raw.mutation?.status === "VERIFIED"
+    || raw.verification?.execute?.verified === true;
+  const undo = raw.placement?.undoVerified?.verified === true
+    || raw.mask?.undo?.verified === true
+    || raw.placement?.undo?.verified === true
+    || raw.undo?.verified === true
+    || raw.restoration?.restored === true;
+  assert.equal(execute, true, "headed execute verification is missing");
+  assert.equal(undo, true, "headed Undo or rollback verification is missing");
+  return { execute: true, undo: true };
+}
+
+function revisionId(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object" && typeof (value as Record<string, unknown>).id === "string") {
+    return (value as Record<string, string>).id;
+  }
+  return undefined;
+}
+
+function verified(name: string, detail: string) {
+  return { name, status: "verified" as const, detail };
+}
+
+function failed(name: string, detail: string) {
+  return { name, status: "failed" as const, detail };
+}
+
+function unrun(name: string, detail: string) {
+  return { name, status: "unrun" as const, detail };
+}
+
+function requireString(value: unknown, label: string): string {
+  assert.equal(typeof value, "string", `${label} is missing`);
+  const result = value as string;
+  assert.ok(result.length > 0, `${label} is empty`);
+  return result;
+}
+
+function requireSha(value: unknown, label: string): string {
+  const result = requireString(value, label);
+  assert.match(result, /^[a-f0-9]{40}$/i, `${label} must be a full commit SHA`);
+  return result;
+}

--- a/tests/release-gate/native-editing.ts
+++ b/tests/release-gate/native-editing.ts
@@ -69,7 +69,7 @@ export interface ReleaseProvenanceInput {
   githubRelease?: { tagName?: string; draft?: boolean };
   workflow?: { status?: string; conclusion?: string; headSha?: string; tagSha?: string };
   npmVersion?: string;
-  nativeAssets?: Array<{ name: string; sha256?: string }>;
+  nativeAssets?: Array<{ name: string; sha256?: string; content?: string }>;
 }
 
 export interface ReleaseProvenanceReport {
@@ -230,10 +230,16 @@ function assessNativeAssets(
   const checksum = assets.find((asset) => asset.name === checksumName);
   const valid = Boolean(archive && checksum)
     && Boolean(archive?.sha256 && /^[a-f0-9]{64}$/i.test(archive.sha256))
-    && Boolean(checksum?.sha256 && /^[a-f0-9]{64}$/i.test(checksum.sha256));
+    && Boolean(checksum?.sha256 && /^[a-f0-9]{64}$/i.test(checksum.sha256))
+    && Boolean(archive?.sha256 && checksum?.content && checksumLineMatches(checksum.content, archiveName, archive.sha256));
   return valid
     ? verified("native-assets", `native archive and checksum exist for ${packageVersion}`)
-    : failed("native-assets", "native archive or checksum is missing or malformed");
+    : failed("native-assets", "native archive or checksum is missing, malformed, or mismatched");
+}
+
+function checksumLineMatches(content: string, archiveName: string, archiveSha256: string): boolean {
+  const escapedName = archiveName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^${archiveSha256}\\s+\\*?${escapedName}$`, "i").test(content.trim());
 }
 
 function extractTarget(raw: Record<string, any>): HeadedEvidenceSummary["target"] {

--- a/tests/release-gate/native-editing.ts
+++ b/tests/release-gate/native-editing.ts
@@ -255,13 +255,26 @@ function extractTarget(raw: Record<string, any>): HeadedEvidenceSummary["target"
   const sequenceId = typeof project === "object" ? project?.sequenceId : target?.sequenceId;
   const occurrenceId = target?.occurrenceId;
   const occurrenceName = target?.occurrenceName ?? target?.name;
+  const safeProject = safeTargetString(projectValue);
+  const safeProjectId = safeTargetString(projectId);
+  const safeSequenceId = safeTargetString(sequenceId);
+  const safeOccurrenceId = safeTargetString(occurrenceId);
+  const safeOccurrenceName = safeTargetString(occurrenceName);
   return {
-    ...(typeof projectValue === "string" ? { project: projectValue } : {}),
-    ...(typeof projectId === "string" ? { projectId } : {}),
-    ...(typeof sequenceId === "string" ? { sequenceId } : {}),
-    ...(typeof occurrenceId === "string" ? { occurrenceId } : {}),
-    ...(typeof occurrenceName === "string" ? { occurrenceName } : {}),
+    ...(safeProject ? { project: safeProject } : {}),
+    ...(safeProjectId ? { projectId: safeProjectId } : {}),
+    ...(safeSequenceId ? { sequenceId: safeSequenceId } : {}),
+    ...(safeOccurrenceId ? { occurrenceId: safeOccurrenceId } : {}),
+    ...(safeOccurrenceName ? { occurrenceName: safeOccurrenceName } : {}),
   };
+}
+
+function safeTargetString(value: unknown): string | undefined {
+  if (typeof value !== "string" || value.length === 0) return undefined;
+  if (value.startsWith("/") || value.startsWith("~/") || /^[A-Za-z]:[\\/]/.test(value) || value.startsWith("\\\\")) {
+    return undefined;
+  }
+  return value;
 }
 
 function extractRevisions(raw: Record<string, any>): HeadedEvidenceSummary["revision"] {

--- a/tests/release-gate/release-gate.test.ts
+++ b/tests/release-gate/release-gate.test.ts
@@ -7,7 +7,7 @@ import { AgentVideoRuntime } from "@framekit/runtime";
 import { InMemoryEditorAdapter } from "@framekit/testkit";
 import { createMcpServer } from "../../apps/mcp-server/src/server.js";
 
-test("release corpus covers both v0.0.3 workflow families and safety cases", async () => {
+test("release corpus covers both v0.1.6 workflow families and safety cases", async () => {
   const raw = await readFile(new URL("./corpus.json", import.meta.url), "utf8");
   const corpus = JSON.parse(raw) as {
     schemaVersion: number;

--- a/tests/release-gate/repository-checks.test.ts
+++ b/tests/release-gate/repository-checks.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { runRepositoryChecks } from "./repository-checks.js";
+
+test("repository release checks run the frozen install and each required gate independently", async () => {
+  const commands: string[] = [];
+  const report = await runRepositoryChecks({
+    rootDirectory: "/private/framekit",
+    run: async (command, args) => {
+      commands.push([command, ...args].join(" "));
+      return { code: 0 };
+    },
+  });
+
+  assert.deepEqual(commands, [
+    "pnpm install --frozen-lockfile",
+    "pnpm run build",
+    "pnpm run test",
+    "pnpm run evaluate",
+    "pnpm run check:boundaries",
+  ]);
+  assert.equal(report.passed, true);
+  assert.deepEqual(report.checks.map((check) => check.status), [
+    "verified",
+    "verified",
+    "verified",
+    "verified",
+    "verified",
+  ]);
+});
+
+test("repository release checks preserve a failed gate without hiding other results", async () => {
+  const report = await runRepositoryChecks({
+    rootDirectory: "/private/framekit",
+    run: async (_command, args) => ({ code: args.includes("build") ? 1 : 0 }),
+  });
+
+  assert.equal(report.passed, false);
+  assert.equal(report.checks.find((check) => check.name === "build")?.status, "failed");
+  assert.equal(report.checks.find((check) => check.name === "test")?.status, "verified");
+  assert.doesNotMatch(JSON.stringify(report), /\/private\/framekit/);
+});

--- a/tests/release-gate/repository-checks.ts
+++ b/tests/release-gate/repository-checks.ts
@@ -1,0 +1,100 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { EvidenceStatus } from "./native-editing.js";
+
+const execFileAsync = promisify(execFile);
+
+export interface RepositoryCheck {
+  name: "install" | "build" | "test" | "mcp-evaluation" | "boundaries";
+  command: string;
+  status: EvidenceStatus;
+  detail: string;
+}
+
+export interface RepositoryChecksReport {
+  passed: boolean;
+  checks: RepositoryCheck[];
+}
+
+export interface RepositoryCheckOptions {
+  rootDirectory: string;
+  run?: RepositoryCommandRunner;
+}
+
+export interface RepositoryCommandResult {
+  code: number;
+}
+
+export type RepositoryCommandRunner = (
+  command: string,
+  args: string[],
+  options: { cwd: string },
+) => Promise<RepositoryCommandResult>;
+
+const commands: Array<Pick<RepositoryCheck, "name" | "command"> & { args: string[] }> = [
+  { name: "install", command: "pnpm", args: ["install", "--frozen-lockfile"] },
+  { name: "build", command: "pnpm", args: ["run", "build"] },
+  { name: "test", command: "pnpm", args: ["run", "test"] },
+  { name: "mcp-evaluation", command: "pnpm", args: ["run", "evaluate"] },
+  { name: "boundaries", command: "pnpm", args: ["run", "check:boundaries"] },
+];
+
+export function unrunRepositoryChecks(): RepositoryChecksReport {
+  return {
+    passed: false,
+    checks: commands.map((current) => ({
+      name: current.name,
+      command: [current.command, ...current.args].join(" "),
+      status: "unrun" as const,
+      detail: `${current.name} was not run by this API call`,
+    })),
+  };
+}
+
+export async function runRepositoryChecks(options: RepositoryCheckOptions): Promise<RepositoryChecksReport> {
+  const run = options.run ?? runCommand;
+  const checks: RepositoryCheck[] = [];
+
+  for (const current of commands) {
+    try {
+      const result = await run(current.command, current.args, { cwd: options.rootDirectory });
+      const command = [current.command, ...current.args].join(" ");
+      checks.push({
+        name: current.name,
+        command,
+        status: result.code === 0 ? "verified" : "failed",
+        detail: result.code === 0
+          ? `${current.name} passed`
+          : `${current.name} exited with code ${result.code}`,
+      });
+    } catch {
+      checks.push({
+        name: current.name,
+        command: [current.command, ...current.args].join(" "),
+        status: "failed",
+        detail: `${current.name} could not be started`,
+      });
+    }
+  }
+
+  return {
+    passed: checks.every((check) => check.status === "verified"),
+    checks,
+  };
+}
+
+async function runCommand(
+  command: string,
+  args: string[],
+  options: { cwd: string },
+): Promise<RepositoryCommandResult> {
+  try {
+    await execFileAsync(command, args, { cwd: options.cwd, maxBuffer: 1024 * 1024 });
+    return { code: 0 };
+  } catch (error) {
+    const code = error && typeof error === "object" && typeof (error as { code?: unknown }).code === "number"
+      ? (error as { code: number }).code
+      : 1;
+    return { code };
+  }
+}

--- a/tests/release-gate/runner.test.ts
+++ b/tests/release-gate/runner.test.ts
@@ -31,5 +31,12 @@ test("release gate executes Skills and separates capability evidence", async () 
   assert.equal(report.evidenceTiers["metadata-only"].status, "verified");
   assert.equal(report.evidenceTiers["canonical-live"].status, "unsupported");
   assert.equal(report.evidenceTiers["headed-native"].status, "unrun");
+  assert.deepEqual(report.repositoryChecks.checks.map((check) => check.status), [
+    "unrun",
+    "unrun",
+    "unrun",
+    "unrun",
+    "unrun",
+  ]);
   assert.equal(report.generatedAt, "2026-08-30T00:00:00.000Z");
 });

--- a/tests/release-gate/runner.test.ts
+++ b/tests/release-gate/runner.test.ts
@@ -13,11 +13,12 @@ test("release gate corpus carries controlled fixtures for every workflow", () =>
   }
 });
 
-test("release gate executes Skills through generic MCP and separates capability evidence", async () => {
+test("release gate executes Skills and separates capability evidence", async () => {
   const report = await runReleaseGate({ generatedAt: "2026-08-30T00:00:00.000Z" });
 
   assert.equal(report.schemaVersion, 1);
-  assert.equal(report.gate, "v0.0.3-closed-loop-speech-editing");
+  assert.equal(report.gate, "v0.1.6-native-editing");
+  assert.equal(report.manifestVersion, "2026-09-11");
   assert.equal(report.deterministic.passed, true);
   assert.ok(report.deterministic.workflows.length >= 15);
   assert.equal(report.adapter.backend, "fixture");
@@ -25,5 +26,10 @@ test("release gate executes Skills through generic MCP and separates capability 
   assert.equal(report.live.status, "unsupported");
   assert.ok(report.live.reason.length > 0);
   assert.ok(report.unsupportedCapabilities.length > 0);
+  assert.equal(report.evidenceTiers.deterministic.status, "verified");
+  assert.equal(report.evidenceTiers["fcpxml-artifact"].status, "verified");
+  assert.equal(report.evidenceTiers["metadata-only"].status, "verified");
+  assert.equal(report.evidenceTiers["canonical-live"].status, "unsupported");
+  assert.equal(report.evidenceTiers["headed-native"].status, "unrun");
   assert.equal(report.generatedAt, "2026-08-30T00:00:00.000Z");
 });

--- a/tests/release-gate/runner.test.ts
+++ b/tests/release-gate/runner.test.ts
@@ -2,10 +2,11 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { loadReleaseGateCorpus, runReleaseGate } from "./runner.js";
 
-test("release gate corpus carries controlled fixtures for every workflow", () => {
+test("v0.1.6 release gate corpus carries controlled fixtures", () => {
   const corpus = loadReleaseGateCorpus();
 
   assert.equal(corpus.schemaVersion, 1);
+  assert.equal(corpus.runtimeContract, "v0.1.6");
   assert.ok(corpus.workflows.length >= 15);
   for (const workflow of corpus.workflows) {
     assert.ok(workflow.fixture, `${workflow.id} has no controlled fixture`);

--- a/tests/release-gate/runner.test.ts
+++ b/tests/release-gate/runner.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { loadReleaseGateCorpus, runReleaseGate } from "./runner.js";
+import { loadReleaseGateCorpus, renderReleaseGateReport, runReleaseGate } from "./runner.js";
 
 test("v0.1.6 release gate corpus carries controlled fixtures", () => {
   const corpus = loadReleaseGateCorpus();
@@ -32,6 +32,9 @@ test("release gate executes Skills and separates capability evidence", async () 
   assert.equal(report.evidenceTiers["metadata-only"].status, "verified");
   assert.equal(report.evidenceTiers["canonical-live"].status, "unsupported");
   assert.equal(report.evidenceTiers["headed-native"].status, "unrun");
+  const rendered = renderReleaseGateReport(report);
+  assert.match(rendered, /provenance_ready=false/);
+  assert.doesNotMatch(rendered, /release_ready=/);
   assert.deepEqual(report.repositoryChecks.checks.map((check) => check.status), [
     "unrun",
     "unrun",

--- a/tests/release-gate/runner.ts
+++ b/tests/release-gate/runner.ts
@@ -1,18 +1,37 @@
 import assert from "node:assert/strict";
+import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import {
   AgentVideoRuntime,
   canonicalSnapshotDigest,
+  createCapabilityPreflight,
+  withCapabilityFamilies,
   type AudioAnalyzer,
   type RuntimeOptions,
   type SpeechAnalyzer,
   type ProjectSnapshot,
+  type WorkflowOperation,
 } from "@framekit/runtime";
+import { FcpxmlDocumentAdapter, FinalCutSessionAdapter } from "@framekit/final-cut";
 import { InMemoryEditorAdapter, type InMemoryFixture } from "@framekit/testkit";
 import { createMcpServer } from "../../apps/mcp-server/src/server.js";
+import { FRAMEKIT_VERSION } from "../../apps/mcp-server/src/version.js";
+import {
+  assessReleaseProvenance,
+  loadNativeEditingManifest,
+  summarizeHeadedEvidence,
+  type EvidenceMode,
+  type EvidenceStatus,
+  type HeadedEvidenceSummary,
+  type NativeEditingManifest,
+  type ReleaseProvenanceInput,
+  type ReleaseProvenanceReport,
+} from "./native-editing.js";
 
 const corpusPath = fileURLToPath(new URL("./corpus.json", import.meta.url));
 const requiredFillerCases = [
@@ -77,7 +96,9 @@ export interface ReleaseGateWorkflowEvidence {
 
 export interface ReleaseGateReport {
   schemaVersion: 1;
-  gate: "v0.0.3-closed-loop-speech-editing";
+  gate: "v0.1.6-native-editing";
+  manifestVersion: string;
+  releaseVersion: "0.1.6";
   corpusVersion: string;
   generatedAt: string;
   deterministic: {
@@ -97,10 +118,62 @@ export interface ReleaseGateReport {
     reason: string;
   };
   unsupportedCapabilities: string[];
+  evidenceTiers: ReleaseGateEvidenceTiers;
+  workflowMatrix: ReleaseGateWorkflowMatrixEntry[];
+  provenance: ReleaseProvenanceReport;
 }
 
 export interface RunReleaseGateOptions {
   generatedAt?: string;
+  headedEvidenceDirectory?: string;
+  provenance?: Partial<ReleaseProvenanceInput>;
+}
+
+export interface ReleaseGateWorkflowMatrixEntry {
+  workflowId: string;
+  operation: string;
+    capability: string;
+  evidence: Array<{
+    tier: string;
+    status: EvidenceStatus;
+    passed: boolean;
+    reason?: string;
+  }>;
+}
+
+export interface ReleaseGateEvidence {
+  tier: string;
+  status: EvidenceStatus;
+  attempted: boolean;
+  passed: boolean;
+  mode: EvidenceMode;
+  backend: string;
+  guarantee: string;
+  preflight: {
+    mode: EvidenceMode;
+    backend: string;
+    guarantee: string;
+    capabilities?: unknown;
+    unavailableReason?: string;
+  };
+  workflows: Array<{
+    workflowId: string;
+    status: EvidenceStatus;
+    passed: boolean;
+    evidenceType?: string;
+    target?: HeadedEvidenceSummary["target"];
+    revision?: HeadedEvidenceSummary["revision"];
+    verification?: { execute: boolean; undo: boolean };
+    reason?: string;
+  }>;
+}
+
+export interface ReleaseGateEvidenceTiers {
+  deterministic: ReleaseGateEvidence;
+  "fcpxml-artifact": ReleaseGateEvidence;
+  "metadata-only": ReleaseGateEvidence;
+  "canonical-live": ReleaseGateEvidence;
+  "headed-native": ReleaseGateEvidence;
 }
 
 export function loadReleaseGateCorpus(): ReleaseGateCorpus {
@@ -127,6 +200,7 @@ export function loadReleaseGateCorpus(): ReleaseGateCorpus {
 
 export async function runReleaseGate(options: RunReleaseGateOptions = {}): Promise<ReleaseGateReport> {
   const corpus = loadReleaseGateCorpus();
+  const manifest = loadNativeEditingManifest();
   const workflows = [];
   for (const workflow of corpus.workflows) workflows.push(await runWorkflow(workflow));
   const fillerResults = workflows.filter((workflow) => workflow.family === "filler-removal"
@@ -134,9 +208,41 @@ export async function runReleaseGate(options: RunReleaseGateOptions = {}): Promi
   const successfulFillers = fillerResults.filter((workflow) => workflow.passed && workflow.actualOutcome === "verified").length;
   const fillerVerificationRate = fillerResults.length === 0 ? 0 : successfulFillers / fillerResults.length;
   const deterministicPassed = workflows.every((workflow) => workflow.passed) && fillerVerificationRate >= 0.95;
-  return {
+  const deterministicEditing = await runDeterministicEditingWorkflows();
+  const fcpxmlArtifact = await runFcpxmlArtifactWorkflows();
+  const metadataOnly = await runMetadataOnlyPreflight();
+  const evidenceTiers = await collectEvidenceTiers({
+    manifest,
+    deterministicPassed,
+    deterministicWorkflows: [
+      ...deterministicEditing,
+      aggregateWorkflow("filler-removal", workflows),
+      aggregateWorkflow("dialogue-normalization", workflows),
+    ],
+    fcpxmlWorkflows: fcpxmlArtifact,
+    metadataOnly,
+    headedEvidenceDirectory: options.headedEvidenceDirectory,
+  });
+  const packageManifest = JSON.parse(readFileSync(new URL("../../package.json", import.meta.url), "utf8")) as {
+    name?: string;
+    version?: string;
+    private?: boolean;
+  };
+  const pluginManifest = JSON.parse(readFileSync(new URL("../../plugins/framekit/.codex-plugin/plugin.json", import.meta.url), "utf8")) as {
+    name?: string;
+    version?: string;
+  };
+  const provenance = assessReleaseProvenance({
+    packageManifest,
+    pluginManifest,
+    serverVersion: FRAMEKIT_VERSION,
+    ...options.provenance,
+  });
+  const report = {
     schemaVersion: 1,
-    gate: "v0.0.3-closed-loop-speech-editing",
+    gate: "v0.1.6-native-editing",
+    manifestVersion: manifest.manifestVersion,
+    releaseVersion: manifest.releaseVersion,
     corpusVersion: corpus.corpusVersion,
     generatedAt: options.generatedAt ?? new Date().toISOString(),
     deterministic: {
@@ -164,19 +270,499 @@ export async function runReleaseGate(options: RunReleaseGateOptions = {}): Promi
       "live canonical timeline enumeration",
       "live canonical timeline mutation",
     ],
-  };
+    evidenceTiers,
+    workflowMatrix: buildWorkflowMatrix(manifest, evidenceTiers),
+    provenance,
+  } satisfies ReleaseGateReport;
+  return report;
 }
 
 export function renderReleaseGateReport(report: ReleaseGateReport): string {
   return [
-    "Framekit v0.0.3 closed-loop speech editing release gate",
+    "Framekit v0.1.6 native-editing release gate",
+    `manifest_version=${report.manifestVersion}`,
     `corpus_version=${report.corpusVersion}`,
     `deterministic_passed=${report.deterministic.passed}`,
     `workflows=${report.deterministic.workflows.length}`,
     `filler_verification_rate=${(report.deterministic.fillerVerificationRate * 100).toFixed(1)}%`,
     `adapter_backend=${report.adapter.backend}`,
     `live_status=${report.live.status}`,
+    `fcpxml_status=${report.evidenceTiers["fcpxml-artifact"].status}`,
+    `metadata_only_status=${report.evidenceTiers["metadata-only"].status}`,
+    `canonical_live_status=${report.evidenceTiers["canonical-live"].status}`,
+    `headed_native_status=${report.evidenceTiers["headed-native"].status}`,
+    `release_ready=${report.provenance.releaseReady}`,
   ].join("\n");
+}
+
+interface TierWorkflowResult {
+  workflowId: string;
+  status: EvidenceStatus;
+  passed: boolean;
+  evidenceType?: string;
+  target?: HeadedEvidenceSummary["target"];
+  revision?: HeadedEvidenceSummary["revision"];
+  verification?: { execute: boolean; undo: boolean };
+  reason?: string;
+}
+
+interface MetadataOnlyResult {
+  preflight: ReleaseGateEvidence["preflight"];
+  workflows: TierWorkflowResult[];
+}
+
+async function runDeterministicEditingWorkflows(): Promise<TierWorkflowResult[]> {
+  return [
+    await runFixtureEditingWorkflow("picture-in-picture", {
+      type: "timeline.picture-in-picture.add",
+      occurrenceId: "pip-occurrence",
+      mediaId: "pip-media",
+      attachedTo: "primary-occurrence",
+      start: 2,
+      duration: 4,
+      targetLane: 1,
+      position: { x: 320, y: -180 },
+      scale: 0.35,
+      crop: { top: 0.1, right: 0.05, bottom: 0.1, left: 0.05 },
+    }),
+    await runFixtureEditingWorkflow("built-in-title-discovery", {
+      type: "timeline.title.add",
+      occurrenceId: "title-occurrence",
+      assetId: "title-basic",
+      text: "Framekit release proof",
+      start: 1,
+      duration: 2,
+      targetLane: 2,
+    }),
+    await runFixtureEditingWorkflow("masking", {
+      type: "timeline.mask.add",
+      occurrenceId: "primary-occurrence",
+      mask: { mode: "rectangle", bounds: { x: 0.1, y: 0.2, width: 0.6, height: 0.7 } },
+    }),
+  ];
+}
+
+async function runFixtureEditingWorkflow(
+  workflowId: string,
+  operation: WorkflowOperation,
+): Promise<TierWorkflowResult> {
+  const adapter = new InMemoryEditorAdapter({
+    projectId: "release-gate-fixture",
+    projectName: "Native Editing Release Gate",
+    timelineId: "release-gate-timeline",
+    timelineName: "Main Edit",
+    clips: [{
+      id: "primary-occurrence",
+      mediaId: "primary-media",
+      name: "Presenter",
+      start: 0,
+      duration: 10,
+      track: 1,
+    }],
+    media: [
+      { mediaId: "primary-media", source: "fixtures/presenter.mov", mediaKind: "video", duration: 10 },
+      { mediaId: "pip-media", source: "fixtures/guest.mov", mediaKind: "video", duration: 6 },
+    ],
+    assets: [{ id: "title-basic", kind: "title", name: "Basic Title", vendor: "Framekit Fixture", metadata: {} }],
+  });
+  const runtime = new AgentVideoRuntime(adapter);
+
+  try {
+    if (workflowId === "built-in-title-discovery") {
+      const titles = await runtime.listAssets({ kind: "title", query: "Basic Title" });
+      assert.equal(titles.length, 1, "fixture title discovery must be unique");
+    }
+    const before = await runtime.inspectProject();
+    const preview = await runtime.previewEdit({ baseRevision: before.revision, operations: [operation] });
+    const transaction = await runtime.executeEdit(preview.previewToken);
+    const after = await runtime.inspectProject();
+    const restored = await runtime.undo(transaction.id);
+    const changed = canonicalSnapshotDigest(before) !== canonicalSnapshotDigest(after);
+    const restoredOriginal = canonicalSnapshotDigest(before) === canonicalSnapshotDigest(restored);
+    const verified = transaction.status === "VERIFIED" && changed && restoredOriginal;
+    return {
+      workflowId,
+      status: verified ? "verified" : "failed",
+      passed: verified,
+      revision: {
+        before: before.revision.id,
+        after: after.revision.id,
+        restored: restored.revision.id,
+      },
+      verification: { execute: verified, undo: restoredOriginal },
+      ...(verified ? {} : { reason: "fixture edit did not verify a changed and restored canonical snapshot" }),
+    };
+  } catch (error) {
+    return { workflowId, status: "failed", passed: false, reason: safeFailure(error) };
+  }
+}
+
+async function runFcpxmlArtifactWorkflows(): Promise<TierWorkflowResult[]> {
+  return [await runFcpxmlPictureInPicture(), await runFcpxmlDialogueNormalization()];
+}
+
+async function runFcpxmlPictureInPicture(): Promise<TierWorkflowResult> {
+  const directory = await mkdtemp(join(tmpdir(), "framekit-release-gate-fcpxml-"));
+  const artifactPath = join(directory, "pip.fcpxml");
+  try {
+    await writeFile(artifactPath, releaseGateFcpxml(), "utf8");
+    const runtime = new AgentVideoRuntime(new FcpxmlDocumentAdapter(artifactPath));
+    const before = await runtime.inspectProject();
+    const preview = await runtime.previewArtifactEdit(artifactPath, {
+      baseRevision: before.revision,
+      operations: [{
+        type: "timeline.picture-in-picture.add",
+        occurrenceId: "pip-occurrence",
+        mediaId: "pip-media",
+        attachedTo: "primary-occurrence",
+        start: 2,
+        duration: 4,
+        targetLane: 1,
+        position: { x: 320, y: -180 },
+        scale: 0.35,
+        crop: { top: 0.1, right: 0.05, bottom: 0.1, left: 0.05 },
+      }],
+    });
+    const transaction = await runtime.executeEdit(preview.previewToken);
+    const after = await runtime.inspectProject();
+    const restored = await runtime.undo(transaction.id);
+    const verified = transaction.status === "VERIFIED"
+      && canonicalSnapshotDigest(before) !== canonicalSnapshotDigest(after)
+      && canonicalSnapshotDigest(before) === canonicalSnapshotDigest(restored);
+    return {
+      workflowId: "picture-in-picture",
+      status: verified ? "verified" : "failed",
+      passed: verified,
+      revision: { before: before.revision.id, after: after.revision.id, restored: restored.revision.id },
+      verification: { execute: verified, undo: canonicalSnapshotDigest(before) === canonicalSnapshotDigest(restored) },
+      ...(verified ? {} : { reason: "FCPXML PIP artifact did not verify and restore" }),
+    };
+  } catch (error) {
+    return { workflowId: "picture-in-picture", status: "failed", passed: false, reason: safeFailure(error) };
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+async function runFcpxmlDialogueNormalization(): Promise<TierWorkflowResult> {
+  const directory = await mkdtemp(join(tmpdir(), "framekit-release-gate-dialogue-"));
+  const artifactPath = join(directory, "dialogue.fcpxml");
+  try {
+    await writeFile(artifactPath, releaseGateFcpxml(), "utf8");
+    const runtime = new AgentVideoRuntime(new FcpxmlDocumentAdapter(artifactPath));
+    const before = await runtime.inspectProject();
+    const preview = await runtime.previewArtifactEdit(artifactPath, {
+      baseRevision: before.revision,
+      operations: [{
+        type: "set-gain",
+        clipId: "primary-occurrence",
+        gainDb: 4,
+      }],
+    });
+    const transaction = await runtime.executeEdit(preview.previewToken);
+    const after = await runtime.inspectProject();
+    const restored = await runtime.undo(transaction.id);
+    const verified = transaction.status === "VERIFIED"
+      && canonicalSnapshotDigest(before) !== canonicalSnapshotDigest(after)
+      && canonicalSnapshotDigest(before) === canonicalSnapshotDigest(restored);
+    return {
+      workflowId: "dialogue-normalization",
+      status: verified ? "verified" : "failed",
+      passed: verified,
+      revision: { before: before.revision.id, after: after.revision.id, restored: restored.revision.id },
+      verification: { execute: verified, undo: canonicalSnapshotDigest(before) === canonicalSnapshotDigest(restored) },
+      ...(verified ? {} : { reason: "FCPXML dialogue artifact did not verify and restore" }),
+    };
+  } catch (error) {
+    return { workflowId: "dialogue-normalization", status: "failed", passed: false, reason: safeFailure(error) };
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+function releaseGateFcpxml(): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<fcpxml version="1.11">
+  <resources>
+    <asset id="primary-media" name="Presenter" src="file:///fixtures/presenter.mov" duration="10s" />
+    <asset id="pip-media" name="Guest" src="file:///fixtures/guest.mov" duration="6s" />
+  </resources>
+  <library><event name="Release Gate"><project uid="release-gate-project" name="Native Editing Release Gate">
+    <sequence uid="release-gate-sequence" name="Main Edit" duration="10s"><spine>
+      <asset-clip id="primary-occurrence" ref="primary-media" name="Presenter" offset="0s" duration="10s" />
+    </spine></sequence>
+  </project></event></library>
+</fcpxml>
+`;
+}
+
+async function runMetadataOnlyPreflight(): Promise<MetadataOnlyResult> {
+  const metadataCapabilities = withCapabilityFamilies({
+    editor: {
+      projectRead: true,
+      timelineSnapshotRead: false,
+      timelineWrite: false,
+      timelineArtifactWrite: false,
+      readAfterWrite: false,
+      incrementalChanges: true,
+      rollback: false,
+      assetDiscovery: false,
+      liveStateRead: true,
+      playheadWrite: false,
+      frameCapture: false,
+      projectCatalogRead: false,
+      projectSelection: false,
+      compositeTransactions: false,
+    },
+    analyzers: {
+      speechTranscribe: false,
+      speechVad: false,
+      audioLoudness: false,
+      visualTrack: false,
+    },
+  }, { backend: "workflow-extension-ipc" });
+  const live = {
+    getIdentity: async () => ({ name: "Final Cut Pro", version: "10.7.1", backend: "workflow-extension-ipc" }),
+    getCapabilities: async () => metadataCapabilities,
+    readLiveState: async () => {
+      throw new Error("metadata-only fixture has no live state payload");
+    },
+    liveChangesSince: async () => [],
+  };
+  const runtime = new AgentVideoRuntime(new FinalCutSessionAdapter({ live }));
+  const inspected = await runtime.inspectEditor();
+  const preflight = createCapabilityPreflight(inspected.identity, inspected.capabilities, { processMode: "headless" });
+  const unavailableReason = preflight.capabilities.canonicalDocument.write.unavailableReason
+    ?? "canonical timeline writes are unavailable";
+  return {
+    preflight: {
+      mode: "headless",
+      backend: preflight.backend,
+      guarantee: "observed",
+      capabilities: preflight.capabilities,
+      unavailableReason,
+    },
+    workflows: loadNativeEditingManifest().workflows.map((workflow) => ({
+      workflowId: workflow.id,
+      status: "unsupported",
+      passed: true,
+      reason: unavailableReason,
+    })),
+  };
+}
+
+async function collectEvidenceTiers(input: {
+  manifest: NativeEditingManifest;
+  deterministicPassed: boolean;
+  deterministicWorkflows: TierWorkflowResult[];
+  fcpxmlWorkflows: TierWorkflowResult[];
+  metadataOnly: MetadataOnlyResult;
+  headedEvidenceDirectory?: string;
+}): Promise<ReleaseGateEvidenceTiers> {
+  const deterministic = createTierEvidence(
+    "deterministic",
+    input.deterministicPassed && input.deterministicWorkflows.every((workflow) => workflow.passed),
+    "headless",
+    "fixture",
+    "verified",
+    input.deterministicWorkflows,
+    { mode: "headless", backend: "fixture", guarantee: "verified" },
+  );
+  const fcpxmlArtifact = createTierEvidence(
+    "fcpxml-artifact",
+    input.fcpxmlWorkflows.every((workflow) => workflow.passed),
+    "headless",
+    "fcpxml-document",
+    "artifact-write",
+    input.fcpxmlWorkflows,
+    { mode: "headless", backend: "fcpxml-document", guarantee: "artifact-write" },
+  );
+  const metadataOnly = createTierEvidence(
+    "metadata-only",
+    true,
+    "headless",
+    input.metadataOnly.preflight.backend,
+    "observed",
+    input.metadataOnly.workflows,
+    input.metadataOnly.preflight,
+  );
+  const canonicalWorkflows = input.manifest.workflows
+    .filter((workflow) => workflow.evidenceTiers.includes("canonical-live"))
+    .map((workflow) => ({
+      workflowId: workflow.id,
+      status: "unsupported" as const,
+      passed: true,
+      reason: input.metadataOnly.preflight.unavailableReason,
+    }));
+  const canonicalLive = createTierEvidence(
+    "canonical-live",
+    true,
+    "headless",
+    input.metadataOnly.preflight.backend,
+    "canonical-write",
+    canonicalWorkflows,
+    {
+      ...input.metadataOnly.preflight,
+      guarantee: "canonical-write",
+      unavailableReason: input.metadataOnly.preflight.unavailableReason,
+    },
+    "unsupported",
+  );
+  const headed = await collectHeadedNativeEvidence(input.manifest, input.headedEvidenceDirectory);
+  return { deterministic, "fcpxml-artifact": fcpxmlArtifact, "metadata-only": metadataOnly, "canonical-live": canonicalLive, "headed-native": headed };
+}
+
+function createTierEvidence(
+  tier: string,
+  passed: boolean,
+  mode: EvidenceMode,
+  backend: string,
+  guarantee: string,
+  workflows: TierWorkflowResult[],
+  preflight: ReleaseGateEvidence["preflight"],
+  explicitStatus?: EvidenceStatus,
+): ReleaseGateEvidence {
+  const status = explicitStatus ?? (passed ? "verified" : "failed");
+  return {
+    tier,
+    status,
+    attempted: true,
+    passed,
+    mode,
+    backend,
+    guarantee,
+    preflight,
+    workflows,
+  };
+}
+
+async function collectHeadedNativeEvidence(
+  manifest: NativeEditingManifest,
+  evidenceDirectory?: string,
+): Promise<ReleaseGateEvidence> {
+  const preflight: ReleaseGateEvidence["preflight"] = {
+    mode: "headed",
+    backend: "final-cut-accessibility",
+    guarantee: "native-verified",
+    unavailableReason: evidenceDirectory
+      ? "no matching headed evidence was supplied for this workflow"
+      : "opt-in headed evidence directory was not supplied",
+  };
+  const workflows = await readHeadedEvidence(manifest, evidenceDirectory);
+  const attempted = workflows.some((workflow) => workflow.status !== "unrun");
+  const failed = workflows.some((workflow) => workflow.status === "failed");
+  const status: EvidenceStatus = failed ? "failed" : attempted ? "verified" : "unrun";
+  return {
+    tier: "headed-native",
+    status,
+    attempted,
+    passed: status === "verified",
+    mode: "headed",
+    backend: "final-cut-accessibility",
+    guarantee: "native-verified",
+    preflight,
+    workflows,
+  };
+}
+
+async function readHeadedEvidence(
+  manifest: NativeEditingManifest,
+  evidenceDirectory?: string,
+): Promise<TierWorkflowResult[]> {
+  if (!evidenceDirectory) {
+    return manifest.workflows
+      .filter((workflow) => workflow.evidenceTiers.includes("headed-native"))
+      .map((workflow) => ({ workflowId: workflow.id, status: "unrun", passed: false, reason: "opt-in headed evidence was not requested" }));
+  }
+  let files: string[];
+  try {
+    files = (await readdir(evidenceDirectory)).filter((file) => file.endsWith(".json"));
+  } catch {
+    return manifest.workflows
+      .filter((workflow) => workflow.evidenceTiers.includes("headed-native"))
+      .map((workflow) => ({ workflowId: workflow.id, status: "failed", passed: false, reason: "headed evidence directory could not be read" }));
+  }
+  const values: unknown[] = [];
+  for (const file of files) {
+    try {
+      values.push(JSON.parse(await readFile(join(evidenceDirectory, file), "utf8")));
+    } catch {
+      values.push({ evidenceType: `invalid:${file}`, passed: false });
+    }
+  }
+  const results: TierWorkflowResult[] = [];
+  for (const workflow of manifest.workflows.filter((candidate) => candidate.evidenceTiers.includes("headed-native"))) {
+    if (workflow.evidenceTypes.length === 0) {
+      results.push({ workflowId: workflow.id, status: "unrun", passed: false, reason: "no headed runner is registered" });
+      continue;
+    }
+    const matches = values.filter((value) => {
+      const evidenceType = value && typeof value === "object" ? (value as Record<string, unknown>).evidenceType : undefined;
+      return typeof evidenceType === "string" && workflow.evidenceTypes.includes(evidenceType);
+    });
+    if (matches.length === 0) {
+      results.push({ workflowId: workflow.id, status: "unrun", passed: false, reason: "matching headed evidence was not supplied" });
+      continue;
+    }
+    if (matches.length > 1) {
+      results.push({ workflowId: workflow.id, status: "failed", passed: false, reason: "multiple headed evidence records matched one workflow" });
+      continue;
+    }
+    try {
+      const summary = summarizeHeadedEvidence(matches[0], workflow);
+      results.push({
+        workflowId: workflow.id,
+        status: "verified",
+        passed: true,
+        evidenceType: summary.evidenceType,
+        target: summary.target,
+        revision: summary.revision,
+        verification: summary.verification,
+      });
+    } catch (error) {
+      results.push({ workflowId: workflow.id, status: "failed", passed: false, reason: safeFailure(error) });
+    }
+  }
+  return results;
+}
+
+function buildWorkflowMatrix(
+  manifest: NativeEditingManifest,
+  evidenceTiers: ReleaseGateEvidenceTiers,
+): ReleaseGateWorkflowMatrixEntry[] {
+  return manifest.workflows.map((workflow) => ({
+    workflowId: workflow.id,
+    operation: workflow.operation,
+    capability: workflow.capability,
+    evidence: workflow.evidenceTiers.map((tier) => {
+      const result = evidenceTiers[tier].workflows.find((candidate) => candidate.workflowId === workflow.id);
+      return {
+        tier,
+        status: result?.status ?? "unrun",
+        passed: result?.passed ?? false,
+        ...(result?.reason ? { reason: result.reason } : {}),
+      };
+    }),
+  }));
+}
+
+function aggregateWorkflow(
+  workflowId: "filler-removal" | "dialogue-normalization",
+  workflows: ReleaseGateWorkflowEvidence[],
+): TierWorkflowResult {
+  const familyWorkflows = workflows.filter((workflow) => workflow.family === workflowId);
+  const passed = familyWorkflows.length > 0 && familyWorkflows.every((workflow) => workflow.passed);
+  return {
+    workflowId,
+    status: passed ? "verified" : "failed",
+    passed,
+    ...(passed ? {} : { reason: `deterministic ${workflowId} corpus did not pass` }),
+  };
+}
+
+function safeFailure(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.split(":", 1)[0] || "release gate workflow failed";
 }
 
 async function runWorkflow(workflow: ReleaseGateWorkflow): Promise<ReleaseGateWorkflowEvidence> {

--- a/tests/release-gate/runner.ts
+++ b/tests/release-gate/runner.ts
@@ -183,7 +183,7 @@ export function loadReleaseGateCorpus(): ReleaseGateCorpus {
   const parsed = JSON.parse(readFileSync(corpusPath, "utf8")) as ReleaseGateCorpus;
   assert.equal(parsed.schemaVersion, 1, "unsupported release gate corpus schema");
   assert.ok(parsed.corpusVersion, "release gate corpus version is required");
-  assert.equal(parsed.runtimeContract, "v0.0.3");
+  assert.equal(parsed.runtimeContract, "v0.1.6");
   assert.ok(Array.isArray(parsed.workflows) && parsed.workflows.length > 0, "release gate workflows are required");
   const ids = new Set<string>();
   for (const workflow of parsed.workflows) {

--- a/tests/release-gate/runner.ts
+++ b/tests/release-gate/runner.ts
@@ -655,7 +655,16 @@ async function collectHeadedNativeEvidence(
   const workflows = await readHeadedEvidence(manifest, evidenceDirectory);
   const attempted = workflows.some((workflow) => workflow.status !== "unrun");
   const failed = workflows.some((workflow) => workflow.status === "failed");
-  const status: EvidenceStatus = failed ? "failed" : attempted ? "verified" : "unrun";
+  const expectedWorkflows = workflows.filter((workflow) => {
+    const manifestWorkflow = manifest.workflows.find((candidate) => candidate.id === workflow.workflowId);
+    return (manifestWorkflow?.evidenceTypes.length ?? 0) > 0;
+  });
+  const complete = expectedWorkflows.length > 0 && expectedWorkflows.every((workflow) => workflow.status === "verified");
+  const status: EvidenceStatus = failed || attempted && !complete
+    ? "failed"
+    : complete
+      ? "verified"
+      : "unrun";
   return {
     tier: "headed-native",
     status,

--- a/tests/release-gate/runner.ts
+++ b/tests/release-gate/runner.ts
@@ -32,6 +32,7 @@ import {
   type ReleaseProvenanceInput,
   type ReleaseProvenanceReport,
 } from "./native-editing.js";
+import { unrunRepositoryChecks, type RepositoryChecksReport } from "./repository-checks.js";
 
 const corpusPath = fileURLToPath(new URL("./corpus.json", import.meta.url));
 const requiredFillerCases = [
@@ -121,12 +122,14 @@ export interface ReleaseGateReport {
   evidenceTiers: ReleaseGateEvidenceTiers;
   workflowMatrix: ReleaseGateWorkflowMatrixEntry[];
   provenance: ReleaseProvenanceReport;
+  repositoryChecks: RepositoryChecksReport;
 }
 
 export interface RunReleaseGateOptions {
   generatedAt?: string;
   headedEvidenceDirectory?: string;
   provenance?: Partial<ReleaseProvenanceInput>;
+  repositoryChecks?: RepositoryChecksReport;
 }
 
 export interface ReleaseGateWorkflowMatrixEntry {
@@ -273,6 +276,7 @@ export async function runReleaseGate(options: RunReleaseGateOptions = {}): Promi
     evidenceTiers,
     workflowMatrix: buildWorkflowMatrix(manifest, evidenceTiers),
     provenance,
+    repositoryChecks: options.repositoryChecks ?? unrunRepositoryChecks(),
   } satisfies ReleaseGateReport;
   return report;
 }

--- a/tests/release-gate/runner.ts
+++ b/tests/release-gate/runner.ts
@@ -128,7 +128,7 @@ export interface ReleaseGateReport {
 export interface RunReleaseGateOptions {
   generatedAt?: string;
   headedEvidenceDirectory?: string;
-  provenance?: Partial<ReleaseProvenanceInput>;
+  provenance?: Partial<Omit<ReleaseProvenanceInput, "packageManifest" | "pluginManifest" | "serverVersion">>;
   repositoryChecks?: RepositoryChecksReport;
 }
 
@@ -236,10 +236,10 @@ export async function runReleaseGate(options: RunReleaseGateOptions = {}): Promi
     version?: string;
   };
   const provenance = assessReleaseProvenance({
+    ...options.provenance,
     packageManifest,
     pluginManifest,
     serverVersion: FRAMEKIT_VERSION,
-    ...options.provenance,
   });
   const report = {
     schemaVersion: 1,

--- a/tests/release-gate/runner.ts
+++ b/tests/release-gate/runner.ts
@@ -295,7 +295,7 @@ export function renderReleaseGateReport(report: ReleaseGateReport): string {
     `metadata_only_status=${report.evidenceTiers["metadata-only"].status}`,
     `canonical_live_status=${report.evidenceTiers["canonical-live"].status}`,
     `headed_native_status=${report.evidenceTiers["headed-native"].status}`,
-    `release_ready=${report.provenance.releaseReady}`,
+    `provenance_ready=${report.provenance.releaseReady}`,
   ].join("\n");
 }
 


### PR DESCRIPTION
Closes: #186

## Summary

Adds the repository-owned v0.1.6 native-editing release gate with a versioned
manifest and workflow matrix for canonical live editing, picture-in-picture,
built-in title discovery, masking, filler removal, and dialogue normalization.

The gate reports deterministic fixture, FCPXML artifact, metadata-only,
canonical-live, and opt-in headed-native evidence independently. It records
safe capability preflight, target, revision, verification, restoration,
repository-check, and release-provenance summaries.

The release workflow now validates the gate, package/plugin alignment, and
downloaded native Workflow Extension archive/checksum before publishing the
GitHub release.

## Validation

Passed:

```text
pnpm install --frozen-lockfile
pnpm run build
pnpm run test                 # 619 tests passed
pnpm run evaluate             # 18 scenarios passed
pnpm run check:boundaries
pnpm run build:package
node scripts/validate-mcp-server-version.mjs
pnpm run release-gate --output-dir <temporary-directory>
```

The release-gate smoke run reported deterministic, FCPXML artifact, and
metadata-only evidence verified; canonical-live unsupported; headed-native
unrun; and all five repository checks verified.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Public release-gate and CLI behavior is covered by focused tests and docs.
- [x] Existing corpus and adapter contracts remain compatible; the speech corpus is versioned for v0.1.6.

## Safety

- [x] Headed evidence is opt-in and incomplete headed evidence fails closed.
- [x] Unsupported and unrun states remain distinct from verified evidence.
- [x] Published summaries omit private paths, credentials, native handles, operation IDs, source identities, and raw diagnostics.
- [x] Native release archives and checksums are verified before public release.
- [x] No credentials, private media, raw crash dumps, or generated build artifacts were added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Process**
  - Releases now require native-editing validation, repository checks, and verified native assets with matching SHA-256 checksums before publication.
  - Release evidence is uploaded for review and includes workflow, capability, and provenance status.

- **Documentation**
  - Updated compatibility, testing, and release guidance for the v0.1.6 native-editing release gate.
  - Documented evidence tiers, supported capability boundaries, validation commands, and release-readiness requirements.

- **Quality Improvements**
  - Expanded validation coverage for native editing workflows, rollback evidence, release artifacts, and checksum verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->