### PR TITLE
fix: sanitize staged commits and repair release gate

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -53,9 +53,9 @@ export FRAMEKIT_FINAL_CUT_NATIVE_WRITES=0
 export FRAMEKIT_AUTO_CONNECT=0
 
 native_changes="$(node scripts/staged-native-changes.mjs)"
-total_steps=3
+total_steps=4
 if [[ "$native_changes" == "true" && "$(uname -s)" == "Darwin" ]]; then
-  total_steps=5
+  total_steps=6
 fi
 
 log_dir="$(mktemp -d "${TMPDIR:-/tmp}/framekit-pre-commit.XXXXXX")"
@@ -132,6 +132,7 @@ run_step() {
   exit "$exit_code"
 }
 
+run_step "sanitize staged content" node scripts/check-staged-content.mjs
 run_step "build" pnpm run build
 
 test_node_options="--test-reporter=dot"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,10 +62,18 @@ complete timeline or media enumeration.
 Every commit runs:
 
 ```sh
+node scripts/check-staged-content.mjs
 pnpm run build
 pnpm run test
 pnpm run check:boundaries
 ```
+
+The first step inspects the staged commit payload, including staged filenames
+and added text, and fails closed for credentials, user-specific paths, private
+media files, diagnostic dump files, and binary content. It reports only the
+affected repository path, line, and category; matched values are never printed.
+Sanitize or remove the affected content from the index, then stage the safe
+replacement before retrying the commit.
 
 When staged files include the Swift Workflow Extension, Xcode project, or
 native toolchain configuration, macOS contributors also run:

--- a/scripts/check-staged-content.d.mts
+++ b/scripts/check-staged-content.d.mts
@@ -1,0 +1,11 @@
+export const maxScannableBytes: number;
+
+export type StagedContentFinding = {
+  path: string;
+  category: string;
+  line?: number;
+};
+
+export function scanText(text: string, filePath?: string): StagedContentFinding[];
+export function scanStagedContent(cwd?: string): StagedContentFinding[];
+export function stagedPaths(cwd?: string): string[];

