### PR TITLE
fix: reject out-of-bounds ripple-delete ranges (#199)

### DIFF
--- a/packages/testkit/src/in-memory-editor.ts
+++ b/packages/testkit/src/in-memory-editor.ts
@@ -781,6 +781,11 @@ export class InMemoryEditorAdapter implements EditorPort {
     if (!Number.isFinite(start) || !Number.isFinite(end) || start < 0 || end <= start) {
       throw new Error("INVALID_OPERATION: ripple delete range must be positive");
     }
+    if (end > snapshot.timeline.duration) {
+      throw new Error(
+        `INVALID_OPERATION: ripple delete range [${start}, ${end}) must fit timeline bounds [0, ${snapshot.timeline.duration})`,
+      );
+    }
     const removedDuration = end - start;
     const clips = snapshot.timeline.clips.flatMap((clip) => {
       const clipEnd = clip.start + clip.duration;

--- a/tests/integration/ripple-delete-range.test.ts
+++ b/tests/integration/ripple-delete-range.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { AgentVideoRuntime } from "@framekit/runtime";
+import { InMemoryEditorAdapter } from "@framekit/testkit";
+
+const fixture = {
+  projectId: "range-project",
+  projectName: "Range Validation",
+  timelineId: "range-timeline",
+  timelineName: "Main Edit",
+  clips: [{ id: "range-clip", mediaId: "range-media", name: "Interview", start: 0, duration: 10, track: 1 }],
+  media: [{ mediaId: "range-media", source: "interview.mov", mediaKind: "video" as const, duration: 10 }],
+};
+
+function rippleDelete(start: number, end: number, timelineId = fixture.timelineId) {
+  return {
+    type: "ripple-delete" as const,
+    timelineId,
+    range: { start, end },
+  };
+}
+
+function textFrom(result: unknown): string {
+  const content = (result as { content?: unknown }).content;
+  assert.ok(Array.isArray(content));
+  const first = content[0] as { text?: unknown } | undefined;
+  assert.ok(first);
+  assert.equal(typeof first?.text, "string");
+  return first.text as string;
+}
+
+test("in-memory preview rejects ripple-delete ranges outside the timeline", async () => {
+  const runtime = new AgentVideoRuntime(new InMemoryEditorAdapter(fixture));
+  const before = await runtime.inspectProject();
+
+  for (const range of [{ start: 9, end: 11 }, { start: 11, end: 12 }]) {
+    await assert.rejects(
+      runtime.previewEdit({ baseRevision: before.revision, operations: [rippleDelete(range.start, range.end)] }),
+      new RegExp(`ripple delete range \\[${range.start}, ${range.end}\\) must fit timeline bounds \\[0, 10\\)`),
+    );
+  }
+
+  assert.deepEqual(await runtime.inspectProject(), before);
+});
+
+test("stdio MCP rejects an out-of-bounds ripple-delete before issuing a token", async () => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: ["--import", "tsx", join(here, "../../apps/mcp-server/src/main.ts")],
+    env: { ...process.env, FRAMEKIT_EDITOR: "fixture", FRAMEKIT_AUTO_CONNECT: "0" },
+    stderr: "pipe",
+  });
+  const client = new Client({ name: "ripple-delete-range-test", version: "0.1.0" });
+
+  try {
+    await client.connect(transport);
+    const beforeResult = await client.callTool({ name: "project.inspect", arguments: {} });
+    const before = JSON.parse(textFrom(beforeResult));
+    const result = await client.callTool({
+      name: "editor.timeline.edit.preview",
+      arguments: {
+        projectId: before.projectId,
+        sequenceId: before.timeline.id,
+        baseRevision: before.revision,
+        operations: [rippleDelete(9, 11, before.timeline.id)],
+      },
+    });
+
+    assert.equal(result.isError, true);
+    assert.match(textFrom(result), /ripple delete range \[9, 11\) must fit timeline bounds \[0, 10\)/);
+    const after = JSON.parse(textFrom(await client.callTool({ name: "project.inspect", arguments: {} })));
+    assert.deepEqual(after, before);
+  } finally {
+    await client.close();
+  }
+});


### PR DESCRIPTION
- [x] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [x] Github issue: Refs: #199

## Summary

Rejects `ripple-delete` ranges that extend beyond the active in-memory timeline.

- Validates the half-open range against the current timeline duration before a preview token is issued or any mutation occurs.
- Returns an actionable `INVALID_OPERATION` error containing the requested and permitted bounds.
- Adds in-memory and MCP stdio regression tests covering both an end-overrun and a start-overrun, including unchanged-state assertions.

## Validation

```bash
pnpm install --frozen-lockfile
pnpm run build
pnpm run test
pnpm run check:boundaries
```

All passed on `33e00605fed00b45a4db2e4d128369eb53478e02` (655 tests).

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Public MCP behavior or package interfaces are documented if changed.
- [x] Existing adapters and test fixtures remain compatible, or the migration is explained above.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [x] Documentation reflects any changed commands, paths, or environment variables.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ripple-delete operations that extend beyond the timeline duration are now rejected with a clear error message.
  - Invalid operations leave the project unchanged across supported interfaces.

- **Tests**
  - Added coverage for out-of-bounds ripple-delete ranges in preview and MCP workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->