### PR TITLE
fix: fail closed on empty native title discovery

### DIFF
--- a/adapters/final-cut/typescript/src/assets.ts
+++ b/adapters/final-cut/typescript/src/assets.ts
@@ -49,6 +49,9 @@ export class FinalCutAssetRegistry {
     let nativeTitles: NativeFinalCutTitleMatch[];
     try {
       nativeTitles = await this.nativeTitleProvider.searchTitles(query?.query ?? "");
+      if (nativeTitles.length === 0) {
+        throw new Error("FINAL_CUT_NATIVE_TITLE_DISCOVERY_EMPTY: native title provider returned no title assets");
+      }
     } catch (error) {
       // Filesystem assets remain usable when the optional native browser is
       // unavailable, but keep the native diagnostic visible in the response.

--- a/adapters/final-cut/typescript/src/native.ts
+++ b/adapters/final-cut/typescript/src/native.ts
@@ -1406,9 +1406,13 @@ export class FinalCutNativeAutomationAdapter implements NativeFinalCutEditor {
       let lastError: unknown;
       for (let attempt = 0; attempt < 2; attempt += 1) {
         try {
-          return parseTitleMatches(await this.executeNativeScript(
+          const matches = parseTitleMatches(await this.executeNativeScript(
             titleSearchScript(identity ?? normalizedQuery, identity !== undefined),
           ));
+          if (matches.length === 0) {
+            throw new Error("FINAL_CUT_NATIVE_TITLE_DISCOVERY_EMPTY: Final Cut's Titles browser returned no title assets");
+          }
+          return matches;
         } catch (error) {
           lastError = error;
           if (attempt === 0) await this.sleep(250);

--- a/adapters/final-cut/typescript/src/native.ts
+++ b/adapters/final-cut/typescript/src/native.ts
@@ -535,6 +535,7 @@ export interface NativeFinalCutTransitionRequest {
 
 export class FinalCutNativeAutomationAdapter implements NativeFinalCutEditor {
   private readonly enabled: boolean;
+  private titleDiscoveryAvailable: boolean;
   private readonly executor: NativeFinalCutExecutor;
   private readonly canDriveNativeMouse: boolean;
   private readonly liveState?: () => Promise<EditorLiveState>;
@@ -620,6 +621,7 @@ export class FinalCutNativeAutomationAdapter implements NativeFinalCutEditor {
 
   public constructor(options: NativeFinalCutAutomationOptions = {}) {
     this.enabled = options.enabled ?? process.env.FRAMEKIT_FINAL_CUT_NATIVE_WRITES === "1";
+    this.titleDiscoveryAvailable = this.enabled;
     this.executor = options.executor ?? runAppleScript;
     this.canDriveNativeMouse = options.executor === undefined;
     this.liveState = options.liveState;
@@ -649,7 +651,7 @@ export class FinalCutNativeAutomationAdapter implements NativeFinalCutEditor {
       mediaAppend: this.enabled,
       mediaInsert: this.enabled,
       titlePlacement: this.enabled,
-      titleDiscovery: this.enabled,
+      titleDiscovery: this.titleDiscoveryAvailable,
       pictureInPicture: this.enabled,
       transitionDiscovery: this.enabled,
       transitionPlacement: this.enabled,
@@ -1410,8 +1412,10 @@ export class FinalCutNativeAutomationAdapter implements NativeFinalCutEditor {
             titleSearchScript(identity ?? normalizedQuery, identity !== undefined),
           ));
           if (matches.length === 0) {
+            this.titleDiscoveryAvailable = false;
             throw new Error("FINAL_CUT_NATIVE_TITLE_DISCOVERY_EMPTY: Final Cut's Titles browser returned no title assets");
           }
+          this.titleDiscoveryAvailable = true;
           return matches;
         } catch (error) {
           lastError = error;

--- a/docs/mcp/final-cut-live.md
+++ b/docs/mcp/final-cut-live.md
@@ -330,7 +330,10 @@ Accessibility automation to open Final Cut's Titles and Generators browser,
 select the discovered template by its stable AX identity, apply the text, and
 verify the selected title and live revision. Missing Accessibility permission,
 an unavailable browser, or a missing AX identity is not converted into a
-fabricated asset.
+fabricated asset. An empty native browser response is reported as
+`FINAL_CUT_NATIVE_TITLE_DISCOVERY_EMPTY`; native-only queries fail explicitly,
+while filesystem Motion-template results remain usable with a native
+unavailable diagnostic when present.
 
 ## Native transition placement
 

--- a/tests/integration/final-cut-assets.test.ts
+++ b/tests/integration/final-cut-assets.test.ts
@@ -85,6 +85,20 @@ test("Final Cut asset discovery propagates native browser unavailability", async
   );
 });
 
+test("Final Cut asset discovery fails closed on empty native title results", async () => {
+  const registry = new FinalCutAssetRegistry({
+    roots: [],
+    nativeTitleProvider: {
+      searchTitles: async () => [],
+    },
+  });
+
+  await assert.rejects(
+    registry.listAssets({ kind: "title" }),
+    /FINAL_CUT_NATIVE_TITLE_DISCOVERY_EMPTY/,
+  );
+});
+
 test("Final Cut asset discovery reports native unavailability with filesystem results", async () => {
   const root = await mkdtemp(join(os.tmpdir(), "framekit-title-assets-diagnostic-"));
   const bundle = join(root, "Titles.localized", "Lower Third.moti");

--- a/tests/integration/final-cut-assets.test.ts
+++ b/tests/integration/final-cut-assets.test.ts
@@ -99,6 +99,35 @@ test("Final Cut asset discovery fails closed on empty native title results", asy
   );
 });
 
+test("Final Cut asset discovery preserves filesystem titles when native discovery is empty", async () => {
+  const root = await mkdtemp(join(os.tmpdir(), "framekit-title-assets-empty-native-"));
+  const bundle = join(root, "Titles.localized", "Lower Third.moti");
+  await mkdir(join(bundle, "Contents"), { recursive: true });
+  await writeFile(
+    join(bundle, "Contents", "Info.plist"),
+    "<plist><key>CFBundleDisplayName</key><string>Lower Third</string><key>CFBundleIdentifier</key><string>Framekit Fixture</string></plist>",
+  );
+  const registry = new FinalCutAssetRegistry({
+    roots: [root],
+    nativeTitleProvider: {
+      searchTitles: async () => [],
+    },
+  });
+
+  const assets = await registry.listAssets({ kind: "title" });
+
+  assert.equal(assets.length, 1);
+  assert.deepEqual(assets[0]?.metadata.discovery, {
+    backend: "filesystem-motion-template",
+    guarantee: "observed",
+    native: {
+      backend: "final-cut-accessibility",
+      guarantee: "none",
+      unavailableReason: "FINAL_CUT_NATIVE_TITLE_DISCOVERY_EMPTY: native title provider returned no title assets",
+    },
+  });
+});
+
 test("Final Cut asset discovery reports native unavailability with filesystem results", async () => {
   const root = await mkdtemp(join(os.tmpdir(), "framekit-title-assets-diagnostic-"));
   const bundle = join(root, "Titles.localized", "Lower Third.moti");

--- a/tests/integration/native-title-discovery.test.ts
+++ b/tests/integration/native-title-discovery.test.ts
@@ -78,10 +78,12 @@ test("native title discovery fails closed when the browser returns no assets", a
     executor: async (script) => script.includes("titleBrowserPreflightResult") ? browserContext() : "",
   });
 
+  assert.equal(adapter.capabilities().titleDiscovery, true);
   await assert.rejects(
     adapter.searchTitles(""),
     /FINAL_CUT_NATIVE_TITLE_DISCOVERY_EMPTY/,
   );
+  assert.equal(adapter.capabilities().titleDiscovery, false);
 });
 
 test("native title discovery capability follows the enabled native provider", () => {

--- a/tests/integration/native-title-discovery.test.ts
+++ b/tests/integration/native-title-discovery.test.ts
@@ -72,6 +72,18 @@ test("native Final Cut adapter discovers stable title assets without a timeline"
   assert.equal(scripts.some((script) => script.includes("titleSearchField")), true);
 });
 
+test("native title discovery fails closed when the browser returns no assets", async () => {
+  const adapter = new FinalCutNativeAutomationAdapter({
+    enabled: true,
+    executor: async (script) => script.includes("titleBrowserPreflightResult") ? browserContext() : "",
+  });
+
+  await assert.rejects(
+    adapter.searchTitles(""),
+    /FINAL_CUT_NATIVE_TITLE_DISCOVERY_EMPTY/,
+  );
+});
+
 test("native title discovery capability follows the enabled native provider", () => {
   const enabled = new FinalCutNativeAutomationAdapter({ enabled: true });
   const disabled = new FinalCutNativeAutomationAdapter({ enabled: false });


### PR DESCRIPTION
Closes: #209

## Summary

Native title discovery now fails closed when Final Cut returns no title assets. The native adapter reports `FINAL_CUT_NATIVE_TITLE_DISCOVERY_EMPTY`, marks the observed discovery capability unavailable, and restores it after a later successful discovery. Filesystem Motion-template titles remain usable with the existing native-unavailable diagnostic.

## TDD implementation

- Added regression tests for empty native adapter results, empty generic provider results, filesystem fallback, and capability state.
- Captured the expected red failures before each production change.
- Committed each implementation step separately using the requested commit message.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm run test` — 659 tests passed
- `pnpm run check:boundaries`
- `pnpm run xcode:check`
- `xcodebuild -project adapters/final-cut/swift-bridge/FinalCutWorkflowExtension/FramekitFinalCutWorkflow.xcodeproj -list`

The final Xcode project-list command used the repository path `adapters/final-cut/swift-bridge/FinalCutWorkflowExtension/FramekitFinalCutWorkflow.xcodeproj` and passed.

## Architecture and safety

- Runtime package boundaries are unchanged.
- No MCP schema changes are required; the existing `editor.assets` failure surface now includes an explicit native discovery code.
- No credentials, private media, raw crash dumps, or generated artifacts were added.
- Deterministic tests do not claim headed Final Cut placement evidence; this change only hardens discovery failure reporting.