--- a/scripts/check-staged-content.mjs
+++ b/scripts/check-staged-content.mjs
@@ -1,0 +1,191 @@
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+
+export const maxScannableBytes = 5 * 1024 * 1024;
+
+const privatePathRoots = ["Users", "home", "private", "var/folders"].join("|");
+const sensitiveCredentialNames = ["api[-_ ]?key", "access[-_ ]?token", "password", "secret", "authorization"];
+const sensitiveCredentialPattern = `(?:${sensitiveCredentialNames.join("|")})`;
+const sensitiveEnvironmentPattern = "(?:API[-_ ]?KEY|ACCESS[-_ ]?TOKEN|PASSWORD|SECRET|AUTHORIZATION)";
+
+const contentRules = [
+  {
+    category: "user-specific path",
+    pattern: new RegExp(
+      `(?:^|[\\s"'\`(=])(?:file://)?/(?:${privatePathRoots})(?:[/\\\\])\\S+`,
+      "i",
+    ),
+  },
+  {
+    category: "user-specific path",
+    pattern: new RegExp(
+      `(?:^|[\\s"'\`(=])[A-Za-z]:[/\\\\](?:${privatePathRoots})(?:[/\\\\])\\S+`,
+      "i",
+    ),
+  },
+  {
+    category: "credential",
+    pattern: new RegExp(`${sensitiveCredentialPattern}\\s*[:=]\\s*[^\\s"'\`]+`, "i"),
+  },
+  {
+    category: "credential",
+    pattern: new RegExp(
+      `(?:^|\\b(?:export|set)\\s+|--env\\s+|--?[A-Za-z0-9_-]+[=\\s]+)${sensitiveEnvironmentPattern}(?:=|\\s+)\\S+`,
+      "i",
+    ),
+  },
+  {
+    category: "credential",
+    pattern: /\bBearer\s+[A-Za-z0-9._~+/=-]{8,}/i,
+  },
+  {
+    category: "credential",
+    pattern: /-----BEGIN [A-Z ]+ PRIVATE KEY-----/,
+  },
+  {
+    category: "credential",
+    pattern: /\b(?:ghp_|github_pat_|glpat-|xox[abprs]-|AKIA[0-9A-Z]{16}|sk-)[A-Za-z0-9._~-]{8,}/,
+  },
+  {
+    category: "diagnostic dump",
+    pattern: new RegExp(
+      "\\b(?:crash\\s+dump|stack\\s+trace|panic\\s+trace|raw\\s+diagnostics?)\\b",
+      "i",
+    ),
+  },
+];
+
+const pathRules = [
+  {
+    category: "credential file",
+    pattern: new RegExp(
+      "(?:^|/)(?:(?:credentials?|secrets?)(?:[._-].*)?|id_(?:rsa|dsa|ecdsa|ed25519)|\\.env(?:\\.(?!example$|sample$|template$).*)?|[^/]+\\.(?:pem|key|p12|pfx|mobileprovision))$",
+      "i",
+    ),
+  },
+  {
+    category: "private media file",
+    pattern: /\.(?:mov|mp4|m4v|avi|mkv|webm|mxf|wav|mp3|aac|flac|aiff|caf|m4a|fcpbundle)$/i,
+  },
+  {
+    category: "diagnostic dump file",
+    pattern: /(?:^|\/)(?:crash|panic)[^/]*\.(?:log|ips|dmp|core|crash)$/i,
+  },
+];
+
+export function scanText(text, filePath = "<text>") {
+  const lines = String(text).split(/\r?\n/).map((line, index) => ({ text: line, line: index + 1 }));
+  return scanLines(lines, filePath);
+}
+
+export function scanStagedContent(cwd = process.cwd()) {
+  const findings = [];
+  for (const filePath of stagedPaths(cwd)) {
+    findings.push(...scanPath(filePath));
+
+    const blob = stagedBlob(cwd, filePath);
+    if (!blob || blob.mode === "160000") continue;
+
+    const size = Number(runGit(cwd, ["cat-file", "-s", blob.oid], { encoding: "utf8" }).trim());
+    if (!Number.isSafeInteger(size) || size > maxScannableBytes) {
+      findings.push({ path: filePath, category: "staged content too large to scan" });
+      continue;
+    }
+
+    const content = runGit(cwd, ["cat-file", "blob", blob.oid], { maxBuffer: maxScannableBytes + 1 });
+    if (content.includes(0)) {
+      findings.push({ path: filePath, category: "binary staged content" });
+      continue;
+    }
+
+    findings.push(...scanLines(stagedAdditions(cwd, filePath), filePath));
+  }
+  return findings;
+}
+
+export function stagedPaths(cwd = process.cwd()) {
+  const output = runGit(cwd, ["diff", "--cached", "--name-only", "-z", "--diff-filter=ACMRTUXB", "--"]);
+  return output.toString("utf8").split("\0").filter(Boolean);
+}
+
+function stagedBlob(cwd, filePath) {
+  const output = runGit(cwd, ["ls-files", "--stage", "-z", "--", filePath]).toString("utf8");
+  const record = output.split("\0").find(Boolean);
+  const match = record?.match(/^(\d{6}) ([0-9a-f]{40}) (\d)\t/);
+  return match ? { mode: match[1], oid: match[2], stage: Number(match[3]) } : undefined;
+}
+
+function stagedAdditions(cwd, filePath) {
+  const diff = runGit(cwd, ["diff", "--cached", "--no-ext-diff", "--no-color", "--unified=0", "--", filePath]).toString("utf8");
+  const lines = [];
+  let nextLine;
+  let inHunk = false;
+
+  for (const line of diff.split("\n")) {
+    const hunk = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+    if (hunk) {
+      nextLine = Number(hunk[1]);
+      inHunk = true;
+      continue;
+    }
+    if (!inHunk || nextLine === undefined) continue;
+    if (line.startsWith("+")) {
+      lines.push({ text: line.slice(1), line: nextLine });
+      nextLine += 1;
+    } else if (line.startsWith("-")) {
+      continue;
+    } else if (!line.startsWith("\\")) {
+      nextLine += 1;
+    }
+  }
+  return lines;
+}
+
+function scanPath(filePath) {
+  return pathRules
+    .filter(({ pattern }) => pattern.test(filePath))
+    .map(({ category }) => ({ path: filePath, category }));
+}
+
+function scanLines(lines, filePath) {
+  const findings = [];
+  for (const { text, line } of lines) {
+    const categories = new Set();
+    for (const { category, pattern } of contentRules) {
+      if (pattern.test(text) && !categories.has(category)) {
+        categories.add(category);
+        findings.push({ path: filePath, line, category });
+      }
+    }
+  }
+  return findings;
+}
+
+function runGit(cwd, args, options = {}) {
+  const { env, ...childOptions } = options;
+  return execFileSync("git", args, {
+    ...childOptions,
+    cwd,
+    env: {
+      ...process.env,
+      GIT_DIR: undefined,
+      GIT_INDEX_FILE: undefined,
+      GIT_WORK_TREE: undefined,
+      ...env,
+    },
+  });
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const findings = scanStagedContent();
+  if (findings.length === 0) process.exit(0);
+
+  process.stderr.write("Framekit staged-content check failed; sanitize the staged commit payload before committing.\n");
+  for (const finding of findings) {
+    const location = finding.line === undefined ? finding.path : `${finding.path}:${finding.line}`;
+    process.stderr.write(`- ${location}: ${finding.category}\n`);
+  }
+  process.stderr.write("No matched content is printed. Remove or sanitize the affected content, then stage it again.\n");
+  process.exitCode = 1;
+}

