### PR TITLE
feat: produce sanitized headed-native evidence

### DIFF
--- a/docs/tests/release-gate.md
+++ b/docs/tests/release-gate.md
@@ -53,8 +53,8 @@ pnpm run test:final-cut-filler-headed > artifacts/final-cut-headed/filler-remova
 
 Supply the workflow-specific disposable project, query, range, and explicit
 mutation-consent variables documented in [Final Cut live E2E](./final-cut-live-e2e.md).
-Every runner emits an allowlisted sanitized record containing its exact project
-and sequence target, a stable occurrence identity where applicable, Framekit
+Every runner emits an allowlisted sanitized record containing its exact project,
+sequence, and occurrence target, Framekit
 and Final Cut versions, the full Git commit, before/after/restored revisions,
 verification, and native Undo or rollback. The record omits private paths,
 credentials, native handles, transaction IDs, raw snapshots, and diagnostics.

--- a/docs/tests/release-gate.md
+++ b/docs/tests/release-gate.md
@@ -42,6 +42,8 @@ The headed-native tier claims exactly five workflows. Run each command against
 its own disposable Final Cut project, redirecting stdout to a fresh JSON file:
 
 ```sh
+mkdir -p artifacts/final-cut-headed
+
 pnpm run test:final-cut-canonical-headed > artifacts/final-cut-headed/canonical-live.json
 pnpm run test:final-cut-pip-headed > artifacts/final-cut-headed/picture-in-picture.json
 pnpm run test:final-cut-title-headed > artifacts/final-cut-headed/built-in-title-discovery.json

--- a/docs/tests/release-gate.md
+++ b/docs/tests/release-gate.md
@@ -36,6 +36,39 @@ The headed runners must be invoked separately with the required disposable
 project and consent configuration. Their JSON output can then be supplied to
 the gate; no headed UI mutation occurs by default.
 
+### Required headed-native evidence bundle
+
+The headed-native tier claims exactly five workflows. Run each command against
+its own disposable Final Cut project, redirecting stdout to a fresh JSON file:
+
+```sh
+pnpm run test:final-cut-canonical-headed > artifacts/final-cut-headed/canonical-live.json
+pnpm run test:final-cut-pip-headed > artifacts/final-cut-headed/picture-in-picture.json
+pnpm run test:final-cut-title-headed > artifacts/final-cut-headed/built-in-title-discovery.json
+pnpm run test:final-cut-masking-headed > artifacts/final-cut-headed/masking.json
+pnpm run test:final-cut-filler-headed > artifacts/final-cut-headed/filler-removal.json
+```
+
+Supply the workflow-specific disposable project, query, range, and explicit
+mutation-consent variables documented in [Final Cut live E2E](./final-cut-live-e2e.md).
+Every runner emits an allowlisted sanitized record containing its exact project
+and sequence target, a stable occurrence identity where applicable, Framekit
+and Final Cut versions, the full Git commit, before/after/restored revisions,
+verification, and native Undo or rollback. The record omits private paths,
+credentials, native handles, transaction IDs, raw snapshots, and diagnostics.
+
+Then run the gate with that directory:
+
+```sh
+pnpm run release-gate \
+  --output-dir artifacts/release-gate/headed-run \
+  --headed-evidence-dir artifacts/final-cut-headed
+```
+
+Completion requires the summary to report both
+`headed-native=verified` and `headed_native_status=verified`. Missing, failed,
+or unavailable workflows keep the tier failed or unrun. `dialogue-normalization` remains explicitly non-native because no headed runner is registered for it.
+
 ## Evidence tiers
 
 | Tier | Mode | Guarantee | Default status |

--- a/scripts/final-cut-evidence.d.mts
+++ b/scripts/final-cut-evidence.d.mts
@@ -1,4 +1,4 @@
-export function evidenceEnvironment(root: string): Promise<{
+export interface EvidenceEnvironment {
   framekitVersion: string;
   finalCutVersion: string;
   gitCommit: string;
@@ -6,39 +6,21 @@ export function evidenceEnvironment(root: string): Promise<{
   platform: string;
   architecture: string;
   osVersion: string;
-}>;
+}
 
-export function sanitizeCanonicalEvidence(run: unknown, environment: {
-  framekitVersion: string;
-  finalCutVersion: string;
-  gitCommit: string;
-  nodeVersion: string;
-  platform: string;
-  architecture: string;
-  osVersion: string;
-}): unknown;
+export function evidenceEnvironment(root: string): Promise<EvidenceEnvironment>;
 
-export function sanitizeDisposableNativeEvidence(run: unknown, environment: {
-  framekitVersion: string;
-  finalCutVersion: string;
-  gitCommit: string;
-  nodeVersion: string;
-  platform: string;
-  architecture: string;
-  osVersion: string;
-}): {
+export function sanitizeCanonicalEvidence(run: unknown, environment: EvidenceEnvironment): unknown;
+
+export function sanitizeDisposableNativeEvidence(run: unknown, environment: EvidenceEnvironment): {
   evidenceType: string;
   mutation: { operation: string; status: string };
   restoration: { restored: boolean };
   toolResults: unknown[];
 };
 
-export function sanitizeCanonicalReadEvidence(run: unknown, environment: {
-  framekitVersion: string;
-  finalCutVersion: string;
-  gitCommit: string;
-  nodeVersion: string;
-  platform: string;
-  architecture: string;
-  osVersion: string;
-}): unknown;
+export function sanitizePictureInPictureEvidence(run: unknown, environment: EvidenceEnvironment): any;
+export function sanitizeNativeTitleEvidence(run: unknown, environment: EvidenceEnvironment): any;
+export function sanitizeMaskEvidence(run: unknown, environment: EvidenceEnvironment): any;
+export function sanitizeFillerRemovalEvidence(run: unknown, environment: EvidenceEnvironment): any;
+export function sanitizeCanonicalReadEvidence(run: unknown, environment: EvidenceEnvironment): unknown;

--- a/scripts/final-cut-evidence.mjs
+++ b/scripts/final-cut-evidence.mjs
@@ -254,6 +254,169 @@ export function sanitizeDisposableNativeEvidence(run, environment) {
   };
 }
 
+export function sanitizePictureInPictureEvidence(run, environment) {
+  assert(run?.passed === true, "headed picture-in-picture run did not pass");
+  assert(run.editor, "editor identity is missing");
+  assert(run.target && run.placement, "picture-in-picture target or placement is missing");
+  const target = {
+    project: requireString(run.target.project ?? run.placement.project, "picture-in-picture project"),
+    sequenceId: requireString(run.target.sequenceId, "picture-in-picture sequence id"),
+    occurrenceId: requireString(run.target.occurrenceId, "picture-in-picture occurrence id"),
+    ...(isNonEmptyString(run.target.occurrenceName) ? { occurrenceName: run.target.occurrenceName } : {}),
+    ...(isNonEmptyString(run.target.start) ? { start: run.target.start } : {}),
+    ...(isNonEmptyString(run.target.duration) ? { duration: run.target.duration } : {}),
+  };
+  const revisions = summarizeWorkflowRevisions(run.placement, "picture-in-picture");
+  assert(run.placement.observed, "picture-in-picture readback is missing");
+  assert(run.placement.undoVerified?.verified === true || run.placement.undo?.verified === true, "picture-in-picture Undo verification is missing");
+  return {
+    schemaVersion: 1,
+    evidenceType: "headed-native-picture-in-picture",
+    passed: true,
+    recordedAt: requireString(run.recordedAt, "recordedAt"),
+    environment: sanitizeEnvironment(environment),
+    editor: sanitizeIdentity(run.editor),
+    capabilities: sanitizeBooleanCapabilities(run.capabilities, ["nativePictureInPicture", "nativeUndo", "nativeTimelineOccurrenceLocate"]),
+    target,
+    placement: {
+      requested: sanitizePictureInPictureProperties(run.placement.requested ?? run.placement),
+      observed: sanitizePictureInPictureProperties(run.placement.observed),
+    },
+    revisions,
+    verification: { execute: true, undo: true },
+    ...(run.toolResults ? { toolResults: sanitizeToolResultList(run.toolResults) } : {}),
+    sanitization: {
+      strategy: "allowlisted-summary",
+      omitted: ["media sources", "native handles", "operation identifiers", "raw diagnostics"],
+    },
+  };
+}
+
+export function sanitizeNativeTitleEvidence(run, environment) {
+  assert(run?.passed === true, "headed title run did not pass");
+  assert(run.discovery && run.placement, "title discovery or placement is missing");
+  assert(run.target, "title target is missing");
+  assert(run.placement.verified === true, "native title placement was not verified");
+  assert(run.placement.undo?.verified === true, "native title Undo verification is missing");
+  const assetId = requireSafeIdentity(run.discovery.id, "native title asset id");
+  assert(assetId.startsWith("final-cut:title:"), "native title asset must be provider-qualified");
+  const target = {
+    project: requireString(run.project ?? run.target.project, "native title project"),
+    sequenceId: requireString(run.target.sequenceId, "native title sequence id"),
+  };
+  return {
+    schemaVersion: 1,
+    evidenceType: "headed-native-title-discovery-and-placement",
+    passed: true,
+    recordedAt: requireString(run.recordedAt, "recordedAt"),
+    environment: sanitizeEnvironment(environment),
+    target,
+    discovery: {
+      assetId,
+      name: requireString(run.discovery.name, "native title name"),
+      vendor: requireString(run.discovery.vendor, "native title vendor"),
+      backend: requireString(run.discovery.backend, "native title discovery backend"),
+      guarantee: requireString(run.discovery.guarantee, "native title discovery guarantee"),
+    },
+    placement: {
+      text: requireString(run.placement.text, "native title text"),
+      target: requireString(run.placement.target, "native title placement target"),
+      start: sanitizeRational(run.placement.start, "native title start"),
+      duration: sanitizeRational(run.placement.duration, "native title duration"),
+    },
+    revisions: summarizeWorkflowRevisions(run.placement, "native title"),
+    verification: { execute: true, undo: true },
+    ...(run.toolResults ? { toolResults: sanitizeToolResultList(run.toolResults) } : {}),
+    sanitization: {
+      strategy: "allowlisted-summary",
+      omitted: ["native handles", "operation identifiers", "raw diagnostics"],
+    },
+  };
+}
+
+export function sanitizeMaskEvidence(run, environment) {
+  assert(run?.passed === true, "headed masking run did not pass");
+  assert(run.target && run.mask, "mask target or configuration is missing");
+  assert(run.verification?.execute?.verified === true, "native mask placement was not verified");
+  assert(run.verification?.undo?.verified === true, "native mask Undo verification is missing");
+  const target = {
+    project: requireString(run.project ?? run.target.project, "native mask project"),
+    sequenceId: requireString(run.target.sequenceId, "native mask sequence id"),
+    occurrenceId: requireString(run.target.occurrenceId, "native mask occurrence id"),
+    ...(isNonEmptyString(run.target.occurrenceName) ? { occurrenceName: run.target.occurrenceName } : {}),
+    ...(isNonEmptyString(run.target.start) ? { start: run.target.start } : {}),
+    ...(isNonEmptyString(run.target.duration) ? { duration: run.target.duration } : {}),
+  };
+  return {
+    schemaVersion: 1,
+    evidenceType: "headed-native-mask-placement",
+    passed: true,
+    recordedAt: requireString(run.recordedAt, "recordedAt"),
+    environment: sanitizeEnvironment(environment),
+    target,
+    mask: {
+      requested: sanitizeMaskConfiguration(run.mask.requested, "requested mask"),
+      observed: sanitizeMaskConfiguration(run.mask.observed, "observed mask"),
+    },
+    revisions: summarizeWorkflowRevisions(run.revisions ?? run, "native mask"),
+    verification: { execute: true, undo: true },
+    ...(run.toolResults ? { toolResults: sanitizeToolResultList(run.toolResults) } : {}),
+    sanitization: {
+      strategy: "allowlisted-summary",
+      omitted: ["raw native contexts", "media paths", "native handles", "operation identifiers", "raw diagnostics"],
+    },
+  };
+}
+
+export function sanitizeFillerRemovalEvidence(run, environment) {
+  assert(run?.passed === true, "headed filler-removal run did not pass");
+  assert(run.editor && run.project && run.removal && run.restoration, "filler-removal evidence is incomplete");
+  assert(run.removal.status === "VERIFIED", "filler-removal mutation was not verified");
+  assert(run.restoration.restored === true && run.restoration.status === "VERIFIED", "filler-removal Undo was not verified");
+  const project = {
+    id: requireString(run.project.id, "filler-removal project id"),
+    name: requireString(run.project.name, "filler-removal project name"),
+    sequenceId: requireString(run.project.sequenceId, "filler-removal sequence id"),
+  };
+  const revisions = {
+    before: requireString(run.removal.beforeRevision?.id, "filler-removal before revision"),
+    after: requireString(run.removal.afterRevision?.id, "filler-removal after revision"),
+    restored: requireString(run.restoration.restoredRevision?.id, "filler-removal restored revision"),
+  };
+  assert(revisions.before !== revisions.after, "filler-removal revision did not advance");
+  return {
+    schemaVersion: 1,
+    evidenceType: "headed-native-filler-removal",
+    passed: true,
+    recordedAt: requireString(run.recordedAt, "recordedAt"),
+    environment: sanitizeEnvironment(environment),
+    editor: sanitizeIdentity(run.editor),
+    capabilities: sanitizeCapabilities(run.capabilities),
+    project,
+    target: { project: project.name, projectId: project.id, sequenceId: project.sequenceId },
+    selection: {
+      start: requireFiniteNumber(run.selection.start, "filler-removal selection start"),
+      end: requireFiniteNumber(run.selection.end, "filler-removal selection end"),
+    },
+    removal: {
+      status: run.removal.status,
+      candidateCount: requireNonNegativeInteger(run.removal.candidateCount, "filler-removal candidate count"),
+      operationCount: requireNonNegativeInteger(run.removal.operationCount, "filler-removal operation count"),
+      removedDurationSeconds: requireFiniteNumber(run.removal.removedDurationSeconds, "filler-removal duration"),
+      affectedRangeCount: requireNonNegativeInteger(run.removal.affectedRangeCount, "filler-removal affected range count"),
+      continuityVerified: run.removal.continuityVerified === true,
+    },
+    revisions,
+    restoration: { status: "VERIFIED", restored: true },
+    verification: { execute: true, undo: true },
+    toolResults: sanitizeToolResultList(run.toolResults),
+    sanitization: {
+      strategy: "allowlisted-summary",
+      omitted: ["media sources", "raw snapshots", "transaction identifiers", "raw diagnostics"],
+    },
+  };
+}
+
 export function sanitizeCanonicalReadEvidence(run, environment) {
   assert(run?.passed === true, "headed read did not pass");
   assert(run.editor, "editor identity is missing");
@@ -370,6 +533,103 @@ function validateReadSnapshot(snapshot) {
     return clip.id;
   });
   return snapshot;
+}
+
+function summarizeWorkflowRevisions(value, label) {
+  const before = revisionIdentity(value.before ?? value.beforeRevision);
+  const after = revisionIdentity(value.after ?? value.afterRevision);
+  const restored = revisionIdentity(value.restored ?? value.restoredRevision ?? value.undoRevision);
+  return {
+    before: requireString(before, `${label} before revision`),
+    after: requireString(after, `${label} after revision`),
+    restored: requireString(restored, `${label} restored revision`),
+  };
+}
+
+function revisionIdentity(value) {
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object" && typeof value.id === "string") return value.id;
+  return undefined;
+}
+
+function sanitizeBooleanCapabilities(value, keys) {
+  const result = {};
+  for (const key of keys) {
+    if (value?.[key] !== undefined) assert(typeof value[key] === "boolean", `${key} capability must be boolean`);
+    if (value?.[key] !== undefined) result[key] = value[key];
+  }
+  return result;
+}
+
+function sanitizePictureInPictureProperties(value) {
+  assert(value && typeof value === "object" && !Array.isArray(value), "picture-in-picture properties are missing");
+  const result = {};
+  if (value.start !== undefined) result.start = sanitizeRational(value.start, "picture-in-picture start");
+  if (value.duration !== undefined) result.duration = sanitizeRational(value.duration, "picture-in-picture duration");
+  if (value.position !== undefined) {
+    assertFiniteNumber(value.position.x, "picture-in-picture position x");
+    assertFiniteNumber(value.position.y, "picture-in-picture position y");
+    result.position = { x: value.position.x, y: value.position.y };
+  }
+  if (value.scale !== undefined) {
+    assertFiniteNumber(value.scale, "picture-in-picture scale");
+    result.scale = value.scale;
+  }
+  if (value.frame !== undefined) {
+    assert(value.frame && value.frame.style === "solid", "picture-in-picture frame style must be solid");
+    assert(typeof value.frame.color === "string" && /^#[0-9a-f]{6}$/i.test(value.frame.color), "picture-in-picture frame color is invalid");
+    assertFiniteNumber(value.frame.width, "picture-in-picture frame width");
+    result.frame = { style: "solid", color: value.frame.color.toUpperCase(), width: value.frame.width };
+  }
+  if (value.crop !== undefined) result.crop = sanitizeCrop(value.crop);
+  assert(Object.keys(result).length > 0, "picture-in-picture properties are empty");
+  return result;
+}
+
+function sanitizeMaskConfiguration(value, label) {
+  assert(value?.mode === "rectangle", `${label} mode must be rectangle`);
+  return { mode: "rectangle", bounds: sanitizeBounds(value.bounds, `${label} bounds`) };
+}
+
+function sanitizeCrop(value) {
+  assert(value && typeof value === "object", "picture-in-picture crop is missing");
+  const crop = { top: value.top, right: value.right, bottom: value.bottom, left: value.left };
+  for (const [key, child] of Object.entries(crop)) assertFiniteNumber(child, `picture-in-picture crop ${key}`);
+  return crop;
+}
+
+function sanitizeBounds(value, label) {
+  assert(value && typeof value === "object", `${label} is missing`);
+  const bounds = { x: value.x, y: value.y, width: value.width, height: value.height };
+  for (const [key, child] of Object.entries(bounds)) assertFiniteNumber(child, `${label} ${key}`);
+  return bounds;
+}
+
+function sanitizeRational(value, label) {
+  if (typeof value === "string") {
+    assert(/^\d+\/\d+$/.test(value), `${label} must use rational value/timescale form`);
+    return value;
+  }
+  assert(value && /^\d+$/.test(value.value) && /^\d+$/.test(value.timescale) && BigInt(value.timescale) > 0n, `${label} must use rational value/timescale form`);
+  return `${value.value}/${value.timescale}`;
+}
+
+function sanitizeToolResultList(value) {
+  assert(Array.isArray(value) && value.length > 0, "tool results are missing");
+  return value.map((result) => ({
+    name: requireSafeIdentity(result?.name, "tool name"),
+    status: requireSafeIdentity(result?.status, "tool status"),
+  }));
+}
+
+function requireSafeIdentity(value, label) {
+  const result = requireString(value, label);
+  assert(!result.includes("/") && !result.includes("\\") && !result.startsWith("~"), `${label} must not be path-like`);
+  return result;
+}
+
+function assertFiniteNumber(value, label) {
+  assert(typeof value === "number" && Number.isFinite(value), `${label} must be a finite number`);
 }
 
 function validateReadCoordinates(value, field) {

--- a/scripts/final-cut-evidence.mjs
+++ b/scripts/final-cut-evidence.mjs
@@ -609,7 +609,8 @@ function sanitizeBounds(value, label) {
 
 function sanitizeRational(value, label) {
   if (typeof value === "string") {
-    assert(/^\d+\/\d+$/.test(value), `${label} must use rational value/timescale form`);
+    const match = /^(\d+)\/(\d+)$/.exec(value);
+    assert(match && BigInt(match[2]) > 0n, `${label} must use rational value/timescale form`);
     return value;
   }
   assert(value && /^\d+$/.test(value.value) && /^\d+$/.test(value.timescale) && BigInt(value.timescale) > 0n, `${label} must use rational value/timescale form`);

--- a/scripts/final-cut-evidence.mjs
+++ b/scripts/final-cut-evidence.mjs
@@ -557,8 +557,8 @@ function revisionIdentity(value) {
 function sanitizeBooleanCapabilities(value, keys) {
   const result = {};
   for (const key of keys) {
-    if (value?.[key] !== undefined) assert(typeof value[key] === "boolean", `${key} capability must be boolean`);
-    if (value?.[key] !== undefined) result[key] = value[key];
+    assert(value?.[key] === true, `${key} capability is required`);
+    result[key] = true;
   }
   return result;
 }

--- a/scripts/final-cut-evidence.mjs
+++ b/scripts/final-cut-evidence.mjs
@@ -303,6 +303,7 @@ export function sanitizeNativeTitleEvidence(run, environment) {
   const target = {
     project: requireString(run.project ?? run.target.project, "native title project"),
     sequenceId: requireString(run.target.sequenceId, "native title sequence id"),
+    occurrenceId: requireSafeIdentity(run.target.occurrenceId, "native title occurrence id"),
   };
   return {
     schemaVersion: 1,
@@ -378,6 +379,10 @@ export function sanitizeFillerRemovalEvidence(run, environment) {
     id: requireString(run.project.id, "filler-removal project id"),
     name: requireString(run.project.name, "filler-removal project name"),
     sequenceId: requireString(run.project.sequenceId, "filler-removal sequence id"),
+    occurrenceId: requireSafeIdentity(
+      run.project.occurrenceId ?? run.target?.occurrenceId,
+      "filler-removal occurrence id",
+    ),
   };
   const revisions = {
     before: requireString(run.removal.beforeRevision?.id, "filler-removal before revision"),
@@ -394,7 +399,12 @@ export function sanitizeFillerRemovalEvidence(run, environment) {
     editor: sanitizeIdentity(run.editor),
     capabilities: sanitizeCapabilities(run.capabilities),
     project,
-    target: { project: project.name, projectId: project.id, sequenceId: project.sequenceId },
+    target: {
+      project: project.name,
+      projectId: project.id,
+      sequenceId: project.sequenceId,
+      occurrenceId: project.occurrenceId,
+    },
     selection: {
       start: requireFiniteNumber(run.selection.start, "filler-removal selection start"),
       end: requireFiniteNumber(run.selection.end, "filler-removal selection end"),

--- a/scripts/final-cut-evidence.mjs
+++ b/scripts/final-cut-evidence.mjs
@@ -537,13 +537,14 @@ function validateReadSnapshot(snapshot) {
 }
 
 function summarizeWorkflowRevisions(value, label) {
-  const before = revisionIdentity(value.before ?? value.beforeRevision);
-  const after = revisionIdentity(value.after ?? value.afterRevision);
-  const restored = revisionIdentity(value.restored ?? value.restoredRevision ?? value.undoRevision);
+  const before = requireString(revisionIdentity(value.before ?? value.beforeRevision), `${label} before revision`);
+  const after = requireString(revisionIdentity(value.after ?? value.afterRevision), `${label} after revision`);
+  const restored = requireString(revisionIdentity(value.restored ?? value.restoredRevision ?? value.undoRevision), `${label} restored revision`);
+  assert(before !== after, `${label} revision did not advance`);
   return {
-    before: requireString(before, `${label} before revision`),
-    after: requireString(after, `${label} after revision`),
-    restored: requireString(restored, `${label} restored revision`),
+    before,
+    after,
+    restored,
   };
 }
 

--- a/scripts/final-cut-evidence.mjs
+++ b/scripts/final-cut-evidence.mjs
@@ -372,6 +372,7 @@ export function sanitizeFillerRemovalEvidence(run, environment) {
   assert(run?.passed === true, "headed filler-removal run did not pass");
   assert(run.editor && run.project && run.removal && run.restoration, "filler-removal evidence is incomplete");
   assert(run.removal.status === "VERIFIED", "filler-removal mutation was not verified");
+  assert(run.removal.continuityVerified === true, "filler-removal continuity was not verified");
   assert(run.restoration.restored === true && run.restoration.status === "VERIFIED", "filler-removal Undo was not verified");
   const project = {
     id: requireString(run.project.id, "filler-removal project id"),

--- a/scripts/final-cut-filler-removal-headed-e2e.mjs
+++ b/scripts/final-cut-filler-removal-headed-e2e.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { promisify } from "node:util";
 import { createHash } from "node:crypto";
+import { sanitizeFillerRemovalEvidence } from "./final-cut-evidence.mjs";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const execFile = promisify(execFileCallback);
@@ -91,7 +92,7 @@ try {
     throw new Error("FINAL_CUT_E2E_ROLLBACK_DIGEST_MISMATCH: undo did not restore the pre-edit canonical digest");
   }
 
-  const evidence = {
+  const rawEvidence = {
     schemaVersion: 1,
     evidenceType: "headed-native-filler-removal",
     passed: true,
@@ -133,6 +134,7 @@ try {
       omitted: ["media sources", "raw snapshots", "transaction identifiers", "diagnostics"],
     },
   };
+  const evidence = sanitizeFillerRemovalEvidence(rawEvidence, rawEvidence.environment);
   process.stdout.write(`${JSON.stringify(evidence, null, 2)}\n`);
 } catch (error) {
   if (canUndo && transactionId) {

--- a/scripts/final-cut-filler-removal-headed-e2e.mjs
+++ b/scripts/final-cut-filler-removal-headed-e2e.mjs
@@ -66,6 +66,11 @@ try {
   if (!Array.isArray(preview.candidates) || preview.candidates.length === 0) {
     throw new Error("FINAL_CUT_E2E_NO_FILLERS: the disposable range contains no high-confidence fillers");
   }
+  const occurrenceIds = [...new Set(preview.candidates.map((candidate) => candidate.clipId).filter(Boolean))];
+  if (occurrenceIds.length !== 1) {
+    throw new Error("FINAL_CUT_E2E_OCCURRENCE_AMBIGUOUS: filler range must resolve to exactly one timeline occurrence");
+  }
+  const occurrenceId = occurrenceIds[0];
 
   const transaction = await callJson("speech.filler.remove.execute", { previewToken: preview.previewToken });
   toolResults.push({ name: "speech.filler.remove.execute", status: transaction.status });
@@ -108,6 +113,7 @@ try {
       id: before.projectId,
       name: before.projectName,
       sequenceId: before.timeline.id,
+      occurrenceId,
     },
     selection: { start, end },
     toolResults,

--- a/scripts/final-cut-masking-headed-e2e.mjs
+++ b/scripts/final-cut-masking-headed-e2e.mjs
@@ -2,7 +2,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { evidenceEnvironment } from "./final-cut-evidence.mjs";
+import { evidenceEnvironment, sanitizeMaskEvidence } from "./final-cut-evidence.mjs";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const expectedProject = process.env.FRAMEKIT_FINAL_CUT_E2E_PROJECT;
@@ -81,13 +81,10 @@ try {
   }
   operationId = undefined;
 
-  const environment = await evidenceEnvironment(root);
-  process.stdout.write(`${JSON.stringify({
-    schemaVersion: 1,
+  const evidence = sanitizeMaskEvidence({
     evidenceType: "headed-native-mask-placement",
     passed: true,
     recordedAt: new Date().toISOString(),
-    environment,
     project: expectedProject,
     target: summarizeOccurrence(preview.occurrence),
     mask: {
@@ -109,7 +106,8 @@ try {
       strategy: "allowlisted-summary",
       omitted: ["raw native contexts", "media paths", "operation handles", "diagnostics"],
     },
-  }, null, 2)}\n`);
+  }, await evidenceEnvironment(root));
+  process.stdout.write(`${JSON.stringify(evidence, null, 2)}\n`);
 } catch (error) {
   if (operationId) {
     try {
@@ -175,6 +173,7 @@ function sameMask(left, right) {
 
 function summarizeOccurrence(occurrence) {
   return {
+    occurrenceId: occurrence.identity,
     name: occurrence.name,
     start: occurrence.start,
     duration: occurrence.duration,

--- a/scripts/final-cut-picture-in-picture-headed-e2e.mjs
+++ b/scripts/final-cut-picture-in-picture-headed-e2e.mjs
@@ -2,7 +2,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { evidenceEnvironment } from "./final-cut-evidence.mjs";
+import { evidenceEnvironment, sanitizePictureInPictureEvidence } from "./final-cut-evidence.mjs";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const expectedProject = process.env.FRAMEKIT_FINAL_CUT_E2E_PROJECT;
@@ -42,11 +42,14 @@ const transport = new StdioClientTransport({
   stderr: "pipe",
 });
 const client = new Client({ name: "framekit-picture-in-picture-headed-e2e", version: "0.1.0" });
+let operationId;
 
 try {
+  const toolResults = [];
   await client.connect(transport);
   const editor = await callJson("editor.inspect");
-  if (editor.identity?.name !== "Final Cut Pro" && editor.identity?.backend !== "final-cut-live") {
+  toolResults.push({ name: "editor.inspect", status: "passed" });
+  if (editor.identity?.name !== "Final Cut Pro" || editor.identity?.backend !== "final-cut-live") {
     throw new Error("FINAL_CUT_E2E_EDITOR_MISMATCH: expected the Final Cut live editor");
   }
   if (editor.native?.pictureInPicture !== true) {
@@ -54,6 +57,7 @@ try {
   }
 
   const focused = await callJson("editor.native.focus");
+  toolResults.push({ name: "editor.native.focus", status: "passed" });
   if (!focused.available || !focused.frontmost || !focused.timelineFocused) {
     throw new Error(`FINAL_CUT_NATIVE_NOT_READY: ${focused.error?.code ?? "timeline focus failed"}`);
   }
@@ -62,23 +66,28 @@ try {
   }
 
   const anchorMatches = await callJson("editor.native.media.search", { query: anchorQuery });
+  toolResults.push({ name: "editor.native.media.search", status: "passed" });
   if (!Array.isArray(anchorMatches) || anchorMatches.length !== 1) {
     throw new Error("FINAL_CUT_E2E_ANCHOR_MEDIA_AMBIGUOUS: anchor query must return exactly one Browser result");
   }
   const anchorMedia = anchorMatches[0];
   await callJson("editor.native.media.select", { mediaHandle: anchorMedia.handle });
+  toolResults.push({ name: "editor.native.media.select", status: "passed" });
   const located = await callJson("editor.native.timeline.locate", { mediaHandle: anchorMedia.handle });
+  toolResults.push({ name: "editor.native.timeline.locate", status: "passed" });
   if (located.status !== "unique" || located.occurrences?.length !== 1) {
     throw new Error("FINAL_CUT_E2E_ANCHOR_OCCURRENCE_AMBIGUOUS: anchor query must locate exactly one timeline occurrence");
   }
   const anchorOccurrence = located.occurrences[0];
 
   const pipMatches = await callJson("editor.native.media.search", { query: pipQuery });
+  toolResults.push({ name: "editor.native.media.search", status: "passed" });
   if (!Array.isArray(pipMatches) || pipMatches.length !== 1) {
     throw new Error("FINAL_CUT_E2E_PIP_MEDIA_AMBIGUOUS: PIP query must return exactly one Browser result");
   }
   const pipMedia = pipMatches[0];
   await callJson("editor.native.media.select", { mediaHandle: pipMedia.handle });
+  toolResults.push({ name: "editor.native.media.select", status: "passed" });
   const preview = await callJson("editor.native.picture-in-picture.preview", {
     mediaHandle: pipMedia.handle,
     anchorOccurrenceHandle: anchorOccurrence.handle,
@@ -88,11 +97,14 @@ try {
     scale: 0.35,
     frame: { style: "solid", color: "#FFFFFF", width: 8 },
   });
+  toolResults.push({ name: "editor.native.picture-in-picture.preview", status: "passed" });
   if (!preview.previewToken || preview.anchorOccurrence?.handle !== anchorOccurrence.handle) {
     throw new Error("FINAL_CUT_E2E_PIP_PREVIEW_FAILED: preview did not preserve stable native bindings");
   }
 
   const executed = await callJson("editor.native.picture-in-picture.execute", { previewToken: preview.previewToken });
+  toolResults.push({ name: "editor.native.picture-in-picture.execute", status: executed.verification?.verified ? "passed" : "failed" });
+  operationId = executed.operationId;
   if (!executed.verification?.verified || executed.afterRevision?.id === executed.beforeRevision?.id) {
     throw new Error("FINAL_CUT_E2E_PIP_EXECUTE_FAILED: native placement was not verified");
   }
@@ -103,46 +115,55 @@ try {
     throw new Error("FINAL_CUT_E2E_PIP_FRAME_READBACK_FAILED: white frame was not read back");
   }
 
-  const undone = await callJson("editor.native.undo", { operationId: executed.operationId });
+  const undone = await callJson("editor.native.undo", { operationId });
+  toolResults.push({ name: "editor.native.undo", status: undone.verification?.verified === true ? "passed" : "failed" });
   if (!undone.undone || undone.verification?.verified !== true) {
     throw new Error("FINAL_CUT_E2E_PIP_UNDO_FAILED: native Undo did not verify");
   }
 
-  process.stdout.write(`${JSON.stringify({
-    schemaVersion: 1,
+  operationId = undefined;
+  const evidence = sanitizePictureInPictureEvidence({
     evidenceType: "headed-native-picture-in-picture",
     passed: true,
     recordedAt: new Date().toISOString(),
-    environment: await evidenceEnvironment(root),
     editor: {
       name: editor.identity?.name,
       version: editor.identity?.version,
       backend: editor.identity?.backend,
+    },
+    target: {
+      sequenceId: anchorOccurrence.sequenceId,
+      occurrenceId: anchorOccurrence.identity,
+      occurrenceName: anchorOccurrence.name,
+      project: expectedProject,
+      start: anchorOccurrence.start,
+      duration: anchorOccurrence.duration,
     },
     capabilities: {
       nativePictureInPicture: editor.native.pictureInPicture,
       nativeUndo: editor.native.undo,
       nativeTimelineOccurrenceLocate: editor.native.timelineOccurrenceLocate,
     },
-    target: {
-      sequenceId: anchorOccurrence.sequenceId,
-      occurrenceName: anchorOccurrence.name,
-    },
     placement: {
-      project: expectedProject,
-      anchorMedia: { name: anchorMedia.name, sourceIdentity: anchorMedia.sourceIdentity },
-      anchorOccurrence: { handle: anchorOccurrence.handle, start: anchorOccurrence.start, duration: anchorOccurrence.duration },
-      pipMedia: { name: pipMedia.name, sourceIdentity: pipMedia.sourceIdentity },
-      requested: { start, duration, position: { x: 320, y: -180 }, scale: 0.35, frame: { color: "#FFFFFF", width: 8 } },
+      requested: { start, duration, position: { x: 320, y: -180 }, scale: 0.35, frame: { style: "solid", color: "#FFFFFF", width: 8 } },
       observed: executed.observed,
       beforeRevision: executed.beforeRevision,
       afterRevision: executed.afterRevision,
-      operationId: executed.operationId,
-      undoOperationId: undone.operationId,
       undoVerified: undone.verification,
       undoRevision: undone.context?.revision?.id,
     },
-  }, null, 2)}\n`);
+    toolResults,
+  }, await evidenceEnvironment(root));
+  process.stdout.write(`${JSON.stringify(evidence, null, 2)}\n`);
+} catch (error) {
+  if (operationId) {
+    try {
+      await callJson("editor.native.undo", { operationId });
+    } catch (rollbackError) {
+      throw new AggregateError([error, rollbackError], "Native picture-in-picture E2E failed and compensating Undo also failed");
+    }
+  }
+  throw error;
 } finally {
   await client.close().catch(() => {});
   await transport.close().catch(() => {});

--- a/scripts/final-cut-title-discovery-headed-e2e.mjs
+++ b/scripts/final-cut-title-discovery-headed-e2e.mjs
@@ -2,7 +2,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { evidenceEnvironment } from "./final-cut-evidence.mjs";
+import { evidenceEnvironment, sanitizeNativeTitleEvidence } from "./final-cut-evidence.mjs";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const expectedProject = process.env.FRAMEKIT_FINAL_CUT_E2E_PROJECT;
@@ -47,8 +47,10 @@ const client = new Client({ name: "framekit-title-discovery-headed-e2e", version
 let operationId;
 
 try {
+  const toolResults = [];
   await client.connect(transport);
   const editor = await callJson("editor.inspect");
+  toolResults.push({ name: "editor.inspect", status: "passed" });
   if (editor.native?.titleDiscovery !== true) {
     throw new Error("CAPABILITY_UNAVAILABLE: native title discovery is not enabled");
   }
@@ -66,6 +68,7 @@ try {
   }
 
   const assets = await callJson("editor.assets", { kind: "title", query: titleQuery });
+  toolResults.push({ name: "editor.assets", status: "passed" });
   const title = Array.isArray(assets)
     ? assets.find((asset) => asset.id?.startsWith("final-cut:title:"))
     : undefined;
@@ -83,11 +86,13 @@ try {
     text: titleText,
     duration,
   });
+  toolResults.push({ name: "editor.native.title.add.preview", status: "passed" });
   if (preview.asset?.id !== title.id || preview.target !== "playhead" || !preview.revision) {
     throw new Error("FINAL_CUT_E2E_TITLE_PREVIEW_FAILED: preview lost the discovered identity or live target");
   }
 
   const executed = await callJson("editor.native.title.add.execute", { previewToken: preview.previewToken });
+  toolResults.push({ name: "editor.native.title.add.execute", status: executed.verification?.verified ? "passed" : "failed" });
   operationId = executed.operationId;
   if (!executed.verification?.verified
     || executed.asset?.id !== title.id
@@ -98,18 +103,16 @@ try {
   }
 
   const undone = await callJson("editor.native.undo", { operationId });
+  toolResults.push({ name: "editor.native.undo", status: undone.verification?.verified === true ? "passed" : "failed" });
   if (!undone.undone || !undone.verification?.verified) {
     throw new Error("FINAL_CUT_E2E_TITLE_UNDO_FAILED: native Undo did not verify restoration");
   }
   operationId = undefined;
 
-  const environment = await evidenceEnvironment(root);
-  process.stdout.write(`${JSON.stringify({
-    schemaVersion: 1,
+  const evidence = sanitizeNativeTitleEvidence({
     evidenceType: "headed-native-title-discovery-and-placement",
     passed: true,
     recordedAt: new Date().toISOString(),
-    environment,
     project: expectedProject,
     discovery: {
       id: title.id,
@@ -131,7 +134,9 @@ try {
       verified: executed.verification.verified,
       undo: { command: executed.undoCommand, verified: undone.verification.verified },
     },
-  }, null, 2)}\n`);
+    toolResults,
+  }, await evidenceEnvironment(root));
+  process.stdout.write(`${JSON.stringify(evidence, null, 2)}\n`);
 } catch (error) {
   if (operationId) {
     try {

--- a/scripts/final-cut-title-discovery-headed-e2e.mjs
+++ b/scripts/final-cut-title-discovery-headed-e2e.mjs
@@ -97,6 +97,7 @@ try {
   if (!executed.verification?.verified
     || executed.asset?.id !== title.id
     || executed.beforeRevision?.id === executed.afterRevision?.id
+    || !executed.after?.target?.identity
     || !executed.undoAvailable
     || !executed.undoCommand) {
     throw new Error("FINAL_CUT_E2E_TITLE_PLACEMENT_FAILED: native title placement was not read-back verified");
@@ -122,7 +123,7 @@ try {
       backend: title.metadata.discovery.backend,
       guarantee: title.metadata.discovery.guarantee,
     },
-    target: { sequenceId: preview.sequenceId },
+    target: { sequenceId: preview.sequenceId, occurrenceId: executed.after.target.identity },
     placement: {
       text: titleText,
       target: preview.target,

--- a/tests/integration/headed-native-evidence.test.ts
+++ b/tests/integration/headed-native-evidence.test.ts
@@ -115,7 +115,11 @@ test("headed title evidence keeps the project, sequence, and discovered asset", 
     },
   }, environment);
 
-  assert.deepEqual(evidence.target, { project: "Disposable Titles", sequenceId: "sequence-2" });
+  assert.deepEqual(evidence.target, {
+    project: "Disposable Titles",
+    sequenceId: "sequence-2",
+    occurrenceId: "occurrence-title",
+  });
   assert.equal(evidence.discovery.assetId, "final-cut:title:basic-title");
   assert.deepEqual(evidence.revisions, { before: "rev-4", after: "rev-5", restored: "rev-6" });
   assert.doesNotMatch(JSON.stringify(evidence), /private-operation|sourceIdentity|native-operation-secret/i);
@@ -197,7 +201,12 @@ test("headed filler evidence keeps rollback proof without private state", () => 
       },
       analyzers: { speechTranscribe: true },
     },
-    project: { id: "project-filler", name: "Disposable Filler", sequenceId: "sequence-filler" },
+    project: {
+      id: "project-filler",
+      name: "Disposable Filler",
+      sequenceId: "sequence-filler",
+      occurrenceId: "occurrence-filler",
+    },
     selection: { start: 2, end: 4 },
     toolResults: [
       { name: "editor.inspect", status: "passed" },
@@ -251,7 +260,7 @@ test("all claimed headed runners publish through an allowlisted sanitizer", asyn
   assert.match(runners[3], /sanitizeMaskEvidence/);
   assert.match(runners[4], /sanitizeFillerRemovalEvidence/);
   assert.match(runners[2], /occurrenceId:\s*executed\.after\.target\.identity/);
-  assert.match(runners[4], /occurrenceId:/);
+  assert.match(runners[4], /occurrenceId[,:]/);
 });
 
 function pictureInPictureRun(): Record<string, any> {

--- a/tests/integration/headed-native-evidence.test.ts
+++ b/tests/integration/headed-native-evidence.test.ts
@@ -41,6 +41,7 @@ test("headed PIP evidence keeps the exact target and removes native secrets", ()
       beforeRevision: { id: "rev-1" },
       afterRevision: { id: "rev-2" },
       undoRevision: "rev-3",
+      undoVerified: { verified: true },
       anchorOccurrence: { handle: "private-handle" },
       pipMedia: { sourceIdentity: "/private/media/guest.mov" },
       operationId: "private-operation",
@@ -89,7 +90,7 @@ test("headed title evidence keeps the project, sequence, and discovered asset", 
   assert.deepEqual(evidence.target, { project: "Disposable Titles", sequenceId: "sequence-2" });
   assert.equal(evidence.discovery.assetId, "final-cut:title:basic-title");
   assert.deepEqual(evidence.revisions, { before: "rev-4", after: "rev-5", restored: "rev-6" });
-  assert.doesNotMatch(JSON.stringify(evidence), /operationId|diagnostic|sourceIdentity/i);
+  assert.doesNotMatch(JSON.stringify(evidence), /private-operation|sourceIdentity|native-operation-secret/i);
 });
 
 test("headed masking evidence keeps the stable occurrence identity", () => {
@@ -111,12 +112,68 @@ test("headed masking evidence keeps the stable occurrence identity", () => {
     },
     revisions: { before: "rev-7", after: "rev-8", restored: "rev-9" },
     verification: { execute: { verified: true }, undo: { verified: true } },
-    toolResults: [],
+    toolResults: [{ name: "editor.native.undo", status: "passed" }],
   }, environment);
 
   assert.equal(evidence.target.occurrenceId, "occurrence-mask");
   assert.deepEqual(evidence.revisions, { before: "rev-7", after: "rev-8", restored: "rev-9" });
   assert.deepEqual(evidence.verification, { execute: true, undo: true });
+});
+
+test("headed filler evidence keeps rollback proof without private state", () => {
+  const evidence = sanitizeFillerRemovalEvidence({
+    passed: true,
+    recordedAt: "2026-09-11T00:00:00.000Z",
+    editor: { name: "Final Cut Pro", version: "10.7.1", backend: "final-cut-live" },
+    capabilities: {
+      editor: {
+        canonicalTimelineMode: "canonical-write",
+        projectRead: true,
+        timelineSnapshotRead: true,
+        timelineWrite: true,
+        readAfterWrite: true,
+        rollback: true,
+        projectCatalogRead: true,
+        projectSelection: true,
+        privateDiagnostic: "/Users/private/diagnostic.log",
+      },
+      analyzers: { speechTranscribe: true },
+    },
+    project: { id: "project-filler", name: "Disposable Filler", sequenceId: "sequence-filler" },
+    selection: { start: 2, end: 4 },
+    toolResults: [
+      { name: "editor.inspect", status: "passed" },
+      { name: "editor.live.inspect", status: "passed" },
+      { name: "speech.filler.remove.preview", status: "passed" },
+      { name: "speech.filler.remove.execute", status: "VERIFIED" },
+      { name: "edit.undo", status: "passed" },
+    ],
+    removal: {
+      status: "VERIFIED",
+      candidateCount: 1,
+      operationCount: 1,
+      removedDurationSeconds: 0.5,
+      affectedRangeCount: 1,
+      continuityVerified: true,
+      beforeRevision: { id: "rev-10" },
+      afterRevision: { id: "rev-11" },
+      operationId: "private-operation",
+    },
+    restoration: {
+      status: "VERIFIED",
+      restored: true,
+      restoredRevision: { id: "rev-12" },
+      rawSnapshot: { source: "/private/media/audio.wav" },
+    },
+  }, environment);
+
+  assert.deepEqual(evidence.target, {
+    project: "Disposable Filler",
+    projectId: "project-filler",
+    sequenceId: "sequence-filler",
+  });
+  assert.deepEqual(evidence.revisions, { before: "rev-10", after: "rev-11", restored: "rev-12" });
+  assert.doesNotMatch(JSON.stringify(evidence), /private-operation|privateDiagnostic|\/private\/media/);
 });
 
 test("all claimed headed runners publish through an allowlisted sanitizer", async () => {
@@ -135,4 +192,3 @@ test("all claimed headed runners publish through an allowlisted sanitizer", asyn
   assert.match(runners[3], /sanitizeMaskEvidence/);
   assert.match(runners[4], /sanitizeFillerRemovalEvidence/);
 });
-

--- a/tests/integration/headed-native-evidence.test.ts
+++ b/tests/integration/headed-native-evidence.test.ts
@@ -59,6 +59,34 @@ test("headed PIP evidence keeps the exact target and removes native secrets", ()
   assert.doesNotMatch(JSON.stringify(evidence), /private-handle|sourceIdentity|private-operation|\/private\/media/);
 });
 
+test("headed PIP evidence rejects a no-op mutation revision", () => {
+  const run = pictureInPictureRun();
+  run.placement.afterRevision = { id: "rev-1" };
+
+  assert.throws(
+    () => sanitizePictureInPictureEvidence(run, environment),
+    /revision did not advance/,
+  );
+});
+
+test("headed PIP evidence requires every native capability", () => {
+  for (const key of ["nativePictureInPicture", "nativeUndo", "nativeTimelineOccurrenceLocate"]) {
+    const missing = pictureInPictureRun();
+    delete missing.capabilities[key];
+    assert.throws(
+      () => sanitizePictureInPictureEvidence(missing, environment),
+      /capability is required/,
+    );
+
+    const disabled = pictureInPictureRun();
+    disabled.capabilities[key] = false;
+    assert.throws(
+      () => sanitizePictureInPictureEvidence(disabled, environment),
+      /capability is required/,
+    );
+  }
+});
+
 test("headed title evidence keeps the project, sequence, and discovered asset", () => {
   const evidence = sanitizeNativeTitleEvidence({
     evidenceType: "headed-native-title-discovery-and-placement",
@@ -73,7 +101,7 @@ test("headed title evidence keeps the project, sequence, and discovered asset", 
       backend: "final-cut-accessibility",
       guarantee: "observed",
     },
-    target: { sequenceId: "sequence-2" },
+    target: { sequenceId: "sequence-2", occurrenceId: "occurrence-title" },
     placement: {
       text: "Framekit title proof",
       target: "playhead",
@@ -91,6 +119,36 @@ test("headed title evidence keeps the project, sequence, and discovered asset", 
   assert.equal(evidence.discovery.assetId, "final-cut:title:basic-title");
   assert.deepEqual(evidence.revisions, { before: "rev-4", after: "rev-5", restored: "rev-6" });
   assert.doesNotMatch(JSON.stringify(evidence), /private-operation|sourceIdentity|native-operation-secret/i);
+});
+
+test("headed title evidence rejects a zero rational timescale", () => {
+  assert.throws(
+    () => sanitizeNativeTitleEvidence({
+      passed: true,
+      recordedAt: "2026-09-11T00:00:00.000Z",
+      project: "Disposable Titles",
+      discovery: {
+        id: "final-cut:title:basic-title",
+        name: "Basic Title",
+        vendor: "Final Cut Pro",
+        backend: "final-cut-accessibility",
+        guarantee: "observed",
+      },
+      target: { sequenceId: "sequence-2", occurrenceId: "occurrence-title" },
+      placement: {
+        text: "Framekit title proof",
+        target: "playhead",
+        start: "1/0",
+        duration: "3/1",
+        beforeRevision: "rev-4",
+        afterRevision: "rev-5",
+        undoRevision: "rev-6",
+        verified: true,
+        undo: { verified: true },
+      },
+    }, environment),
+    /rational value\/timescale/,
+  );
 });
 
 test("headed masking evidence keeps the stable occurrence identity", () => {
@@ -171,6 +229,7 @@ test("headed filler evidence keeps rollback proof without private state", () => 
     project: "Disposable Filler",
     projectId: "project-filler",
     sequenceId: "sequence-filler",
+    occurrenceId: "occurrence-filler",
   });
   assert.deepEqual(evidence.revisions, { before: "rev-10", after: "rev-11", restored: "rev-12" });
   assert.doesNotMatch(JSON.stringify(evidence), /private-operation|privateDiagnostic|\/private\/media/);
@@ -191,4 +250,24 @@ test("all claimed headed runners publish through an allowlisted sanitizer", asyn
   assert.match(runners[2], /sanitizeNativeTitleEvidence/);
   assert.match(runners[3], /sanitizeMaskEvidence/);
   assert.match(runners[4], /sanitizeFillerRemovalEvidence/);
+  assert.match(runners[2], /occurrenceId:\s*executed\.after\.target\.identity/);
+  assert.match(runners[4], /occurrenceId:/);
 });
+
+function pictureInPictureRun(): Record<string, any> {
+  return {
+    passed: true,
+    recordedAt: "2026-09-11T00:00:00.000Z",
+    editor: { name: "Final Cut Pro", version: "10.7.1", backend: "final-cut-live" },
+    capabilities: { nativePictureInPicture: true, nativeUndo: true, nativeTimelineOccurrenceLocate: true },
+    target: { project: "Disposable PIP", sequenceId: "sequence-1", occurrenceId: "occurrence-1" },
+    placement: {
+      requested: { start: "2/1", duration: "4/1", position: { x: 320, y: -180 }, scale: 0.35 },
+      observed: { position: { x: 320, y: -180 }, scale: 0.35 },
+      beforeRevision: { id: "rev-1" },
+      afterRevision: { id: "rev-2" },
+      undoRevision: "rev-3",
+      undoVerified: { verified: true },
+    },
+  };
+}

--- a/tests/integration/headed-native-evidence.test.ts
+++ b/tests/integration/headed-native-evidence.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  sanitizeFillerRemovalEvidence,
+  sanitizeMaskEvidence,
+  sanitizeNativeTitleEvidence,
+  sanitizePictureInPictureEvidence,
+} from "../../scripts/final-cut-evidence.mjs";
+
+const environment = {
+  framekitVersion: "0.1.6",
+  finalCutVersion: "10.7.1",
+  gitCommit: "a".repeat(40),
+  nodeVersion: "v22.14.0",
+  platform: "darwin",
+  architecture: "arm64",
+  osVersion: "Darwin",
+};
+
+test("headed PIP evidence keeps the exact target and removes native secrets", () => {
+  const evidence = sanitizePictureInPictureEvidence({
+    schemaVersion: 1,
+    evidenceType: "headed-native-picture-in-picture",
+    passed: true,
+    recordedAt: "2026-09-11T00:00:00.000Z",
+    editor: { name: "Final Cut Pro", version: "10.7.1", backend: "final-cut-live" },
+    capabilities: { nativePictureInPicture: true, nativeUndo: true, nativeTimelineOccurrenceLocate: true },
+    target: {
+      project: "Disposable PIP",
+      sequenceId: "sequence-1",
+      occurrenceId: "occurrence-anchor",
+      occurrenceName: "Anchor",
+      start: "0/1",
+      duration: "10/1",
+    },
+    placement: {
+      requested: { start: "2/1", duration: "4/1", position: { x: 320, y: -180 }, scale: 0.35 },
+      observed: { position: { x: 320, y: -180 }, scale: 0.35 },
+      beforeRevision: { id: "rev-1" },
+      afterRevision: { id: "rev-2" },
+      undoRevision: "rev-3",
+      anchorOccurrence: { handle: "private-handle" },
+      pipMedia: { sourceIdentity: "/private/media/guest.mov" },
+      operationId: "private-operation",
+    },
+    toolResults: [
+      { name: "editor.native.picture-in-picture.preview", status: "passed" },
+      { name: "editor.native.picture-in-picture.execute", status: "passed" },
+      { name: "editor.native.undo", status: "passed" },
+    ],
+  }, environment);
+
+  assert.equal(evidence.target.occurrenceId, "occurrence-anchor");
+  assert.deepEqual(evidence.revisions, { before: "rev-1", after: "rev-2", restored: "rev-3" });
+  assert.deepEqual(evidence.verification, { execute: true, undo: true });
+  assert.doesNotMatch(JSON.stringify(evidence), /private-handle|sourceIdentity|private-operation|\/private\/media/);
+});
+
+test("headed title evidence keeps the project, sequence, and discovered asset", () => {
+  const evidence = sanitizeNativeTitleEvidence({
+    evidenceType: "headed-native-title-discovery-and-placement",
+    passed: true,
+    recordedAt: "2026-09-11T00:00:00.000Z",
+    project: "Disposable Titles",
+    discovery: {
+      id: "final-cut:title:basic-title",
+      name: "Basic Title",
+      vendor: "Final Cut Pro",
+      identity: "basic-title",
+      backend: "final-cut-accessibility",
+      guarantee: "observed",
+    },
+    target: { sequenceId: "sequence-2" },
+    placement: {
+      text: "Framekit title proof",
+      target: "playhead",
+      start: "1/24",
+      duration: "3/1",
+      beforeRevision: "rev-4",
+      afterRevision: "rev-5",
+      undoRevision: "rev-6",
+      verified: true,
+      undo: { command: "Undo", verified: true },
+    },
+  }, environment);
+
+  assert.deepEqual(evidence.target, { project: "Disposable Titles", sequenceId: "sequence-2" });
+  assert.equal(evidence.discovery.assetId, "final-cut:title:basic-title");
+  assert.deepEqual(evidence.revisions, { before: "rev-4", after: "rev-5", restored: "rev-6" });
+  assert.doesNotMatch(JSON.stringify(evidence), /operationId|diagnostic|sourceIdentity/i);
+});
+
+test("headed masking evidence keeps the stable occurrence identity", () => {
+  const evidence = sanitizeMaskEvidence({
+    evidenceType: "headed-native-mask-placement",
+    passed: true,
+    recordedAt: "2026-09-11T00:00:00.000Z",
+    project: "Disposable Mask",
+    target: {
+      occurrenceId: "occurrence-mask",
+      occurrenceName: "Subject",
+      sequenceId: "sequence-3",
+      start: "0/1",
+      duration: "10/1",
+    },
+    mask: {
+      requested: { mode: "rectangle", bounds: { x: 0.1, y: 0.2, width: 0.6, height: 0.7 } },
+      observed: { mode: "rectangle", bounds: { x: 0.1, y: 0.2, width: 0.6, height: 0.7 } },
+    },
+    revisions: { before: "rev-7", after: "rev-8", restored: "rev-9" },
+    verification: { execute: { verified: true }, undo: { verified: true } },
+    toolResults: [],
+  }, environment);
+
+  assert.equal(evidence.target.occurrenceId, "occurrence-mask");
+  assert.deepEqual(evidence.revisions, { before: "rev-7", after: "rev-8", restored: "rev-9" });
+  assert.deepEqual(evidence.verification, { execute: true, undo: true });
+});
+
+test("all claimed headed runners publish through an allowlisted sanitizer", async () => {
+  const root = process.cwd();
+  const runners = await Promise.all([
+    readFile(join(root, "scripts/final-cut-canonical-headed-e2e.mjs"), "utf8"),
+    readFile(join(root, "scripts/final-cut-picture-in-picture-headed-e2e.mjs"), "utf8"),
+    readFile(join(root, "scripts/final-cut-title-discovery-headed-e2e.mjs"), "utf8"),
+    readFile(join(root, "scripts/final-cut-masking-headed-e2e.mjs"), "utf8"),
+    readFile(join(root, "scripts/final-cut-filler-removal-headed-e2e.mjs"), "utf8"),
+  ]);
+
+  assert.match(runners[0], /sanitizeCanonicalEvidence/);
+  assert.match(runners[1], /sanitizePictureInPictureEvidence/);
+  assert.match(runners[2], /sanitizeNativeTitleEvidence/);
+  assert.match(runners[3], /sanitizeMaskEvidence/);
+  assert.match(runners[4], /sanitizeFillerRemovalEvidence/);
+});
+

--- a/tests/integration/release-gate-docs.test.ts
+++ b/tests/integration/release-gate-docs.test.ts
@@ -25,6 +25,24 @@ test("release gate documentation records commands and evidence boundaries", asyn
   }
 });
 
+test("release gate documentation lists every required headed-native runner", async () => {
+  const documentation = await readFile("docs/tests/release-gate.md", "utf8");
+
+  for (const command of [
+    "test:final-cut-canonical-headed",
+    "test:final-cut-pip-headed",
+    "test:final-cut-title-headed",
+    "test:final-cut-masking-headed",
+    "test:final-cut-filler-headed",
+  ]) {
+    assert.match(documentation, new RegExp(command.replaceAll(".", "\\.")));
+  }
+  assert.match(documentation, /headed-native=verified/);
+  assert.match(documentation, /sanitized/i);
+  assert.match(documentation, /disposable project/i);
+  assert.match(documentation, /dialogue-normalization.*non-native|non-native.*dialogue-normalization/i);
+});
+
 test("Skill documentation describes only the generic MCP workflow", async () => {
   const documentation = await readFile("docs/mcp/skills.md", "utf8");
 

--- a/tests/integration/release-gate-docs.test.ts
+++ b/tests/integration/release-gate-docs.test.ts
@@ -38,6 +38,7 @@ test("release gate documentation lists every required headed-native runner", asy
     assert.match(documentation, new RegExp(command.replaceAll(".", "\\.")));
   }
   assert.match(documentation, /headed-native=verified/);
+  assert.match(documentation, /mkdir -p artifacts\/final-cut-headed/);
   assert.match(documentation, /sanitized/i);
   assert.match(documentation, /disposable project/i);
   assert.match(documentation, /dialogue-normalization.*non-native|non-native.*dialogue-normalization/i);

--- a/tests/release-gate/native-editing.test.ts
+++ b/tests/release-gate/native-editing.test.ts
@@ -61,6 +61,7 @@ test("headed evidence is reduced to a target, revision, verification, and restor
     },
     editor: { name: "Final Cut Pro", version: "10.7.1", backend: "final-cut-live" },
     capabilities: { nativePictureInPicture: true, nativeUndo: true },
+    target: { project: "Disposable PIP", sequenceId: "sequence-1", occurrenceId: "occurrence-1" },
     placement: {
       project: "Disposable PIP",
       anchorOccurrence: { handle: "private-occurrence-handle", start: "0/1", duration: "10/1" },
@@ -78,7 +79,7 @@ test("headed evidence is reduced to a target, revision, verification, and restor
   assert.equal(summary.workflowId, "picture-in-picture");
   assert.equal(summary.evidenceType, "headed-native-picture-in-picture");
   assert.equal(summary.status, "verified");
-  assert.deepEqual(summary.target, { project: "Disposable PIP" });
+  assert.deepEqual(summary.target, { project: "Disposable PIP", sequenceId: "sequence-1", occurrenceId: "occurrence-1" });
   assert.deepEqual(summary.revision, { before: "rev-1", after: "rev-2", restored: "rev-3" });
   assert.deepEqual(summary.verification, { execute: true, undo: true });
   assert.equal(summary.environment.gitCommit, "a".repeat(40));
@@ -93,11 +94,12 @@ test("headed evidence omits path-like target identities", () => {
     evidenceType: "headed-native-picture-in-picture",
     passed: true,
     environment: { framekitVersion: "0.1.6", finalCutVersion: "10.7.1", gitCommit: "a".repeat(40) },
-    project: "/Users/example/Disposable PIP.fcpbundle",
+    project: "Disposable PIP",
     target: {
-      sequenceId: "/home/example/sequence",
-      occurrenceId: "C:\\Users\\example\\clip",
+      sequenceId: "sequence-1",
+      occurrenceId: "occurrence-1",
       occurrenceName: "Guest",
+      sourceIdentity: "C:\\Users\\example\\clip",
     },
     placement: {
       beforeRevision: "rev-1",
@@ -108,7 +110,7 @@ test("headed evidence omits path-like target identities", () => {
     },
   }, workflow);
 
-  assert.deepEqual(summary.target, { occurrenceName: "Guest" });
+  assert.deepEqual(summary.target, { project: "Disposable PIP", sequenceId: "sequence-1", occurrenceId: "occurrence-1", occurrenceName: "Guest" });
 });
 
 test("headed evidence requires a verified rollback for mutating workflows", () => {
@@ -121,11 +123,33 @@ test("headed evidence requires a verified rollback for mutating workflows", () =
       passed: true,
       environment: { framekitVersion: "0.1.6", finalCutVersion: "10.7.1", gitCommit: "b".repeat(40) },
       project: "Disposable Mask",
-      target: { occurrenceId: "clip-1" },
+      target: { sequenceId: "sequence-1", occurrenceId: "clip-1" },
       revisions: { before: "rev-1", after: "rev-2", restored: "rev-3" },
       verification: { execute: { verified: true } },
     }, workflow),
     /rollback|undo/i,
+  );
+});
+
+test("headed occurrence workflows require a stable occurrence identity", () => {
+  const workflow = loadNativeEditingManifest().workflows.find((candidate) => candidate.id === "picture-in-picture");
+  assert.ok(workflow);
+
+  assert.throws(
+    () => summarizeHeadedEvidence({
+      evidenceType: "headed-native-picture-in-picture",
+      passed: true,
+      environment: { framekitVersion: "0.1.6", finalCutVersion: "10.7.1", gitCommit: "c".repeat(40) },
+      target: { project: "Disposable PIP", sequenceId: "sequence-1" },
+      placement: {
+        beforeRevision: "rev-1",
+        afterRevision: "rev-2",
+        undoRevision: "rev-3",
+        observed: { position: { x: 320, y: -180 }, scale: 0.35 },
+        undoVerified: { verified: true },
+      },
+    }, workflow),
+    /occurrence identity/i,
   );
 });
 
@@ -243,6 +267,7 @@ test("partial headed evidence cannot promote the headed tier", async () => {
       environment: { framekitVersion: "0.1.6", finalCutVersion: "10.7.1", gitCommit: "a".repeat(40) },
       placement: {
         project: "Disposable PIP",
+        target: { sequenceId: "sequence-1", occurrenceId: "occurrence-1" },
         beforeRevision: "rev-1",
         afterRevision: "rev-2",
         undoRevision: "rev-3",

--- a/tests/release-gate/native-editing.test.ts
+++ b/tests/release-gate/native-editing.test.ts
@@ -113,6 +113,49 @@ test("headed evidence omits path-like target identities", () => {
   assert.deepEqual(summary.target, { project: "Disposable PIP", sequenceId: "sequence-1", occurrenceId: "occurrence-1", occurrenceName: "Guest" });
 });
 
+test("headed evidence rejects path-like project identities", () => {
+  const workflow = loadNativeEditingManifest().workflows.find((candidate) => candidate.id === "picture-in-picture");
+  assert.ok(workflow);
+
+  for (const project of ["file:///private/project", "../private/project"]) {
+    assert.throws(
+      () => summarizeHeadedEvidence({
+        evidenceType: "headed-native-picture-in-picture",
+        passed: true,
+        environment: { framekitVersion: "0.1.6", finalCutVersion: "10.7.1", gitCommit: "a".repeat(40) },
+        project,
+        target: { sequenceId: "sequence-1", occurrenceId: "occurrence-1" },
+        placement: {
+          beforeRevision: "rev-1",
+          afterRevision: "rev-2",
+          undoRevision: "rev-3",
+          observed: { position: { x: 320, y: -180 }, scale: 0.35 },
+          undoVerified: { verified: true },
+        },
+      }, workflow),
+      /headed project identity is missing/,
+    );
+  }
+
+  const fallback = summarizeHeadedEvidence({
+    evidenceType: "headed-native-picture-in-picture",
+    passed: true,
+    environment: { framekitVersion: "0.1.6", finalCutVersion: "10.7.1", gitCommit: "a".repeat(40) },
+    project: "file:///private/project",
+    target: { project: "../private/project", sequenceId: "sequence-1", occurrenceId: "occurrence-1" },
+    placement: {
+      project: "Disposable PIP",
+      beforeRevision: "rev-1",
+      afterRevision: "rev-2",
+      undoRevision: "rev-3",
+      observed: { position: { x: 320, y: -180 }, scale: 0.35 },
+      undoVerified: { verified: true },
+    },
+  }, workflow);
+
+  assert.equal(fallback.target.project, "Disposable PIP");
+});
+
 test("headed evidence requires a verified rollback for mutating workflows", () => {
   const workflow = loadNativeEditingManifest().workflows.find((candidate) => candidate.id === "masking");
   assert.ok(workflow);
@@ -151,6 +194,25 @@ test("headed occurrence workflows require a stable occurrence identity", () => {
     }, workflow),
     /occurrence identity/i,
   );
+});
+
+test("every headed workflow requires a stable occurrence identity", () => {
+  const manifest = loadNativeEditingManifest();
+  for (const workflowId of ["built-in-title-discovery", "filler-removal"] as const) {
+    const workflow = manifest.workflows.find((candidate) => candidate.id === workflowId);
+    assert.ok(workflow);
+    assert.throws(
+      () => summarizeHeadedEvidence({
+        evidenceType: workflow.evidenceTypes[0],
+        passed: true,
+        environment: { framekitVersion: "0.1.6", finalCutVersion: "10.7.1", gitCommit: "d".repeat(40) },
+        target: { project: "Disposable Target", sequenceId: "sequence-1" },
+        revisions: { before: "rev-1", after: "rev-2", restored: "rev-3" },
+        verification: { execute: true, undo: true },
+      }, workflow),
+      /occurrence identity/i,
+    );
+  }
 });
 
 test("release provenance verifies aligned versions, tag, workflow, npm, and checksums", () => {
@@ -308,7 +370,7 @@ test("complete headed evidence promotes every claimed native workflow", async ()
     {
       file: "title.json",
       evidenceType: "headed-native-title-discovery-and-placement",
-      target: { project: "Disposable Title", sequenceId: "sequence-3" },
+      target: { project: "Disposable Title", sequenceId: "sequence-3", occurrenceId: "occurrence-3" },
     },
     {
       file: "mask.json",
@@ -318,7 +380,7 @@ test("complete headed evidence promotes every claimed native workflow", async ()
     {
       file: "filler.json",
       evidenceType: "headed-native-filler-removal",
-      target: { project: "Disposable Filler", projectId: "project-5", sequenceId: "sequence-5" },
+      target: { project: "Disposable Filler", projectId: "project-5", sequenceId: "sequence-5", occurrenceId: "occurrence-5" },
     },
   ];
 

--- a/tests/release-gate/native-editing.test.ts
+++ b/tests/release-gate/native-editing.test.ts
@@ -286,3 +286,64 @@ test("partial headed evidence cannot promote the headed tier", async () => {
     await rm(directory, { recursive: true, force: true });
   }
 });
+
+test("complete headed evidence promotes every claimed native workflow", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "framekit-complete-headed-evidence-"));
+  const environment = {
+    framekitVersion: "0.1.6",
+    finalCutVersion: "10.7.1",
+    gitCommit: "d".repeat(40),
+  };
+  const records = [
+    {
+      file: "canonical.json",
+      evidenceType: "headed-native-canonical-mutation",
+      target: { project: "Disposable Canonical", projectId: "project-1", sequenceId: "sequence-1", occurrenceId: "occurrence-1" },
+    },
+    {
+      file: "pip.json",
+      evidenceType: "headed-native-picture-in-picture",
+      target: { project: "Disposable PIP", sequenceId: "sequence-2", occurrenceId: "occurrence-2" },
+    },
+    {
+      file: "title.json",
+      evidenceType: "headed-native-title-discovery-and-placement",
+      target: { project: "Disposable Title", sequenceId: "sequence-3" },
+    },
+    {
+      file: "mask.json",
+      evidenceType: "headed-native-mask-placement",
+      target: { project: "Disposable Mask", sequenceId: "sequence-4", occurrenceId: "occurrence-4" },
+    },
+    {
+      file: "filler.json",
+      evidenceType: "headed-native-filler-removal",
+      target: { project: "Disposable Filler", projectId: "project-5", sequenceId: "sequence-5" },
+    },
+  ];
+
+  try {
+    for (const record of records) {
+      await writeFile(join(directory, record.file), JSON.stringify({
+        schemaVersion: 1,
+        evidenceType: record.evidenceType,
+        passed: true,
+        environment,
+        target: record.target,
+        revisions: { before: "rev-1", after: "rev-2", restored: "rev-3" },
+        verification: { execute: true, undo: true },
+      }), "utf8");
+    }
+
+    const report = await runReleaseGate({ headedEvidenceDirectory: directory });
+
+    assert.equal(report.evidenceTiers["headed-native"].status, "verified");
+    assert.equal(report.evidenceTiers["headed-native"].passed, true);
+    assert.deepEqual(
+      report.evidenceTiers["headed-native"].workflows.map((workflow) => workflow.status),
+      ["verified", "verified", "verified", "verified", "verified"],
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/tests/release-gate/native-editing.ts
+++ b/tests/release-gate/native-editing.ts
@@ -251,12 +251,16 @@ function checksumLineMatches(content: string, archiveName: string, archiveSha256
 function extractTarget(raw: Record<string, any>): HeadedEvidenceSummary["target"] {
   const project = raw.project;
   const target = raw.target ?? raw.placement?.target;
-  const projectValue = typeof project === "string" ? project : project?.name ?? raw.placement?.project ?? target?.project;
+  const projectValue = [
+    typeof project === "string" ? project : project?.name,
+    raw.placement?.project,
+    target?.project,
+  ].find((candidate) => safeProjectString(candidate));
   const projectId = typeof project === "object" ? project?.id : target?.projectId;
   const sequenceId = typeof project === "object" ? project?.sequenceId : target?.sequenceId;
   const occurrenceId = target?.occurrenceId ?? raw.placement?.occurrenceId;
   const occurrenceName = target?.occurrenceName ?? target?.name;
-  const safeProject = safeTargetString(projectValue);
+  const safeProject = safeProjectString(projectValue);
   const safeProjectId = safeTargetString(projectId);
   const safeSequenceId = safeTargetString(sequenceId);
   const safeOccurrenceId = safeTargetString(occurrenceId);
@@ -284,6 +288,13 @@ function safeTargetString(value: unknown): string | undefined {
     return undefined;
   }
   return value;
+}
+
+function safeProjectString(value: unknown): string | undefined {
+  const result = safeTargetString(value);
+  if (!result || result.includes("/") || result.includes("\\") || result.startsWith("~")) return undefined;
+  if (/^[A-Za-z][A-Za-z0-9+.-]*:\/\//.test(result)) return undefined;
+  return result;
 }
 
 function extractRevisions(raw: Record<string, any>): HeadedEvidenceSummary["revision"] {

--- a/tests/release-gate/native-editing.ts
+++ b/tests/release-gate/native-editing.ts
@@ -277,9 +277,7 @@ function extractTarget(raw: Record<string, any>): HeadedEvidenceSummary["target"
 function assertHeadedTarget(target: HeadedEvidenceSummary["target"], workflowId: string): void {
   assert.ok(target.project, `${workflowId}: headed project identity is missing`);
   assert.ok(target.sequenceId, `${workflowId}: headed sequence identity is missing`);
-  if (["canonical-live", "picture-in-picture", "masking"].includes(workflowId)) {
-    assert.ok(target.occurrenceId, `${workflowId}: headed occurrence identity is missing`);
-  }
+  assert.ok(target.occurrenceId, `${workflowId}: headed occurrence identity is missing`);
 }
 
 function safeTargetString(value: unknown): string | undefined {

--- a/tests/release-gate/native-editing.ts
+++ b/tests/release-gate/native-editing.ts
@@ -134,6 +134,7 @@ export function summarizeHeadedEvidence(
       }
     : undefined;
   const target = extractTarget(raw);
+  assertHeadedTarget(target, workflow.id);
   const revision = extractRevisions(raw);
   const verification = extractVerification(raw);
 
@@ -250,10 +251,10 @@ function checksumLineMatches(content: string, archiveName: string, archiveSha256
 function extractTarget(raw: Record<string, any>): HeadedEvidenceSummary["target"] {
   const project = raw.project;
   const target = raw.target ?? raw.placement?.target;
-  const projectValue = typeof project === "string" ? project : project?.name ?? raw.placement?.project;
-  const projectId = typeof project === "object" ? project?.id : undefined;
+  const projectValue = typeof project === "string" ? project : project?.name ?? raw.placement?.project ?? target?.project;
+  const projectId = typeof project === "object" ? project?.id : target?.projectId;
   const sequenceId = typeof project === "object" ? project?.sequenceId : target?.sequenceId;
-  const occurrenceId = target?.occurrenceId;
+  const occurrenceId = target?.occurrenceId ?? raw.placement?.occurrenceId;
   const occurrenceName = target?.occurrenceName ?? target?.name;
   const safeProject = safeTargetString(projectValue);
   const safeProjectId = safeTargetString(projectId);
@@ -269,6 +270,14 @@ function extractTarget(raw: Record<string, any>): HeadedEvidenceSummary["target"
   };
 }
 
+function assertHeadedTarget(target: HeadedEvidenceSummary["target"], workflowId: string): void {
+  assert.ok(target.project, `${workflowId}: headed project identity is missing`);
+  assert.ok(target.sequenceId, `${workflowId}: headed sequence identity is missing`);
+  if (["canonical-live", "picture-in-picture", "masking"].includes(workflowId)) {
+    assert.ok(target.occurrenceId, `${workflowId}: headed occurrence identity is missing`);
+  }
+}
+
 function safeTargetString(value: unknown): string | undefined {
   if (typeof value !== "string" || value.length === 0) return undefined;
   if (value.startsWith("/") || value.startsWith("~/") || /^[A-Za-z]:[\\/]/.test(value) || value.startsWith("\\\\")) {
@@ -278,7 +287,7 @@ function safeTargetString(value: unknown): string | undefined {
 }
 
 function extractRevisions(raw: Record<string, any>): HeadedEvidenceSummary["revision"] {
-  const source = raw.revisions ?? raw.placement ?? raw.removal ?? raw.mutation;
+  const source = raw.revisions ?? raw.revision ?? raw.placement ?? raw.removal ?? raw.mutation;
   const before = revisionId(source?.before ?? source?.beforeRevision);
   const after = revisionId(source?.after ?? source?.afterRevision);
   const restored = revisionId(source?.restored ?? raw.restoration?.restoredRevision ?? raw.placement?.undoRevision);
@@ -295,11 +304,14 @@ function extractVerification(raw: Record<string, any>): HeadedEvidenceSummary["v
     || raw.placement?.verified === true
     || raw.removal?.continuityVerified === true
     || raw.mutation?.status === "VERIFIED"
+    || raw.verification?.execute === true
     || raw.verification?.execute?.verified === true;
   const undo = raw.placement?.undoVerified?.verified === true
     || raw.mask?.undo?.verified === true
     || raw.placement?.undo?.verified === true
     || raw.undo?.verified === true
+    || raw.verification?.undo === true
+    || raw.restoration?.status === "VERIFIED"
     || raw.restoration?.restored === true;
   assert.equal(execute, true, "headed execute verification is missing");
   assert.equal(undo, true, "headed Undo or rollback verification is missing");

--- a/tests/release-gate/runner.test.ts
+++ b/tests/release-gate/runner.test.ts
@@ -34,6 +34,7 @@ test("release gate executes Skills and separates capability evidence", async () 
   assert.equal(report.evidenceTiers["headed-native"].status, "unrun");
   const rendered = renderReleaseGateReport(report);
   assert.match(rendered, /provenance_ready=false/);
+  assert.match(rendered, /headed-native=unrun/);
   assert.doesNotMatch(rendered, /release_ready=/);
   assert.deepEqual(report.repositoryChecks.checks.map((check) => check.status), [
     "unrun",

--- a/tests/release-gate/runner.ts
+++ b/tests/release-gate/runner.ts
@@ -295,6 +295,7 @@ export function renderReleaseGateReport(report: ReleaseGateReport): string {
     `metadata_only_status=${report.evidenceTiers["metadata-only"].status}`,
     `canonical_live_status=${report.evidenceTiers["canonical-live"].status}`,
     `headed_native_status=${report.evidenceTiers["headed-native"].status}`,
+    `headed-native=${report.evidenceTiers["headed-native"].status}`,
     `provenance_ready=${report.provenance.releaseReady}`,
   ].join("\n");
 }


### PR DESCRIPTION
- [x] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [x] Github issue: Closes: #195

## Summary

Adds the sanitized headed-native evidence contract for the five v0.1.6 workflows:

- canonical live editing
- picture-in-picture
- built-in title discovery and placement
- native masking
- filler removal with rollback proof

Each runner now emits an allowlisted evidence bundle with disposable target identity, revisions, verification, and tool-result status. Private paths, raw handles, operation IDs, diagnostics, and media sources are excluded. The release gate requires all five verified bundles and reports `headed-native=verified`; dialogue normalization remains explicitly non-native.

Closes #195.

## Validation

```bash
pnpm install --frozen-lockfile
pnpm run build
pnpm run test
pnpm run check:boundaries
```

All passed: 630 tests, build, and boundary checks.

The headed runner preflight was attempted, but this environment reported an unknown macOS console-lock state before Final Cut execution. No native evidence was fabricated or committed.

No Swift/Xcode files changed, so the native Xcode gates were not applicable.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Public MCP behavior or package interfaces are documented if changed.
- [x] Existing adapters and test fixtures remain compatible, or the migration is explained above.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [x] Documentation reflects any changed commands, paths, or environment variables.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added headed-native evidence validation for picture-in-picture, title discovery, masking, and filler-removal workflows.
  - Release-gate reports now display headed-native verification status.
  - Release documentation now defines the required headed workflow evidence and completion criteria.

- **Bug Fixes**
  - Improved evidence sanitization to remove private identifiers, paths, diagnostics, and secrets while preserving verification details.

- **Tests**
  - Added integration coverage for sanitization, release-gate documentation, workflow identity validation, and complete headed-native verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->