### PR TITLE
feat: Enable headed canonical Final Cut provider

### DIFF
--- a/adapters/final-cut/typescript/src/canonical.ts
+++ b/adapters/final-cut/typescript/src/canonical.ts
@@ -1,3 +1,8 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { mkdtemp, rm, stat } from "node:fs/promises";
+import { basename, join } from "node:path";
+import { tmpdir } from "node:os";
+import { promisify } from "node:util";
 import {
   canonicalSnapshotDigest,
   withCapabilityFamilies,
@@ -13,6 +18,12 @@ import {
   type ProjectSnapshot,
   type RuntimeCapabilities,
 } from "@framekit/runtime";
+import type {
+  NativeFinalCutEditor,
+} from "./native.js";
+import { FcpxmlDocumentAdapter } from "./fcpxml.js";
+
+const execFile = promisify(execFileCallback);
 
 export interface CanonicalNativeMutationPort {
   renameSelectedClip(name: string): Promise<{ operationId: string; undoAvailable: boolean }>;
@@ -29,6 +40,177 @@ export interface FinalCutCanonicalNativeProviderOptions {
   native: CanonicalNativeMutationPort;
   readSnapshot: () => Promise<ProjectSnapshot>;
   resolveTarget: CanonicalNativeTargetResolver;
+}
+
+export interface FinalCutCanonicalSnapshotSourceOptions {
+  executor?: (script: string) => Promise<string>;
+  exportTimeoutMs?: number;
+  pollIntervalMs?: number;
+}
+
+/** Reads the active Final Cut project through its headed Export XML command. */
+export class FinalCutCanonicalSnapshotSource {
+  private readonly executor: (script: string) => Promise<string>;
+  private readonly exportTimeoutMs: number;
+  private readonly pollIntervalMs: number;
+
+  public constructor(options: FinalCutCanonicalSnapshotSourceOptions = {}) {
+    this.executor = options.executor ?? executeCanonicalAppleScript;
+    this.exportTimeoutMs = Math.max(1_000, options.exportTimeoutMs ?? 30_000);
+    this.pollIntervalMs = Math.max(10, options.pollIntervalMs ?? 100);
+  }
+
+  public async readSnapshot(): Promise<ProjectSnapshot> {
+    const directory = await mkdtemp(join(tmpdir(), "framekit-finalcut-canonical-"));
+    const exportPath = join(directory, "active.fcpxml");
+    try {
+      await this.executor(buildFinalCutCanonicalExportScript(exportPath));
+      await waitForExportFile(exportPath, this.exportTimeoutMs, this.pollIntervalMs);
+      return new FcpxmlDocumentAdapter(exportPath).readProject();
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      if (detail.includes("FINAL_CUT_CANONICAL_")) throw error;
+      throw new Error(`FINAL_CUT_CANONICAL_EXPORT_FAILED: ${detail}`);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  }
+}
+
+export function buildFinalCutCanonicalExportScript(exportPath: string): string {
+  return `
+using terms from application "System Events"
+
+on findMenuItem(container, expectedNames, timeoutSeconds, timeoutMessage)
+  set deadline to (current date) + timeoutSeconds
+  repeat
+    repeat with candidate in (menu items of container)
+      try
+        set candidateName to name of candidate as text
+        repeat with expectedName in expectedNames
+          if candidateName is (expectedName as text) then return candidate
+        end repeat
+      end try
+    end repeat
+    if (current date) > deadline then error timeoutMessage
+    delay 0.1
+  end repeat
+end findMenuItem
+
+on findWindow(finalCut, expectedNames, timeoutSeconds, timeoutMessage)
+  set deadline to (current date) + timeoutSeconds
+  repeat
+    repeat with expectedName in expectedNames
+      try
+        if exists window (expectedName as text) of finalCut then return window (expectedName as text) of finalCut
+      end try
+    end repeat
+    if (current date) > deadline then error timeoutMessage
+    delay 0.1
+  end repeat
+end findWindow
+
+on pressButtonIfPresent(targetWindow, expectedNames)
+  repeat with candidate in (buttons of targetWindow)
+    try
+      set candidateName to name of candidate as text
+      repeat with expectedName in expectedNames
+        if candidateName is (expectedName as text) and enabled of candidate then
+          perform action "AXPress" of candidate
+          return true
+        end if
+      end repeat
+    end try
+  end repeat
+  return false
+end pressButtonIfPresent
+
+end using terms from
+
+tell application "System Events"
+  tell process "Final Cut Pro"
+    if not frontmost then error "FINAL_CUT_CANONICAL_NOT_FRONTMOST: Final Cut Pro must be frontmost"
+    set finalCut to it
+    set fileMenu to menu "File" of menu bar 1
+    set exportCommand to missing value
+    try
+      set exportCommand to my findMenuItem(fileMenu, {"Export XML…", "Export XML..."}, 10, "FINAL_CUT_CANONICAL_EXPORT_MENU_UNAVAILABLE: File > Export XML was not exposed")
+    on error
+      set exportMenuItem to my findMenuItem(fileMenu, {"Export"}, 10, "FINAL_CUT_CANONICAL_EXPORT_MENU_UNAVAILABLE: File > Export was not exposed")
+      perform action "AXPress" of exportMenuItem
+      set exportMenu to missing value
+      repeat 100 times
+        try
+          if exists menu "Export" of exportMenuItem then
+            set exportMenu to menu "Export" of exportMenuItem
+            exit repeat
+          end if
+        end try
+        delay 0.1
+      end repeat
+      if exportMenu is missing value then error "FINAL_CUT_CANONICAL_EXPORT_MENU_UNAVAILABLE: Export submenu was not exposed"
+      set exportCommand to my findMenuItem(exportMenu, {"XML…", "XML..."}, 10, "FINAL_CUT_CANONICAL_EXPORT_MENU_UNAVAILABLE: Export XML command was not exposed")
+    end try
+    perform action "AXPress" of exportCommand
+    set exportWindow to my findWindow(finalCut, {"Export XML", "XML"}, 15, "FINAL_CUT_CANONICAL_EXPORT_WINDOW_UNAVAILABLE: Export XML window did not appear")
+    my pressButtonIfPresent(exportWindow, {"Next…", "Next...", "Export"})
+    delay 0.2
+    set saveWindow to my findWindow(finalCut, {"Save", "Export XML"}, 15, "FINAL_CUT_CANONICAL_SAVE_WINDOW_UNAVAILABLE: XML save window did not appear")
+    keystroke "g" using {command down, shift down}
+    repeat 50 times
+      try
+        if exists sheet 1 of saveWindow then exit repeat
+      end try
+      delay 0.1
+    end repeat
+    if not (exists sheet 1 of saveWindow) then error "FINAL_CUT_CANONICAL_SAVE_WINDOW_UNAVAILABLE: save path sheet did not appear"
+    set pathSheet to sheet 1 of saveWindow
+    if (count of text fields of pathSheet) is 0 then error "FINAL_CUT_CANONICAL_SAVE_PATH_UNAVAILABLE: save path field did not appear"
+    set value of text field 1 of pathSheet to ${appleScriptString(exportPath)}
+    key code 36
+    delay 0.2
+    if exists button "Save" of saveWindow then click button "Save" of saveWindow
+    delay 0.2
+    if exists button "Replace" of saveWindow then click button "Replace" of saveWindow
+    return "canonical-export-requested"
+  end tell
+end tell`;
+}
+
+export function createFinalCutNativeTargetResolver(
+  native: Pick<NativeFinalCutEditor, "searchMedia" | "locateOccurrence">,
+): CanonicalNativeTargetResolver {
+  return async (clip, snapshot) => {
+    if (!clip.mediaId) throw new Error(`TARGET_MISMATCH: occurrence ${clip.id} has no media binding`);
+    const media = snapshot.media.find(({ mediaId }) => mediaId === clip.mediaId);
+    if (!media?.source) throw new Error(`TARGET_MISMATCH: media ${clip.mediaId} has no source binding`);
+    const query = sourceBasename(media.source);
+    if (!query) throw new Error(`TARGET_MISMATCH: media ${clip.mediaId} has no searchable source basename`);
+
+    const matches = (await native.searchMedia(query)).filter((match) => match.name.toLocaleLowerCase() === query.toLocaleLowerCase());
+    if (matches.length === 0) throw new Error(`TARGET_MISMATCH: Final Cut Browser has no exact media match for ${query}`);
+    if (matches.length > 1) throw new Error(`AMBIGUOUS_PROJECT_TARGET: Final Cut Browser has multiple exact media matches for ${query}`);
+    const match = matches[0]!;
+    if (!match.sourceIdentity) throw new Error("TARGET_MISMATCH: exact Browser media has no stable source identity");
+
+    const located = await native.locateOccurrence(match.handle);
+    if (located.status === "none" || located.occurrences.length === 0) {
+      throw new Error(`TARGET_MISMATCH: Final Cut timeline has no occurrence for ${query}`);
+    }
+    if (located.status !== "unique" || located.occurrences.length !== 1) {
+      throw new Error(`AMBIGUOUS_PROJECT_TARGET: Final Cut timeline has multiple occurrences for ${query}`);
+    }
+    const occurrence = located.occurrences[0]!;
+    if (occurrence.sourceIdentity && occurrence.sourceIdentity !== match.sourceIdentity) {
+      throw new Error(`TARGET_MISMATCH: native occurrence source identity changed for ${clip.id}`);
+    }
+    if (!occurrence.start || !occurrence.duration || !clip.startTime || !clip.durationTime) {
+      throw new Error(`TARGET_MISMATCH: exact timeline coordinates are unavailable for ${clip.id}`);
+    }
+    if (!sameRationalText(occurrence.start, clip.startTime) || !sameRationalText(occurrence.duration, clip.durationTime)) {
+      throw new Error(`TARGET_MISMATCH: native occurrence coordinates changed for ${clip.id}`);
+    }
+  };
 }
 
 interface PendingNativeOperation {
@@ -223,4 +405,51 @@ function assertSameRevision(expected: ContextRevision, actual: ContextRevision):
 
 function sameRevision(left: ContextRevision, right: ContextRevision): boolean {
   return left.id === right.id && left.sequence === right.sequence;
+}
+
+async function executeCanonicalAppleScript(script: string): Promise<string> {
+  try {
+    const result = await execFile("osascript", ["-e", script], { maxBuffer: 1_000_000 });
+    return result.stdout.trim();
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    if (detail.includes("not authorized") || detail.includes("-1743") || detail.includes("-25211")) {
+      throw new Error(`FINAL_CUT_CANONICAL_PERMISSION_REQUIRED: ${detail}`);
+    }
+    throw new Error(`FINAL_CUT_CANONICAL_AUTOMATION_FAILED: ${detail}`);
+  }
+}
+
+async function waitForExportFile(path: string, timeoutMs: number, pollIntervalMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() <= deadline) {
+    try {
+      const details = await stat(path);
+      if (details.isFile() && details.size > 0) return;
+    } catch {
+      // The Save dialog may still be open.
+    }
+    await new Promise((resolve) => setTimeout(resolve, Math.min(pollIntervalMs, Math.max(1, deadline - Date.now()))));
+  }
+  throw new Error(`FINAL_CUT_CANONICAL_EXPORT_TIMEOUT: Final Cut did not create ${path}`);
+}
+
+function sourceBasename(source: string): string {
+  const withoutQuery = source.split(/[?#]/, 1)[0] ?? source;
+  try {
+    const url = new URL(withoutQuery);
+    return basename(decodeURIComponent(url.pathname));
+  } catch {
+    return basename(withoutQuery.replace(/^file:\/\//, ""));
+  }
+}
+
+function sameRationalText(value: string, expected: { value: string; timescale: string }): boolean {
+  const match = value.trim().match(/^(-?\d+)\/(\d+)$/);
+  if (!match || Number(match[2]) <= 0 || Number(expected.timescale) <= 0) return false;
+  return BigInt(match[1]!) * BigInt(expected.timescale) === BigInt(expected.value) * BigInt(match[2]!);
+}
+
+function appleScriptString(value: string): string {
+  return `"${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"').replace(/[\r\n]/g, " ")}"`;
 }

--- a/adapters/final-cut/typescript/src/canonical.ts
+++ b/adapters/final-cut/typescript/src/canonical.ts
@@ -324,16 +324,36 @@ export class FinalCutCanonicalNativeProvider implements EditorPort, LiveEditorSt
       afterRevision: before.revision,
     };
 
-    const after = await this.readProject();
-    const afterClip = after.timeline.clips.find(({ id }) => id === operation.clipId);
-    if (!afterClip || afterClip.name !== operation.name) {
-      throw new Error("FINAL_CUT_CANONICAL_READBACK_FAILED: renamed occurrence was not read back from Final Cut");
+    try {
+      const after = await this.readProject();
+      const afterClip = after.timeline.clips.find(({ id }) => id === operation.clipId);
+      if (!afterClip || afterClip.name !== operation.name) {
+        throw new Error("FINAL_CUT_CANONICAL_READBACK_FAILED: renamed occurrence was not read back from Final Cut");
+      }
+      if (canonicalSnapshotDigest(after) === this.pending.beforeDigest) {
+        throw new Error("FINAL_CUT_CANONICAL_READBACK_FAILED: native edit did not change the canonical digest");
+      }
+      this.pending.afterRevision = after.revision;
+      return after.revision;
+    } catch (error) {
+      try {
+        const undone = await this.native.undo(nativeResult.operationId);
+        if (!undone.undone || undone.verification?.verified !== true) {
+          throw new Error("native Undo did not verify restoration");
+        }
+        const restored = await this.readProject();
+        if (canonicalSnapshotDigest(restored) !== this.pending.beforeDigest) {
+          throw new Error("restored canonical digest does not match the pre-edit state");
+        }
+      } catch (rollbackError) {
+        const original = error instanceof Error ? error.message : String(error);
+        const rollback = rollbackError instanceof Error ? rollbackError.message : String(rollbackError);
+        throw new Error(`FINAL_CUT_CANONICAL_ROLLBACK_FAILED: ${rollback}; original error: ${original}`);
+      } finally {
+        this.pending = undefined;
+      }
+      throw error;
     }
-    if (canonicalSnapshotDigest(after) === this.pending.beforeDigest) {
-      throw new Error("FINAL_CUT_CANONICAL_READBACK_FAILED: native edit did not change the canonical digest");
-    }
-    this.pending.afterRevision = after.revision;
-    return after.revision;
   }
 
   public async restore(snapshot: ProjectSnapshot, expectedRevision: ContextRevision): Promise<void> {

--- a/adapters/final-cut/typescript/src/canonical.ts
+++ b/adapters/final-cut/typescript/src/canonical.ts
@@ -65,8 +65,7 @@ export class FinalCutCanonicalSnapshotSource {
     const exportPath = join(directory, "active.fcpxml");
     try {
       await this.executor(buildFinalCutCanonicalExportScript(exportPath));
-      await waitForExportFile(exportPath, this.exportTimeoutMs, this.pollIntervalMs);
-      return new FcpxmlDocumentAdapter(exportPath).readProject();
+      return await readCanonicalExport(exportPath, this.exportTimeoutMs, this.pollIntervalMs);
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
       if (detail.includes("FINAL_CUT_CANONICAL_")) throw error;
@@ -440,18 +439,34 @@ async function executeCanonicalAppleScript(script: string): Promise<string> {
   }
 }
 
-async function waitForExportFile(path: string, timeoutMs: number, pollIntervalMs: number): Promise<void> {
+async function readCanonicalExport(path: string, timeoutMs: number, pollIntervalMs: number): Promise<ProjectSnapshot> {
   const deadline = Date.now() + timeoutMs;
+  let previousSignature: string | undefined;
+  let lastReadError: unknown;
+
   while (Date.now() <= deadline) {
+    let signature: string | undefined;
     try {
       const details = await stat(path);
-      if (details.isFile() && details.size > 0) return;
+      if (details.isFile() && details.size > 0) {
+        signature = `${details.size}:${details.mtimeMs}`;
+      }
     } catch {
       // The Save dialog may still be open.
     }
+
+    if (signature && signature === previousSignature) {
+      try {
+        return await new FcpxmlDocumentAdapter(path).readProject();
+      } catch (error) {
+        lastReadError = error;
+      }
+    }
+    previousSignature = signature;
     await new Promise((resolve) => setTimeout(resolve, Math.min(pollIntervalMs, Math.max(1, deadline - Date.now()))));
   }
-  throw new Error(`FINAL_CUT_CANONICAL_EXPORT_TIMEOUT: Final Cut did not create ${path}`);
+  const detail = lastReadError instanceof Error ? `: ${lastReadError.message}` : "";
+  throw new Error(`FINAL_CUT_CANONICAL_EXPORT_TIMEOUT: Final Cut did not provide a complete export at ${path}${detail}`);
 }
 
 function sourceBasename(source: string): string {

--- a/adapters/final-cut/typescript/src/canonical.ts
+++ b/adapters/final-cut/typescript/src/canonical.ts
@@ -1,0 +1,226 @@
+import {
+  canonicalSnapshotDigest,
+  withCapabilityFamilies,
+  type ContextRevision,
+  type EditorChange,
+  type EditorIdentity,
+  type EditorLiveState,
+  type EditOperation,
+  type EditorPort,
+  type LiveEditorStatePort,
+  type ProjectCatalog,
+  type ProjectSelection,
+  type ProjectSnapshot,
+  type RuntimeCapabilities,
+} from "@framekit/runtime";
+
+export interface CanonicalNativeMutationPort {
+  renameSelectedClip(name: string): Promise<{ operationId: string; undoAvailable: boolean }>;
+  undo(operationId: string): Promise<{ undone: boolean; verification?: { verified: boolean } }>;
+}
+
+export type CanonicalNativeTargetResolver = (
+  clip: ProjectSnapshot["timeline"]["clips"][number],
+  snapshot: ProjectSnapshot,
+) => Promise<void>;
+
+export interface FinalCutCanonicalNativeProviderOptions {
+  live: LiveEditorStatePort & { getIdentity(): Promise<EditorIdentity> };
+  native: CanonicalNativeMutationPort;
+  readSnapshot: () => Promise<ProjectSnapshot>;
+  resolveTarget: CanonicalNativeTargetResolver;
+}
+
+interface PendingNativeOperation {
+  operationId: string;
+  beforeDigest: string;
+  beforeRevision: ContextRevision;
+  afterRevision: ContextRevision;
+}
+
+/**
+ * Canonical provider for the headed Final Cut UI path.
+ *
+ * `readSnapshot` must export the currently active Final Cut project through
+ * Final Cut itself. It is deliberately injected so the provider cannot fall
+ * back to an arbitrary FCPXML artifact. Native mutation is separately bound
+ * to one exported occurrence before Accessibility is allowed to edit it.
+ */
+export class FinalCutCanonicalNativeProvider implements EditorPort, LiveEditorStatePort {
+  private readonly live: FinalCutCanonicalNativeProviderOptions["live"];
+  private readonly native: CanonicalNativeMutationPort;
+  private readonly readSnapshotSource: () => Promise<ProjectSnapshot>;
+  private readonly resolveTarget: CanonicalNativeTargetResolver;
+  private lastDigest?: string;
+  private lastSnapshot?: ProjectSnapshot;
+  private revisionSequence = 0;
+  private revision?: ContextRevision;
+  private pending?: PendingNativeOperation;
+
+  public constructor(options: FinalCutCanonicalNativeProviderOptions) {
+    this.live = options.live;
+    this.native = options.native;
+    this.readSnapshotSource = options.readSnapshot;
+    this.resolveTarget = options.resolveTarget;
+  }
+
+  public async getIdentity(): Promise<EditorIdentity> {
+    const identity = await this.live.getIdentity();
+    return { ...identity, backend: "final-cut-native-canonical" };
+  }
+
+  public async getCapabilities(): Promise<RuntimeCapabilities> {
+    return withCapabilityFamilies({
+      editor: {
+        projectRead: true,
+        timelineSnapshotRead: true,
+        timelineWrite: true,
+        timelineArtifactWrite: false,
+        readAfterWrite: true,
+        incrementalChanges: true,
+        rollback: true,
+        assetDiscovery: false,
+        liveStateRead: true,
+        playheadWrite: false,
+        frameCapture: false,
+        playbackControl: false,
+        projectCatalogRead: true,
+        projectSelection: true,
+      },
+      analyzers: {
+        speechTranscribe: false,
+        speechVad: false,
+        audioLoudness: false,
+        visualTrack: false,
+      },
+    }, {
+      backend: "final-cut-native-canonical",
+      connectionBackend: "workflow-extension-ipc",
+      canonicalDocument: { read: true, write: true, artifactWrite: false },
+    });
+  }
+
+  public async read(): Promise<ProjectSnapshot> {
+    return this.readProject();
+  }
+
+  public async readProject(): Promise<ProjectSnapshot> {
+    const snapshot = await this.readSnapshotSource();
+    await this.assertActiveTarget(snapshot);
+    const digest = canonicalSnapshotDigest(snapshot);
+    if (digest !== this.lastDigest || !this.revision) {
+      this.revisionSequence = Math.max(this.revisionSequence + 1, snapshot.revision.sequence + 1);
+      this.lastDigest = digest;
+      this.revision = {
+        id: `canonical:${digest}`,
+        sequence: this.revisionSequence,
+        timestamp: new Date().toISOString(),
+      };
+    }
+    this.lastSnapshot = { ...snapshot, revision: this.revision };
+    return structuredClone(this.lastSnapshot);
+  }
+
+  public async apply(operation: EditOperation, expectedRevision: ContextRevision): Promise<ContextRevision> {
+    const before = await this.readProject();
+    assertSameRevision(expectedRevision, before.revision);
+    if (operation.type !== "rename-clip") {
+      throw new Error(`CAPABILITY_UNAVAILABLE: final-cut native canonical provider does not support ${operation.type}`);
+    }
+    const clip = before.timeline.clips.find(({ id }) => id === operation.clipId);
+    if (!clip) throw new Error(`CLIP_NOT_FOUND: ${operation.clipId}`);
+
+    await this.resolveTarget(clip, before);
+    const nativeResult = await this.native.renameSelectedClip(operation.name);
+    if (!nativeResult.operationId || !nativeResult.undoAvailable) {
+      throw new Error("FINAL_CUT_CANONICAL_UNDO_UNAVAILABLE: native rename did not expose Undo");
+    }
+    this.pending = {
+      operationId: nativeResult.operationId,
+      beforeDigest: canonicalSnapshotDigest(before),
+      beforeRevision: before.revision,
+      afterRevision: before.revision,
+    };
+
+    const after = await this.readProject();
+    const afterClip = after.timeline.clips.find(({ id }) => id === operation.clipId);
+    if (!afterClip || afterClip.name !== operation.name) {
+      throw new Error("FINAL_CUT_CANONICAL_READBACK_FAILED: renamed occurrence was not read back from Final Cut");
+    }
+    if (canonicalSnapshotDigest(after) === this.pending.beforeDigest) {
+      throw new Error("FINAL_CUT_CANONICAL_READBACK_FAILED: native edit did not change the canonical digest");
+    }
+    this.pending.afterRevision = after.revision;
+    return after.revision;
+  }
+
+  public async restore(snapshot: ProjectSnapshot, expectedRevision: ContextRevision): Promise<void> {
+    const current = await this.readProject();
+    assertSameRevision(expectedRevision, current.revision);
+    const pending = this.pending;
+    if (!pending || !sameRevision(pending.afterRevision, expectedRevision)) {
+      throw new Error("FINAL_CUT_CANONICAL_UNDO_STALE: native operation is not the current canonical edit");
+    }
+    if (canonicalSnapshotDigest(snapshot) !== pending.beforeDigest) {
+      throw new Error("FINAL_CUT_CANONICAL_UNDO_TARGET_MISMATCH: rollback target differs from the applied edit");
+    }
+    const undone = await this.native.undo(pending.operationId);
+    if (!undone.undone || undone.verification?.verified !== true) {
+      throw new Error("FINAL_CUT_CANONICAL_UNDO_FAILED: Final Cut did not verify native Undo");
+    }
+    const restored = await this.readProject();
+    if (canonicalSnapshotDigest(restored) !== pending.beforeDigest) {
+      throw new Error("FINAL_CUT_CANONICAL_UNDO_FAILED: restored canonical digest does not match the pre-edit state");
+    }
+    this.pending = undefined;
+  }
+
+  public async listProjects(): Promise<ProjectCatalog> {
+    const snapshot = await this.readProject();
+    return {
+      projects: [{
+        id: snapshot.projectId,
+        name: snapshot.projectName,
+        sequences: [{ id: snapshot.timeline.id, name: snapshot.timeline.name }],
+      }],
+      activeProjectId: snapshot.projectId,
+      activeSequenceId: snapshot.timeline.id,
+    };
+  }
+
+  public async selectProject(selection: ProjectSelection): Promise<ProjectCatalog> {
+    const catalog = await this.listProjects();
+    const project = catalog.projects.find(({ id }) => id === selection.projectId);
+    if (!project) throw new Error(`TARGET_MISMATCH: active project is not ${selection.projectId}`);
+    const sequenceId = selection.sequenceId ?? (project.sequences.length === 1 ? project.sequences[0]?.id : undefined);
+    if (!sequenceId) throw new Error(`AMBIGUOUS_PROJECT_TARGET: sequenceId is required for ${selection.projectId}`);
+    if (sequenceId !== catalog.activeSequenceId) throw new Error(`TARGET_MISMATCH: active sequence is not ${sequenceId}`);
+    return catalog;
+  }
+
+  public async readLiveState(): Promise<EditorLiveState> {
+    return this.live.readLiveState();
+  }
+
+  public async liveChangesSince(revision: ContextRevision, waitMs = 0): Promise<EditorChange[]> {
+    return this.live.liveChangesSince(revision, waitMs);
+  }
+
+  private async assertActiveTarget(snapshot: ProjectSnapshot): Promise<void> {
+    const live = await this.live.readLiveState();
+    if (live.project && live.project.name !== snapshot.projectName) {
+      throw new Error(`TARGET_MISMATCH: exported project ${snapshot.projectName} is not active Final Cut project ${live.project.name}`);
+    }
+    if (live.sequence && live.sequence.name !== snapshot.timeline.name) {
+      throw new Error(`TARGET_MISMATCH: exported sequence ${snapshot.timeline.name} is not active Final Cut sequence ${live.sequence.name}`);
+    }
+  }
+}
+
+function assertSameRevision(expected: ContextRevision, actual: ContextRevision): void {
+  if (!sameRevision(expected, actual)) throw new Error("STALE_CONTEXT: canonical Final Cut revision changed before mutation");
+}
+
+function sameRevision(left: ContextRevision, right: ContextRevision): boolean {
+  return left.id === right.id && left.sequence === right.sequence;
+}

--- a/adapters/final-cut/typescript/src/connection.ts
+++ b/adapters/final-cut/typescript/src/connection.ts
@@ -57,6 +57,19 @@ export interface FinalCutConnectionOptions {
   sleep?: (milliseconds: number) => Promise<void>;
 }
 
+export interface CanonicalProviderConfiguration {
+  required: boolean;
+  fcpxmlPath?: string;
+}
+
+export function assertCanonicalProviderConfiguration(options: CanonicalProviderConfiguration): void {
+  if (options.required && options.fcpxmlPath?.trim()) {
+    throw new Error(
+      "FINAL_CUT_CANONICAL_FALLBACK_CONFLICT: canonical provider mode cannot use FRAMEKIT_FCPXML_PATH",
+    );
+  }
+}
+
 export interface FinalCutActivationOptions {
   signal?: AbortSignal;
   timeoutMs?: number;

--- a/adapters/final-cut/typescript/src/connection.ts
+++ b/adapters/final-cut/typescript/src/connection.ts
@@ -37,6 +37,8 @@ export interface FinalCutConnectionStatus {
 export interface FinalCutConnectionOptions {
   /** Probe an existing Workflow Extension socket without launching or activating Final Cut. */
   headless?: boolean;
+  /** Require an external provider that advertises verified canonical writes. */
+  canonicalProviderRequired?: boolean;
   socketPath?: string;
   extensionSourcePath?: string;
   extensionInstallPath?: string;
@@ -78,6 +80,7 @@ const DEFAULT_EXTENSION_NAME = "FramekitFinalCutWorkflow.app";
 export class FinalCutConnectionManager {
   private readonly socketPath: string;
   private readonly headless: boolean;
+  private readonly canonicalProviderRequired: boolean;
   private readonly extensionSourcePath?: string;
   private readonly extensionInstallPath: string;
   private readonly finalCutApp: string;
@@ -101,6 +104,8 @@ export class FinalCutConnectionManager {
   public constructor(options: FinalCutConnectionOptions = {}) {
     this.socketPath = options.socketPath ?? process.env.FRAMEKIT_FINAL_CUT_SOCKET ?? DEFAULT_FINAL_CUT_LIVE_SOCKET;
     this.headless = options.headless ?? process.env.FRAMEKIT_FINAL_CUT_HEADLESS === "1";
+    this.canonicalProviderRequired = options.canonicalProviderRequired
+      ?? process.env.FRAMEKIT_FINAL_CUT_CANONICAL_REQUIRED === "1";
     this.extensionInstallPath = options.extensionInstallPath
       ?? process.env.FRAMEKIT_EXTENSION_INSTALL_PATH
       ?? join(homedir(), "Applications", DEFAULT_EXTENSION_NAME);
@@ -166,6 +171,14 @@ export class FinalCutConnectionManager {
       this.update({ state: "detecting", lastError: undefined });
       const existing = await this.tryProbe();
       if (existing) return this.ready(existing);
+
+      if (this.canonicalProviderRequired) {
+        return this.fail(
+          "FINAL_CUT_CANONICAL_PROVIDER_UNAVAILABLE",
+          `Canonical live provider is unavailable at ${this.socketPath}; metadata-only fallback is disabled`,
+          "needs-user-action",
+        );
+      }
 
       if (this.headless) {
         return this.fail(
@@ -265,15 +278,23 @@ export class FinalCutConnectionManager {
   }
 
   private ready(result: { identity: EditorIdentity; capabilities: RuntimeCapabilities }): FinalCutConnectionStatus {
+    const capabilities = withCapabilityFamilies(result.capabilities, {
+      backend: result.identity.backend,
+      connectionBackend: result.identity.backend,
+    });
+    if (this.canonicalProviderRequired && capabilities.editor.canonicalTimelineMode !== "canonical-write") {
+      return this.fail(
+        "FINAL_CUT_CANONICAL_PROVIDER_REQUIRED",
+        `Canonical live provider at ${this.socketPath} reports ${capabilities.editor.canonicalTimelineMode}; canonical-write is required`,
+        "needs-user-action",
+      );
+    }
     this.update({
       state: "ready",
       editorDetected: true,
       extensionInstalled: true,
       identity: result.identity,
-      capabilities: withCapabilityFamilies(result.capabilities, {
-        backend: result.identity.backend,
-        connectionBackend: result.identity.backend,
-      }),
+      capabilities,
       lastError: undefined,
     });
     return this.getStatus();

--- a/adapters/final-cut/typescript/src/index.ts
+++ b/adapters/final-cut/typescript/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./fcpxml.js";
 export * from "./live.js";
 export * from "./connection.js";
+export * from "./canonical.js";
 export * from "./session.js";
 export * from "./analyzers.js";
 export * from "./assets.js";

--- a/apps/mcp-server/src/main.ts
+++ b/apps/mcp-server/src/main.ts
@@ -100,17 +100,23 @@ const nativeEditor = liveMode
       nativeOperationLease,
     })
   : undefined;
+const canonicalNativeMutationEditor = canonicalNativeProviderEnabled
+  ? new FinalCutNativeAutomationAdapter({
+      enabled: true,
+      nativeOperationLease,
+    })
+  : nativeEditor;
 
 const canonicalNativeProvider = canonicalNativeProviderEnabled
   ? new FinalCutCanonicalNativeProvider({
       live: liveAdapter!,
       native: {
         renameSelectedClip: async (name) => {
-          const result = await nativeEditor!.edit({ type: "rename-selected-clip", name });
+          const result = await canonicalNativeMutationEditor!.edit({ type: "rename-selected-clip", name });
           return { operationId: result.operationId, undoAvailable: result.undoAvailable };
         },
         undo: async (operationId) => {
-          const result = await nativeEditor!.undo(operationId);
+          const result = await canonicalNativeMutationEditor!.undo(operationId);
           return { undone: result.undone, verification: result.verification };
         },
       },

--- a/apps/mcp-server/src/main.ts
+++ b/apps/mcp-server/src/main.ts
@@ -6,6 +6,7 @@ import {
   FcpxmlDocumentAdapter,
   FinalCutAssetRegistry,
   FinalCutConnectionManager,
+  assertCanonicalProviderConfiguration,
   FinalCutNativeAutomationAdapter,
   DisposableNativeEditWorkflow,
   FinalCutProjectPublisher,
@@ -66,7 +67,11 @@ const fixture = new InMemoryEditorAdapter({
 const liveMode = process.env.FRAMEKIT_EDITOR === "final-cut-live";
 const headlessFinalCut = liveMode && process.env.FRAMEKIT_FINAL_CUT_HEADLESS === "1";
 const fcpxmlPath = liveMode ? process.env.FRAMEKIT_FCPXML_PATH : undefined;
-const connection = liveMode ? new FinalCutConnectionManager({ headless: headlessFinalCut }) : undefined;
+const canonicalProviderRequired = liveMode && process.env.FRAMEKIT_FINAL_CUT_CANONICAL_REQUIRED === "1";
+assertCanonicalProviderConfiguration({ required: canonicalProviderRequired, fcpxmlPath });
+const connection = liveMode
+  ? new FinalCutConnectionManager({ headless: headlessFinalCut, canonicalProviderRequired })
+  : undefined;
 const autoConnect = liveMode && process.env.FRAMEKIT_AUTO_CONNECT !== "0";
 if (autoConnect) connection?.startAutoConnect();
 const liveAdapter = liveMode ? createFinalCutLiveAdapter() : undefined;

--- a/apps/mcp-server/src/main.ts
+++ b/apps/mcp-server/src/main.ts
@@ -7,7 +7,10 @@ import {
   FinalCutAssetRegistry,
   FinalCutConnectionManager,
   assertCanonicalProviderConfiguration,
+  FinalCutCanonicalNativeProvider,
+  FinalCutCanonicalSnapshotSource,
   FinalCutNativeAutomationAdapter,
+  createFinalCutNativeTargetResolver,
   DisposableNativeEditWorkflow,
   FinalCutProjectPublisher,
   FinalCutVideoExporter,
@@ -67,8 +70,17 @@ const fixture = new InMemoryEditorAdapter({
 const liveMode = process.env.FRAMEKIT_EDITOR === "final-cut-live";
 const headlessFinalCut = liveMode && process.env.FRAMEKIT_FINAL_CUT_HEADLESS === "1";
 const fcpxmlPath = liveMode ? process.env.FRAMEKIT_FCPXML_PATH : undefined;
-const canonicalProviderRequired = liveMode && process.env.FRAMEKIT_FINAL_CUT_CANONICAL_REQUIRED === "1";
-assertCanonicalProviderConfiguration({ required: canonicalProviderRequired, fcpxmlPath });
+const canonicalNativeProviderEnabled = liveMode && process.env.FRAMEKIT_FINAL_CUT_CANONICAL_PROVIDER === "native";
+if (canonicalNativeProviderEnabled && headlessFinalCut) {
+  throw new Error("FINAL_CUT_CANONICAL_NATIVE_REQUIRES_HEADED: set FRAMEKIT_FINAL_CUT_HEADLESS=0 for the native provider");
+}
+if (canonicalNativeProviderEnabled && process.env.FRAMEKIT_FINAL_CUT_NATIVE_WRITES !== "1") {
+  throw new Error("FINAL_CUT_CANONICAL_NATIVE_REQUIRES_WRITES: set FRAMEKIT_FINAL_CUT_NATIVE_WRITES=1 for the native provider");
+}
+const canonicalProviderRequired = liveMode
+  && process.env.FRAMEKIT_FINAL_CUT_CANONICAL_REQUIRED === "1"
+  && !canonicalNativeProviderEnabled;
+assertCanonicalProviderConfiguration({ required: canonicalProviderRequired || canonicalNativeProviderEnabled, fcpxmlPath });
 const connection = liveMode
   ? new FinalCutConnectionManager({ headless: headlessFinalCut, canonicalProviderRequired })
   : undefined;
@@ -89,10 +101,28 @@ const nativeEditor = liveMode
     })
   : undefined;
 
+const canonicalNativeProvider = canonicalNativeProviderEnabled
+  ? new FinalCutCanonicalNativeProvider({
+      live: liveAdapter!,
+      native: {
+        renameSelectedClip: async (name) => {
+          const result = await nativeEditor!.edit({ type: "rename-selected-clip", name });
+          return { operationId: result.operationId, undoAvailable: result.undoAvailable };
+        },
+        undo: async (operationId) => {
+          const result = await nativeEditor!.undo(operationId);
+          return { undone: result.undone, verification: result.verification };
+        },
+      },
+      readSnapshot: () => new FinalCutCanonicalSnapshotSource().readSnapshot(),
+      resolveTarget: createFinalCutNativeTargetResolver(nativeEditor!),
+    })
+  : undefined;
+
 const editor = liveMode
   ? new FinalCutSessionAdapter({
-      live: liveAdapter!,
-      ...(fcpxmlPath
+      live: canonicalNativeProvider ?? liveAdapter!,
+      ...(fcpxmlPath && !canonicalNativeProviderEnabled
         ? (() => {
             const document = new FcpxmlDocumentAdapter(fcpxmlPath);
             return { snapshot: document, mutation: document };

--- a/docs/final-cut/installation.md
+++ b/docs/final-cut/installation.md
@@ -98,6 +98,58 @@ read-only procedure.
 
 ## Canonical document and analysis providers
 
+### Canonical live provider
+
+The bundled Framekit Workflow Extension is metadata-only. It can report the
+active Final Cut project, sequence, playhead, and range, but it does not expose
+complete timeline enumeration or canonical mutation. Do not treat that bridge
+as canonical-live support.
+
+For a provider that implements the v1 Framekit Unix-socket protocol, require a
+canonical-write connection explicitly:
+
+```sh
+FRAMEKIT_EDITOR=final-cut-live \
+FRAMEKIT_FINAL_CUT_CANONICAL_REQUIRED=1 \
+FRAMEKIT_FINAL_CUT_SOCKET=/absolute/path/to/canonical-provider.sock \
+FRAMEKIT_FINAL_CUT_HEADLESS=1 \
+pnpm run framekit -- mcp --editor final-cut-live --headless
+```
+
+The provider must advertise `projectRead`, `projectCatalogRead`,
+`projectSelection`, `timelineSnapshotRead`, `timelineWrite`, `readAfterWrite`,
+and `rollback`, and implement the `capabilities`, `projects`,
+`select-project`, `snapshot`, `apply`, and `restore` protocol methods. The
+connection is `ready` only when its normalized `canonicalTimelineMode` is
+`canonical-write`. If the socket is unavailable or reports metadata-only or
+canonical-read capabilities, Framekit returns an actionable
+`needs-user-action` status without launching Final Cut, installing the bundled
+extension, or falling back to an artifact.
+
+Leave `FRAMEKIT_FCPXML_PATH` unset in this mode. Combining it with
+`FRAMEKIT_FINAL_CUT_CANONICAL_REQUIRED=1` fails at startup with
+`FINAL_CUT_CANONICAL_FALLBACK_CONFLICT` rather than silently routing reads or
+writes to the artifact. The provider must report its Final Cut and macOS
+versions in its identity; the repository's supported transport boundary is
+protocol v1, while provider-specific version compatibility must be confirmed by
+the sanitized headed evidence.
+
+Use the canonical headed runners only with a disposable project and stable
+project, sequence, and occurrence IDs:
+
+```sh
+FRAMEKIT_FINAL_CUT_E2E_PROJECT="Framekit Canonical E2E" \
+pnpm run test:final-cut-canonical-read-headed
+
+FRAMEKIT_FINAL_CUT_E2E_PROJECT="Framekit Canonical E2E" \
+FRAMEKIT_FINAL_CUT_E2E_CLIP_ID="final-cut:occurrence:example" \
+pnpm run test:final-cut-canonical-headed
+```
+
+The mutation runner requires canonical-write mode and verifies the target,
+advancing revision, diff, and restored digest. Both runners emit sanitized
+evidence only; a metadata-only bundled bridge is not a passing result.
+
 To enable project/timeline reads, artifact edits, diffs, verification, and undo
 in the live MCP session, provide an exported FCPXML file:
 

--- a/docs/final-cut/installation.md
+++ b/docs/final-cut/installation.md
@@ -134,6 +134,34 @@ versions in its identity; the repository's supported transport boundary is
 protocol v1, while provider-specific version compatibility must be confirmed by
 the sanitized headed evidence.
 
+### Bundled headed canonical provider
+
+The repository also provides an explicit headed provider that composes the
+metadata socket with Final Cut's own UI. It exports the active timeline through
+`File > Export XML` into a private temporary file, parses that export as the
+canonical snapshot, and removes the file after each read. It does not read or
+write `FRAMEKIT_FCPXML_PATH`. The provider supports `rename-clip` after an exact
+Browser media match and a unique timeline occurrence with matching rational
+coordinates; native Accessibility Undo and a second export verify rollback.
+
+Use it only with Final Cut Pro 10.7.1 on the repository's macOS/Xcode 16.4
+baseline until a different Final Cut version has its own headed evidence:
+
+```sh
+FRAMEKIT_EDITOR=final-cut-live \
+FRAMEKIT_FINAL_CUT_CANONICAL_PROVIDER=native \
+FRAMEKIT_FINAL_CUT_NATIVE_WRITES=1 \
+FRAMEKIT_FINAL_CUT_HEADLESS=0 \
+pnpm run framekit -- mcp --editor final-cut-live
+```
+
+Keep `FRAMEKIT_FCPXML_PATH` unset. Open the disposable project and intended
+sequence in Final Cut before connecting, and grant Accessibility and Automation
+permission to the MCP host. `project.list` exposes the one active project and
+sequence; `project.select` must confirm that exact target. If the export,
+identity binding, readback, advancing revision, or native Undo verification is
+unavailable, the provider fails closed and must not claim canonical-write.
+
 Use the canonical headed runners only with a disposable project and stable
 project, sequence, and occurrence IDs:
 

--- a/docs/mcp/final-cut-live.md
+++ b/docs/mcp/final-cut-live.md
@@ -39,6 +39,35 @@ tool `connection.status` or:
 pnpm run framekit -- doctor finalcut --json
 ```
 
+### Canonical provider mode
+
+Canonical live mode is an explicit provider contract, not a capability inferred
+from a connected socket. Set `FRAMEKIT_FINAL_CUT_CANONICAL_REQUIRED=1` when the
+socket must provide canonical writes:
+
+```sh
+FRAMEKIT_EDITOR=final-cut-live \
+FRAMEKIT_FINAL_CUT_CANONICAL_REQUIRED=1 \
+FRAMEKIT_FINAL_CUT_SOCKET=/absolute/path/to/canonical-provider.sock \
+FRAMEKIT_FINAL_CUT_HEADLESS=1 \
+pnpm run framekit -- mcp --editor final-cut-live --headless
+```
+
+This mode accepts only a provider whose capability payload normalizes to
+`canonical-write`. A missing socket or a metadata-only/canonical-read provider
+returns `FINAL_CUT_CANONICAL_PROVIDER_UNAVAILABLE` or
+`FINAL_CUT_CANONICAL_PROVIDER_REQUIRED` before lifecycle recovery runs. The
+bundled Workflow Extension remains metadata-only and is never upgraded by this
+flag. `FRAMEKIT_FCPXML_PATH` must be omitted; setting it with the flag returns
+`FINAL_CUT_CANONICAL_FALLBACK_CONFLICT`.
+
+The provider must speak protocol v1 and support stable project/sequence
+catalog IDs, explicit selection, complete snapshots, apply, restore, and
+revision-bearing responses. `editor.inspect` is the first check; then use
+`project.list`, `project.select`, and `project.inspect` before a supported edit.
+Successful mutation evidence must show a target-matching before/after diff, an
+advancing revision, and a restored canonical digest after `edit.undo`.
+
 ## Headless mode
 
 For repository development without the plugin, start the equivalent headless

--- a/docs/mcp/final-cut-live.md
+++ b/docs/mcp/final-cut-live.md
@@ -68,6 +68,36 @@ revision-bearing responses. `editor.inspect` is the first check; then use
 Successful mutation evidence must show a target-matching before/after diff, an
 advancing revision, and a restored canonical digest after `edit.undo`.
 
+### Headed native canonical provider
+
+For the bundled provider, set `FRAMEKIT_FINAL_CUT_CANONICAL_PROVIDER=native`
+with headed native writes enabled:
+
+```sh
+FRAMEKIT_EDITOR=final-cut-live \
+FRAMEKIT_FINAL_CUT_CANONICAL_PROVIDER=native \
+FRAMEKIT_FINAL_CUT_NATIVE_WRITES=1 \
+FRAMEKIT_FINAL_CUT_HEADLESS=0 \
+pnpm run framekit -- mcp --editor final-cut-live
+```
+
+This provider uses the socket only for live identity/state and change events.
+Each canonical read drives Final Cut's `File > Export XML` command into a
+private temporary file, parses the result, and removes it. It never uses
+`FRAMEKIT_FCPXML_PATH`. The supported write is `rename-clip`: Framekit requires
+one exact Browser media result, one timeline occurrence, matching rational
+start/duration coordinates, native readback, an advancing canonical revision,
+and native Undo that restores the original canonical digest. Duplicate media,
+duplicate occurrences, stale coordinates, missing Accessibility identity, or
+any failed verification returns an error before claiming success.
+
+The headed baseline is Final Cut Pro 10.7.1 on the repository's macOS/Xcode
+16.4 environment. A different Final Cut version requires fresh headed evidence.
+Use a disposable project, open the intended sequence before connecting, and
+grant Accessibility and Automation permission to the MCP host. The provider
+exposes only the active project/sequence in `project.list`; it does not infer a
+project from an arbitrary artifact.
+
 ## Headless mode
 
 For repository development without the plugin, start the equivalent headless

--- a/scripts/final-cut-canonical-headed-e2e.mjs
+++ b/scripts/final-cut-canonical-headed-e2e.mjs
@@ -21,7 +21,9 @@ const transport = new StdioClientTransport({
     FRAMEKIT_EDITOR: "final-cut-live",
     FRAMEKIT_AUTO_CONNECT: "0",
     FRAMEKIT_FCPXML_PATH: "",
-    FRAMEKIT_FINAL_CUT_CANONICAL_REQUIRED: "1",
+    FRAMEKIT_FINAL_CUT_CANONICAL_PROVIDER: "native",
+    FRAMEKIT_FINAL_CUT_NATIVE_WRITES: "1",
+    FRAMEKIT_FINAL_CUT_HEADLESS: "0",
   },
   stderr: "pipe",
 });

--- a/scripts/final-cut-canonical-headed-e2e.mjs
+++ b/scripts/final-cut-canonical-headed-e2e.mjs
@@ -21,6 +21,7 @@ const transport = new StdioClientTransport({
     FRAMEKIT_EDITOR: "final-cut-live",
     FRAMEKIT_AUTO_CONNECT: "0",
     FRAMEKIT_FCPXML_PATH: "",
+    FRAMEKIT_FINAL_CUT_CANONICAL_REQUIRED: "1",
   },
   stderr: "pipe",
 });

--- a/scripts/final-cut-canonical-read-headed-e2e.mjs
+++ b/scripts/final-cut-canonical-read-headed-e2e.mjs
@@ -20,7 +20,6 @@ const transport = new StdioClientTransport({
     FRAMEKIT_EDITOR: "final-cut-live",
     FRAMEKIT_AUTO_CONNECT: "0",
     FRAMEKIT_FCPXML_PATH: "",
-    FRAMEKIT_FINAL_CUT_CANONICAL_REQUIRED: "1",
     FRAMEKIT_FINAL_CUT_HEADLESS: "0",
     FRAMEKIT_FINAL_CUT_NATIVE_WRITES: "0",
   },

--- a/scripts/final-cut-canonical-read-headed-e2e.mjs
+++ b/scripts/final-cut-canonical-read-headed-e2e.mjs
@@ -20,6 +20,7 @@ const transport = new StdioClientTransport({
     FRAMEKIT_EDITOR: "final-cut-live",
     FRAMEKIT_AUTO_CONNECT: "0",
     FRAMEKIT_FCPXML_PATH: "",
+    FRAMEKIT_FINAL_CUT_CANONICAL_REQUIRED: "1",
     FRAMEKIT_FINAL_CUT_HEADLESS: "0",
     FRAMEKIT_FINAL_CUT_NATIVE_WRITES: "0",
   },

--- a/scripts/final-cut-canonical-read-headed-e2e.mjs
+++ b/scripts/final-cut-canonical-read-headed-e2e.mjs
@@ -21,7 +21,8 @@ const transport = new StdioClientTransport({
     FRAMEKIT_AUTO_CONNECT: "0",
     FRAMEKIT_FCPXML_PATH: "",
     FRAMEKIT_FINAL_CUT_HEADLESS: "0",
-    FRAMEKIT_FINAL_CUT_NATIVE_WRITES: "0",
+    FRAMEKIT_FINAL_CUT_CANONICAL_PROVIDER: "native",
+    FRAMEKIT_FINAL_CUT_NATIVE_WRITES: "1",
   },
   stderr: "pipe",
 });

--- a/tests/integration/canonical-evidence.test.ts
+++ b/tests/integration/canonical-evidence.test.ts
@@ -10,7 +10,8 @@ test("canonical headed runner publishes the sanitized evidence contract", async 
   assert.match(runner, /sanitizeCanonicalEvidence/);
   assert.match(runner, /evidenceEnvironment\(root\)/);
   assert.match(runner, /editStatus: transaction\.status/);
-  assert.match(runner, /FRAMEKIT_FINAL_CUT_CANONICAL_REQUIRED: "1"/);
+  assert.match(runner, /FRAMEKIT_FINAL_CUT_CANONICAL_PROVIDER: "native"/);
+  assert.match(runner, /FRAMEKIT_FINAL_CUT_NATIVE_WRITES: "1"/);
   assert.match(runner, /JSON\.stringify\(evidence, null, 2\)/);
 });
 

--- a/tests/integration/canonical-evidence.test.ts
+++ b/tests/integration/canonical-evidence.test.ts
@@ -21,7 +21,6 @@ test("canonical headed read runner publishes a read-only sanitized evidence cont
   assert.match(runner, /project\.list/);
   assert.match(runner, /project\.inspect/);
   assert.doesNotMatch(runner, /timeline\.edit/);
-  assert.match(runner, /FRAMEKIT_FINAL_CUT_CANONICAL_REQUIRED: "1"/);
   assert.match(runner, /JSON\.stringify\(evidence, null, 2\)/);
 });
 

--- a/tests/integration/canonical-evidence.test.ts
+++ b/tests/integration/canonical-evidence.test.ts
@@ -10,6 +10,7 @@ test("canonical headed runner publishes the sanitized evidence contract", async 
   assert.match(runner, /sanitizeCanonicalEvidence/);
   assert.match(runner, /evidenceEnvironment\(root\)/);
   assert.match(runner, /editStatus: transaction\.status/);
+  assert.match(runner, /FRAMEKIT_FINAL_CUT_CANONICAL_REQUIRED: "1"/);
   assert.match(runner, /JSON\.stringify\(evidence, null, 2\)/);
 });
 
@@ -20,6 +21,7 @@ test("canonical headed read runner publishes a read-only sanitized evidence cont
   assert.match(runner, /project\.list/);
   assert.match(runner, /project\.inspect/);
   assert.doesNotMatch(runner, /timeline\.edit/);
+  assert.match(runner, /FRAMEKIT_FINAL_CUT_CANONICAL_REQUIRED: "1"/);
   assert.match(runner, /JSON\.stringify\(evidence, null, 2\)/);
 });
 

--- a/tests/integration/canonical-native-provider.test.ts
+++ b/tests/integration/canonical-native-provider.test.ts
@@ -231,6 +231,7 @@ test("canonical Final Cut export waits for a complete FCPXML file", async () => 
             .finally(resolve);
         }, 40);
       });
+      return "canonical-export-requested";
     },
   });
 

--- a/tests/integration/canonical-native-provider.test.ts
+++ b/tests/integration/canonical-native-provider.test.ts
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { appendFile, writeFile } from "node:fs/promises";
 import {
   buildFinalCutCanonicalExportScript,
   createFinalCutNativeTargetResolver,
+  FinalCutCanonicalSnapshotSource,
   FinalCutCanonicalNativeProvider,
   type CanonicalNativeTargetResolver,
 } from "@framekit/final-cut";
@@ -208,6 +210,37 @@ test("canonical Final Cut export is driven by the active timeline UI", () => {
   assert.match(script, /XML/);
   assert.match(script, /framekit-canonical\.fcpxml/);
   assert.doesNotMatch(script, /FRAMEKIT_FCPXML_PATH/);
+});
+
+test("canonical Final Cut export waits for a complete FCPXML file", async () => {
+  const completeDocument = "<?xml version=\"1.0\"?><fcpxml><resources/><library><event><project uid=\"project-export\" name=\"Exported\"><sequence uid=\"sequence-export\" name=\"Main\" duration=\"1s\"><spine/></sequence></project></event></library></fcpxml>";
+  let finishExport: Promise<void> | undefined;
+  const source = new FinalCutCanonicalSnapshotSource({
+    exportTimeoutMs: 500,
+    pollIntervalMs: 10,
+    executor: async (script) => {
+      const match = script.match(/set value of text field 1 of pathSheet to "([^"]+)"/);
+      assert.ok(match?.[1]);
+      const exportPath = match[1];
+      const partialDocument = completeDocument.slice(0, Math.floor(completeDocument.length / 2));
+      await writeFile(exportPath, partialDocument);
+      finishExport = new Promise((resolve) => {
+        setTimeout(() => {
+          void appendFile(exportPath, completeDocument.slice(partialDocument.length))
+            .catch(() => undefined)
+            .finally(resolve);
+        }, 40);
+      });
+    },
+  });
+
+  let project: ProjectSnapshot;
+  try {
+    project = await source.readSnapshot();
+  } finally {
+    await finishExport;
+  }
+  assert.equal(project!.projectName, "Exported");
 });
 
 test("canonical target resolver requires one exact native occurrence", async () => {

--- a/tests/integration/canonical-native-provider.test.ts
+++ b/tests/integration/canonical-native-provider.test.ts
@@ -1,0 +1,168 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  FinalCutCanonicalNativeProvider,
+  type CanonicalNativeTargetResolver,
+} from "@framekit/final-cut";
+import type {
+  ContextRevision,
+  EditorChange,
+  EditorIdentity,
+  EditorLiveState,
+  ProjectSnapshot,
+} from "@framekit/runtime";
+
+const identity: EditorIdentity = {
+  name: "Final Cut Pro",
+  version: "10.7.1",
+  backend: "workflow-extension-ipc",
+};
+
+function snapshot(name: string): ProjectSnapshot {
+  return {
+    projectId: "final-cut:project:project-1",
+    projectName: "Canonical E2E",
+    timeline: {
+      id: "final-cut:sequence:sequence-1",
+      name: "Canonical E2E",
+      duration: 4,
+      durationTime: { value: "96", timescale: "24" },
+      frameDuration: { value: "1", timescale: "24" },
+      clips: [{
+        id: "final-cut:occurrence:clip-1",
+        mediaId: "final-cut:media:media-1",
+        name,
+        start: 0,
+        duration: 4,
+        track: 0,
+        startTime: { value: "0", timescale: "24" },
+        durationTime: { value: "96", timescale: "24" },
+      }],
+      storyElements: [{
+        id: "final-cut:occurrence:clip-1",
+        kind: "asset-clip",
+        start: 0,
+        duration: 4,
+        startTime: { value: "0", timescale: "24" },
+        durationTime: { value: "96", timescale: "24" },
+        lane: 0,
+        mediaId: "final-cut:media:media-1",
+      }],
+      markers: [],
+      captions: [],
+    },
+    media: [{ mediaId: "final-cut:media:media-1", source: "/tmp/clip.mov" }],
+    revision: { id: "source-revision", sequence: 0, timestamp: new Date(0).toISOString() },
+  };
+}
+
+function liveState(): EditorLiveState {
+  return {
+    project: { id: "active-project", name: "Canonical E2E" },
+    sequence: {
+      id: "active-sequence",
+      name: "Canonical E2E",
+      startTime: { value: "0", timescale: "24" },
+      duration: { value: "96", timescale: "24" },
+      frameDuration: { value: "1", timescale: "24" },
+    },
+    revision: { id: "live-revision", sequence: 1, timestamp: new Date(1).toISOString() },
+  };
+}
+
+function providerFor(
+  snapshots: ProjectSnapshot[],
+  calls: string[],
+  resolveTarget: CanonicalNativeTargetResolver = async () => {},
+) {
+  const native = {
+    edit: async () => {
+      calls.push("edit");
+      return { operationId: "native-operation-1", undoAvailable: true };
+    },
+    undo: async () => {
+      calls.push("undo");
+      return { undone: true, verification: { verified: true, detail: "restored" } };
+    },
+  };
+  const live = {
+    getIdentity: async () => identity,
+    readLiveState: async () => liveState(),
+    liveChangesSince: async (_revision: ContextRevision, _waitMs?: number): Promise<EditorChange[]> => [],
+  };
+  return new FinalCutCanonicalNativeProvider({
+    live,
+    native,
+    readSnapshot: async () => {
+      const next = snapshots.shift();
+      if (!next) throw new Error("snapshot queue exhausted");
+      return structuredClone(next);
+    },
+    resolveTarget,
+  });
+}
+
+test("canonical native provider exposes one explicit active project and sequence", async () => {
+  const provider = providerFor([snapshot("Original")], []);
+
+  const catalog = await provider.listProjects();
+
+  assert.equal(catalog.projects.length, 1);
+  assert.equal(catalog.activeProjectId, "final-cut:project:project-1");
+  assert.equal(catalog.activeSequenceId, "final-cut:sequence:sequence-1");
+  assert.equal((await provider.getCapabilities()).editor.canonicalTimelineMode, "canonical-write");
+});
+
+test("canonical native provider rejects stale targets before native mutation", async () => {
+  const calls: string[] = [];
+  const provider = providerFor([snapshot("Original")], calls);
+  const before = await provider.readProject();
+
+  await assert.rejects(
+    provider.apply({
+      type: "rename-clip",
+      clipId: "final-cut:occurrence:clip-1",
+      name: "Renamed",
+      baseRevision: { id: "stale", sequence: before.revision.sequence },
+    }, { id: "stale", sequence: before.revision.sequence }),
+    /STALE_CONTEXT/,
+  );
+  assert.deepEqual(calls, []);
+});
+
+test("canonical native provider verifies native edit and restores its canonical digest", async () => {
+  const calls: string[] = [];
+  const provider = providerFor([snapshot("Original"), snapshot("Renamed"), snapshot("Original")], calls);
+  const before = await provider.readProject();
+  const afterRevision = await provider.apply({
+    type: "rename-clip",
+    clipId: "final-cut:occurrence:clip-1",
+    name: "Renamed",
+    baseRevision: before.revision,
+  }, before.revision);
+
+  assert.ok(afterRevision.sequence > before.revision.sequence);
+  assert.deepEqual(calls, ["edit"]);
+  await provider.restore(before, afterRevision);
+  assert.deepEqual(calls, ["edit", "undo"]);
+});
+
+test("canonical native provider rejects ambiguous occurrence bindings before edit", async () => {
+  const calls: string[] = [];
+  const resolveTarget: CanonicalNativeTargetResolver = async () => {
+    throw new Error("AMBIGUOUS_PROJECT_TARGET: occurrence binding is not unique");
+  };
+  const provider = providerFor([snapshot("Original")], calls, resolveTarget);
+  const before = await provider.readProject();
+
+  await assert.rejects(
+    provider.apply({
+      type: "rename-clip",
+      clipId: "final-cut:occurrence:clip-1",
+      name: "Renamed",
+      baseRevision: before.revision,
+    }, before.revision),
+    /AMBIGUOUS_PROJECT_TARGET/,
+  );
+  assert.deepEqual(calls, []);
+});

--- a/tests/integration/canonical-native-provider.test.ts
+++ b/tests/integration/canonical-native-provider.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  buildFinalCutCanonicalExportScript,
+  createFinalCutNativeTargetResolver,
   FinalCutCanonicalNativeProvider,
   type CanonicalNativeTargetResolver,
 } from "@framekit/final-cut";
@@ -171,4 +173,79 @@ test("canonical native provider rejects ambiguous occurrence bindings before edi
     /AMBIGUOUS_PROJECT_TARGET/,
   );
   assert.deepEqual(calls, []);
+});
+
+test("canonical Final Cut export is driven by the active timeline UI", () => {
+  const script = buildFinalCutCanonicalExportScript("/tmp/framekit-canonical.fcpxml");
+
+  assert.match(script, /File/);
+  assert.match(script, /Export/);
+  assert.match(script, /XML/);
+  assert.match(script, /framekit-canonical\.fcpxml/);
+  assert.doesNotMatch(script, /FRAMEKIT_FCPXML_PATH/);
+});
+
+test("canonical target resolver requires one exact native occurrence", async () => {
+  const native = {
+    searchMedia: async () => [{
+      handle: "media-handle",
+      name: "clip.mov",
+      sourceIdentity: "browser-source-1",
+    }],
+    locateOccurrence: async () => ({
+      status: "unique" as const,
+      occurrences: [{
+        handle: "occurrence-handle",
+        mediaHandle: "media-handle",
+        name: "Original",
+        start: "0/24",
+        duration: "96/24",
+      }],
+    }),
+  };
+
+  const resolver = createFinalCutNativeTargetResolver(native);
+  await resolver(snapshot("Original").timeline.clips[0]!, snapshot("Original"));
+});
+
+test("canonical target resolver rejects ambiguous native media", async () => {
+  const native = {
+    searchMedia: async () => [
+      { handle: "media-1", name: "clip.mov", sourceIdentity: "browser-source-1" },
+      { handle: "media-2", name: "clip.mov", sourceIdentity: "browser-source-2" },
+    ],
+    locateOccurrence: async () => ({ status: "none" as const, occurrences: [] }),
+  };
+  const resolver = createFinalCutNativeTargetResolver(native);
+
+  await assert.rejects(
+    resolver(snapshot("Original").timeline.clips[0]!, snapshot("Original")),
+    /AMBIGUOUS_PROJECT_TARGET/,
+  );
+});
+
+test("canonical target resolver rejects native coordinate drift", async () => {
+  const native = {
+    searchMedia: async () => [{
+      handle: "media-handle",
+      name: "clip.mov",
+      sourceIdentity: "browser-source-1",
+    }],
+    locateOccurrence: async () => ({
+      status: "unique" as const,
+      occurrences: [{
+        handle: "occurrence-handle",
+        mediaHandle: "media-handle",
+        name: "Original",
+        start: "24/24",
+        duration: "96/24",
+      }],
+    }),
+  };
+  const resolver = createFinalCutNativeTargetResolver(native);
+
+  await assert.rejects(
+    resolver(snapshot("Original").timeline.clips[0]!, snapshot("Original")),
+    /TARGET_MISMATCH/,
+  );
 });

--- a/tests/integration/canonical-native-provider.test.ts
+++ b/tests/integration/canonical-native-provider.test.ts
@@ -73,7 +73,7 @@ function liveState(): EditorLiveState {
 }
 
 function providerFor(
-  snapshots: ProjectSnapshot[],
+  snapshots: Array<ProjectSnapshot | Error>,
   calls: string[],
   resolveTarget: CanonicalNativeTargetResolver = async () => {},
 ) {
@@ -98,6 +98,7 @@ function providerFor(
     readSnapshot: async () => {
       const next = snapshots.shift();
       if (!next) throw new Error("snapshot queue exhausted");
+      if (next instanceof Error) throw next;
       return structuredClone(next);
     },
     resolveTarget,
@@ -153,6 +154,30 @@ test("canonical native provider verifies native edit and restores its canonical 
   assert.deepEqual(calls, ["edit"]);
   await provider.restore(before, afterRevision);
   assert.deepEqual(calls, ["edit", "undo"]);
+});
+
+test("canonical native provider undoes failed post-edit verification", async () => {
+  for (const [label, after] of [
+    ["read error", new Error("export read failed")],
+    ["name mismatch", snapshot("Unexpected")],
+    ["unchanged digest", snapshot("Original")],
+  ] as const) {
+    const calls: string[] = [];
+    const provider = providerFor([snapshot("Original"), snapshot("Original"), after, snapshot("Original")], calls);
+    const before = await provider.readProject();
+
+    await assert.rejects(
+      provider.apply({
+        type: "rename-clip",
+        clipId: "final-cut:occurrence:clip-1",
+        name: "Renamed",
+        baseRevision: before.revision,
+      }, before.revision),
+      { name: "Error" },
+      label,
+    );
+    assert.deepEqual(calls, ["edit", "undo"], label);
+  }
 });
 
 test("canonical native provider rejects ambiguous occurrence bindings before edit", async () => {

--- a/tests/integration/canonical-native-provider.test.ts
+++ b/tests/integration/canonical-native-provider.test.ts
@@ -125,8 +125,8 @@ test("canonical native provider rejects stale targets before native mutation", a
       type: "rename-clip",
       clipId: "final-cut:occurrence:clip-1",
       name: "Renamed",
-      baseRevision: { id: "stale", sequence: before.revision.sequence },
-    }, { id: "stale", sequence: before.revision.sequence }),
+      baseRevision: { ...before.revision, id: "stale" },
+    }, { ...before.revision, id: "stale" }),
     /STALE_CONTEXT/,
   );
   assert.deepEqual(calls, []);

--- a/tests/integration/canonical-native-provider.test.ts
+++ b/tests/integration/canonical-native-provider.test.ts
@@ -76,7 +76,7 @@ function providerFor(
   resolveTarget: CanonicalNativeTargetResolver = async () => {},
 ) {
   const native = {
-    edit: async () => {
+    renameSelectedClip: async () => {
       calls.push("edit");
       return { operationId: "native-operation-1", undoAvailable: true };
     },
@@ -115,7 +115,7 @@ test("canonical native provider exposes one explicit active project and sequence
 
 test("canonical native provider rejects stale targets before native mutation", async () => {
   const calls: string[] = [];
-  const provider = providerFor([snapshot("Original")], calls);
+  const provider = providerFor([snapshot("Original"), snapshot("Original")], calls);
   const before = await provider.readProject();
 
   await assert.rejects(
@@ -132,7 +132,13 @@ test("canonical native provider rejects stale targets before native mutation", a
 
 test("canonical native provider verifies native edit and restores its canonical digest", async () => {
   const calls: string[] = [];
-  const provider = providerFor([snapshot("Original"), snapshot("Renamed"), snapshot("Original")], calls);
+  const provider = providerFor([
+    snapshot("Original"),
+    snapshot("Original"),
+    snapshot("Renamed"),
+    snapshot("Renamed"),
+    snapshot("Original"),
+  ], calls);
   const before = await provider.readProject();
   const afterRevision = await provider.apply({
     type: "rename-clip",
@@ -152,7 +158,7 @@ test("canonical native provider rejects ambiguous occurrence bindings before edi
   const resolveTarget: CanonicalNativeTargetResolver = async () => {
     throw new Error("AMBIGUOUS_PROJECT_TARGET: occurrence binding is not unique");
   };
-  const provider = providerFor([snapshot("Original")], calls, resolveTarget);
+  const provider = providerFor([snapshot("Original"), snapshot("Original")], calls, resolveTarget);
   const before = await provider.readProject();
 
   await assert.rejects(

--- a/tests/integration/canonical-native-provider.test.ts
+++ b/tests/integration/canonical-native-provider.test.ts
@@ -159,11 +159,12 @@ test("canonical native provider verifies native edit and restores its canonical 
 });
 
 test("canonical native provider undoes failed post-edit verification", async () => {
-  for (const [label, after] of [
-    ["read error", new Error("export read failed")],
-    ["name mismatch", snapshot("Unexpected")],
-    ["unchanged digest", snapshot("Original")],
-  ] as const) {
+  const cases: Array<{ label: string; after: ProjectSnapshot | Error; name: string; expected: RegExp }> = [
+    { label: "read error", after: new Error("export read failed"), name: "Renamed", expected: /export read failed/ },
+    { label: "name mismatch", after: snapshot("Unexpected"), name: "Renamed", expected: /renamed occurrence was not read back/ },
+    { label: "unchanged digest", after: snapshot("Original"), name: "Original", expected: /native edit did not change the canonical digest/ },
+  ];
+  for (const { label, after, name, expected } of cases) {
     const calls: string[] = [];
     const provider = providerFor([snapshot("Original"), snapshot("Original"), after, snapshot("Original")], calls);
     const before = await provider.readProject();
@@ -172,10 +173,10 @@ test("canonical native provider undoes failed post-edit verification", async () 
       provider.apply({
         type: "rename-clip",
         clipId: "final-cut:occurrence:clip-1",
-        name: "Renamed",
+        name,
         baseRevision: before.revision,
       }, before.revision),
-      { name: "Error" },
+      expected,
       label,
     );
     assert.deepEqual(calls, ["edit", "undo"], label);

--- a/tests/integration/connection.test.ts
+++ b/tests/integration/connection.test.ts
@@ -23,6 +23,19 @@ const capabilities = {
   analyzers: { speechTranscribe: false, speechVad: false, audioLoudness: false, visualTrack: false },
 };
 
+const canonicalWriteCapabilities = {
+  ...capabilities,
+  editor: {
+    ...capabilities.editor,
+    timelineSnapshotRead: true,
+    timelineWrite: true,
+    readAfterWrite: true,
+    rollback: true,
+    projectCatalogRead: true,
+    projectSelection: true,
+  },
+};
+
 test("connection manager reports a ready live bridge without installing anything", async () => {
   const manager = new FinalCutConnectionManager({
     headless: false,
@@ -66,6 +79,34 @@ test("canonical provider requirement rejects FCPXML fallback configuration", () 
     () => assertCanonicalProviderConfiguration({ required: true, fcpxmlPath: "/tmp/project.fcpxml" }),
     /FINAL_CUT_CANONICAL_FALLBACK_CONFLICT/,
   );
+});
+
+test("canonical provider requirement accepts a canonical-write socket", async () => {
+  const manager = new FinalCutConnectionManager({
+    canonicalProviderRequired: true,
+    probe: async () => ({
+      identity: { name: "Final Cut Pro", version: "test", backend: "external-canonical-provider" },
+      capabilities: canonicalWriteCapabilities,
+    }),
+  });
+
+  const status = await manager.ensureConnected();
+
+  assert.equal(status.state, "ready");
+  assert.equal(status.capabilities?.editor.canonicalTimelineMode, "canonical-write");
+});
+
+test("canonical provider requirement reports unavailable when no provider socket responds", async () => {
+  const manager = new FinalCutConnectionManager({
+    canonicalProviderRequired: true,
+    detectFinalCut: async () => { throw new Error("must not detect Final Cut"); },
+    probe: async () => { throw new Error("socket missing"); },
+  });
+
+  const status = await manager.ensureConnected();
+
+  assert.equal(status.state, "needs-user-action");
+  assert.equal(status.lastError?.code, "FINAL_CUT_CANONICAL_PROVIDER_UNAVAILABLE");
 });
 
 test("headless connection probes an existing bridge without launching or activating Final Cut", async () => {

--- a/tests/integration/connection.test.ts
+++ b/tests/integration/connection.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, mkdir } from "node:fs/promises";
 import os from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { FinalCutConnectionManager } from "@framekit/final-cut";
+import { FinalCutConnectionManager, assertCanonicalProviderConfiguration } from "@framekit/final-cut";
 
 const capabilities = {
   editor: {
@@ -59,6 +59,13 @@ test("canonical provider requirement rejects metadata-only sockets without fallb
   assert.equal(status.state, "needs-user-action");
   assert.equal(status.lastError?.code, "FINAL_CUT_CANONICAL_PROVIDER_REQUIRED");
   assert.deepEqual(events, []);
+});
+
+test("canonical provider requirement rejects FCPXML fallback configuration", () => {
+  assert.throws(
+    () => assertCanonicalProviderConfiguration({ required: true, fcpxmlPath: "/tmp/project.fcpxml" }),
+    /FINAL_CUT_CANONICAL_FALLBACK_CONFLICT/,
+  );
 });
 
 test("headless connection probes an existing bridge without launching or activating Final Cut", async () => {

--- a/tests/integration/connection.test.ts
+++ b/tests/integration/connection.test.ts
@@ -39,6 +39,28 @@ test("connection manager reports a ready live bridge without installing anything
   assert.equal(status.capabilities?.editor.liveStateRead, true);
 });
 
+test("canonical provider requirement rejects metadata-only sockets without fallback", async () => {
+  const events: string[] = [];
+  const manager = new FinalCutConnectionManager({
+    canonicalProviderRequired: true,
+    headless: false,
+    detectFinalCut: async () => { events.push("detect"); return true; },
+    launchFinalCut: async () => { events.push("launch"); },
+    installExtension: async () => { events.push("install"); },
+    activateExtension: async () => { events.push("activate"); },
+    probe: async () => ({
+      identity: { name: "Final Cut Pro", version: "test", backend: "workflow-extension-ipc" },
+      capabilities,
+    }),
+  });
+
+  const status = await manager.ensureConnected();
+
+  assert.equal(status.state, "needs-user-action");
+  assert.equal(status.lastError?.code, "FINAL_CUT_CANONICAL_PROVIDER_REQUIRED");
+  assert.deepEqual(events, []);
+});
+
 test("headless connection probes an existing bridge without launching or activating Final Cut", async () => {
   const events: string[] = [];
   const manager = new FinalCutConnectionManager({

--- a/tests/integration/editing-surface-docs.test.ts
+++ b/tests/integration/editing-surface-docs.test.ts
@@ -10,6 +10,8 @@ test("editing surface docs distinguish artifact, publish, and live targets", asy
   const compatibility = await readFile(join(repositoryRoot, "docs/COMPATIBILITY.md"), "utf8");
   const backendSelection = await readFile(join(repositoryRoot, "docs/architecture/backend-selection.md"), "utf8");
   const mcpTools = await readFile(join(repositoryRoot, "docs/mcp/tools.md"), "utf8");
+  const finalCutInstallation = await readFile(join(repositoryRoot, "docs/final-cut/installation.md"), "utf8");
+  const finalCutLive = await readFile(join(repositoryRoot, "docs/mcp/final-cut-live.md"), "utf8");
   const liveE2e = await readFile(join(repositoryRoot, "docs/tests/final-cut-live-e2e.md"), "utf8");
   const roughCutConstruction = await readFile(join(repositoryRoot, "docs/architecture/rough-cut-construction.md"), "utf8");
 
@@ -23,6 +25,10 @@ test("editing surface docs distinguish artifact, publish, and live targets", asy
   }
   assert.match(mcpTools, /artifact\.publish[\s\S]*artifactPath[\s\S]*confirm/);
   assert.match(mcpTools, /PUBLISH_CONFIRMATION_REQUIRED/);
+  assert.match(finalCutInstallation, /FRAMEKIT_FINAL_CUT_CANONICAL_REQUIRED/);
+  assert.match(finalCutInstallation, /FINAL_CUT_CANONICAL_FALLBACK_CONFLICT/);
+  assert.match(finalCutLive, /canonical-write/);
+  assert.match(finalCutLive, /metadata-only/);
   assert.doesNotMatch(mcpTools, /\| `timeline\.edit` \|/);
   assert.doesNotMatch(mcpTools, /\| `timeline\.publish\.new-project` \|/);
   assert.match(liveE2e, /FCPXML publisher headed E2E/);

--- a/tests/integration/editing-surface-docs.test.ts
+++ b/tests/integration/editing-surface-docs.test.ts
@@ -26,8 +26,13 @@ test("editing surface docs distinguish artifact, publish, and live targets", asy
   assert.match(mcpTools, /artifact\.publish[\s\S]*artifactPath[\s\S]*confirm/);
   assert.match(mcpTools, /PUBLISH_CONFIRMATION_REQUIRED/);
   assert.match(finalCutInstallation, /FRAMEKIT_FINAL_CUT_CANONICAL_REQUIRED/);
+  assert.match(finalCutInstallation, /FRAMEKIT_FINAL_CUT_CANONICAL_PROVIDER=native/);
+  assert.match(finalCutInstallation, /File > Export XML/);
+  assert.match(finalCutInstallation, /native Undo/);
   assert.match(finalCutInstallation, /FINAL_CUT_CANONICAL_FALLBACK_CONFLICT/);
   assert.match(finalCutLive, /canonical-write/);
+  assert.match(finalCutLive, /FRAMEKIT_FINAL_CUT_CANONICAL_PROVIDER=native/);
+  assert.match(finalCutLive, /Export XML/);
   assert.match(finalCutLive, /metadata-only/);
   assert.doesNotMatch(mcpTools, /\| `timeline\.edit` \|/);
   assert.doesNotMatch(mcpTools, /\| `timeline\.publish\.new-project` \|/);


### PR DESCRIPTION
## Summary

- Add an explicit headed `FinalCutCanonicalNativeProvider` for the live Final Cut session.
- Read the active timeline through Final Cut `File > Export XML` into a transient private file.
- Bind `rename-clip` only to one exact Browser media result and one matching timeline occurrence.
- Verify native readback, advancing canonical revisions, native Undo, and restored canonical digest.
- Document `FRAMEKIT_FINAL_CUT_CANONICAL_PROVIDER=native`, supported environment, and evidence boundaries.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm run test` — 647 passed
- `pnpm run check:boundaries`
- `pnpm run xcode:check`
- `xcodebuild -project adapters/final-cut/swift-bridge/FinalCutWorkflowExtension/FramekitFinalCutWorkflow.xcodeproj -list`

## Native evidence

The repository and deterministic provider tests are green. Real headed Final Cut
verification was attempted but stopped before execution because the macOS
console reported `CGSSessionScreenIsLocked=true`. No native placement, edit,
revision, or Undo result is being claimed from that attempt. After the console
is unlocked, run the documented canonical headed runner against a disposable
project and capture the sanitized evidence artifact.

Refs #194


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a canonical Final Cut Pro provider for headed workflows.
  - Supports project inspection through Final Cut XML export and controlled clip renaming with verified undo.
  - Added safeguards for stale revisions, ambiguous clip matches, and timeline changes.
  - Added canonical-provider connection requirements and clearer failure handling.

- **Documentation**
  - Documented canonical live and headed provider setup, supported capabilities, environment configuration, safeguards, and rollback behavior.

- **Tests**
  - Added integration coverage for provider availability, canonical writes, export behavior, target resolution, and undo verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->