--- a/tests/integration/git-hooks.test.ts
+++ b/tests/integration/git-hooks.test.ts
@@ -53,6 +53,7 @@ test("pre-commit hook presents grouped validation stages and failure diagnostics
   const hook = await readFile(join(repository, ".githooks", "pre-commit"), "utf8");
   assert.match(hook, /run_step\(\)/);
   assert.match(hook, /#%d \[%d\/%d\]/);
+  assert.match(hook, /run_step "sanitize staged content" node scripts\/check-staged-content\.mjs/);
   assert.match(hook, /--test-reporter=dot/);
   assert.match(hook, /mktemp -d/);
   assert.match(hook, /cat \"\$log_file\" >&2/);

--- a/tests/integration/staged-content.test.ts
+++ b/tests/integration/staged-content.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { scanStagedContent, scanText } from "../../scripts/check-staged-content.mjs";
+
+const exec = promisify(execFile);
+const scanner = fileURLToPath(new URL("../../scripts/check-staged-content.mjs", import.meta.url));
+
+test("staged-content sanitization permits explanatory prose", () => {
+  const findings = scanText([
+    "No API key is required for this operation.",
+    "The secret to success is practice.",
+    "Use an allowlisted evidence summary.",
+  ].join("\n"), "README.md");
+
+  assert.deepEqual(findings, []);
+});
+
+test("staged-content sanitization reports redacted findings", () => {
+  const userPath = ["/", "Users", "/", "alice", "/", "footage.mov"].join("");
+  const credential = ["API", "_KEY", "=", "do-not-commit"].join("");
+  const diagnostic = ["raw", " ", "crash", " ", "dump"].join("");
+  const findings = scanText([userPath, credential, diagnostic].join("\n"), "evidence.txt");
+
+  assert.deepEqual(findings.map(({ category, line }) => ({ category, line })), [
+    { category: "user-specific path", line: 1 },
+    { category: "credential", line: 2 },
+    { category: "diagnostic dump", line: 3 },
+  ]);
+  assert.doesNotMatch(JSON.stringify(findings), /alice|do-not-commit/);
+});
+
+test("staged-content sanitization inspects the index and staged filenames", { concurrency: false }, async () => {
+  const directory = await mkdtemp(join(os.tmpdir(), "framekit-staged-content-"));
+  try {
+    await runGit(directory, ["init", "--quiet"]);
+    const userPath = ["/", "home", "/", "alice", "/", "footage.mov"].join("");
+    const credential = ["ACCESS", "_TOKEN", ":", "do-not-commit"].join("");
+    await writeFile(join(directory, "evidence.txt"), `${userPath}\n${credential}\n`, "utf8");
+    await writeFile(join(directory, "private-footage.mov"), Buffer.from([0, 1, 2]));
+    await runGit(directory, ["add", "--", "evidence.txt", "private-footage.mov"]);
+
+    const findings = scanStagedContent(directory);
+
+    assert.ok(findings.some(({ path, category }) => path === "evidence.txt" && category === "user-specific path"));
+    assert.ok(findings.some(({ path, category }) => path === "evidence.txt" && category === "credential"));
+    assert.ok(findings.some(({ path, category }) => path === "private-footage.mov" && category === "private media file"));
+    assert.ok(findings.some(({ path, category }) => path === "private-footage.mov" && category === "binary staged content"));
+    assert.doesNotMatch(JSON.stringify(findings), /alice|do-not-commit/);
+
+    await assert.rejects(
+      exec("node", [scanner], { cwd: directory }),
+      (error: { stdout?: string; stderr?: string }) => {
+        const output = `${error.stdout ?? ""}${error.stderr ?? ""}`;
+        assert.match(output, /staged-content check failed/);
+        assert.doesNotMatch(output, /alice|do-not-commit/);
+        return true;
+      },
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("staged-content sanitization ignores unstaged edits", { concurrency: false }, async () => {
+  const directory = await mkdtemp(join(os.tmpdir(), "framekit-staged-content-"));
+  try {
+    await runGit(directory, ["init", "--quiet"]);
+    const file = join(directory, "evidence.txt");
+    await writeFile(file, "safe content\n", "utf8");
+    await runGit(directory, ["add", "--", "evidence.txt"]);
+    const userPath = ["/", "Users", "/", "alice", "/", "footage.mov"].join("");
+    await writeFile(file, `${userPath}\n`, "utf8");
+
+    assert.deepEqual(scanStagedContent(directory), []);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+function runGit(directory: string, args: string[]) {
+  const env = { ...process.env };
+  delete env.GIT_DIR;
+  delete env.GIT_INDEX_FILE;
+  delete env.GIT_WORK_TREE;
+  return exec("git", args, { cwd: directory, env });
+}

--- a/tests/release-gate/native-editing.test.ts
+++ b/tests/release-gate/native-editing.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -289,9 +289,15 @@ test("release gate keeps repository-owned provenance values authoritative", asyn
       serverVersion: "9.9.9",
     } as never,
   });
+  const packageManifest = JSON.parse(await readFile(new URL("../../package.json", import.meta.url), "utf8")) as {
+    version?: string;
+  };
+  if (typeof packageManifest.version !== "string") throw new Error("repository package version is missing");
+  assert.notEqual(packageManifest.version, "9.9.9");
+  const expectedVersion = new RegExp(escapeRegExp(packageManifest.version));
 
-  assert.match(report.provenance.checks.find((check) => check.name === "package-plugin-versions")?.detail ?? "", /0\.1\.5/);
-  assert.match(report.provenance.checks.find((check) => check.name === "mcp-server-version")?.detail ?? "", /0\.1\.5/);
+  assert.match(report.provenance.checks.find((check) => check.name === "package-plugin-versions")?.detail ?? "", expectedVersion);
+  assert.match(report.provenance.checks.find((check) => check.name === "mcp-server-version")?.detail ?? "", expectedVersion);
 });
 
 test("release gate reports each v0.1.6 evidence tier independently", async () => {
@@ -348,6 +354,10 @@ test("partial headed evidence cannot promote the headed tier", async () => {
     await rm(directory, { recursive: true, force: true });
   }
 });
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
 
 test("complete headed evidence promotes every claimed native workflow", async () => {
   const directory = await mkdtemp(join(tmpdir(), "framekit-complete-headed-evidence-"));


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- Github issue: Not applicable; fixes the regression reported in [PR #187](https://github.com/morshoto/framekit/pull/187)

## Summary

The release PR [#187](https://github.com/morshoto/framekit/pull/187) failed because its release-gate test still expected `0.1.5` after the repository manifests had advanced to `0.1.6`.

This PR:

- Makes the release-gate test derive its expected version from the repository-owned package manifest and verify the plugin and MCP server provenance.
- Adds a fail-closed pre-commit staged-content check for sensitive filenames, added credential/path/diagnostic content, binary staged content, and oversized files.
- Keeps scanner output redacted and documents how to sanitize and re-stage rejected content.
- Adds deterministic tests for the scanner, staged-index behavior, filename checks, binary checks, redaction, and unstaged edits.

## Validation

```bash
PATH=/Users/shotomorisaki/.nix-profile/bin:$PATH .agents/skills/validate-framekit/scripts/validate.sh
PATH=/Users/shotomorisaki/.nix-profile/bin:$PATH .githooks/pre-commit
```

Both passed: frozen install, build, 639/639 tests, package-boundary checks, and all four pre-commit stages. Native validation is not applicable; no native files changed.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Public MCP behavior or package interfaces are documented if changed.
- [x] Existing adapters and test fixtures remain compatible, or the migration is explained above.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [x] Documentation reflects the changed commit-time check and scanner command.
