### PR TITLE
fix: build and upload native release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,11 +78,78 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.TAGPR_TOKEN }}
 
+  native-release-assets:
+    if: needs.tagpr.outputs.release-tag != ''
+    needs: tagpr
+    runs-on: [self-hosted, macOS, framekit-release]
+    permissions:
+      contents: write
+    steps:
+      - name: Check out release tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.tagpr.outputs.release-tag }}
+          persist-credentials: false
+
+      - name: Package signed native release assets
+        env:
+          FRAMEKIT_CODESIGN_IDENTITY: ${{ secrets.FRAMEKIT_CODESIGN_IDENTITY }}
+          FRAMEKIT_NOTARY_PROFILE: ${{ vars.FRAMEKIT_NOTARY_PROFILE }}
+          FRAMEKIT_RELEASE_DIR: ${{ runner.temp }}/framekit-native-release
+          RELEASE_TAG: ${{ needs.tagpr.outputs.release-tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          export FRAMEKIT_RELEASE_VERSION="${RELEASE_TAG#v}"
+          bash scripts/package-final-cut-release.sh
+
+      - name: Upload native release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          FRAMEKIT_RELEASE_DIR: ${{ runner.temp }}/framekit-native-release
+          RELEASE_TAG: ${{ needs.tagpr.outputs.release-tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected_version="${RELEASE_TAG#v}"
+          archive_name="FramekitFinalCutWorkflow-${expected_version}.zip"
+          checksum_name="${archive_name}.sha256"
+          test -s "${FRAMEKIT_RELEASE_DIR}/${archive_name}"
+          test -s "${FRAMEKIT_RELEASE_DIR}/${checksum_name}"
+          release_id="$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
+            --jq ".[] | select(.name == \"${RELEASE_TAG}\" or .tag_name == \"${RELEASE_TAG}\") | .id" \
+            | head -n 1)"
+          test -n "${release_id}"
+          upload_url="$(gh api "repos/${GITHUB_REPOSITORY}/releases/${release_id}" --jq '.upload_url')"
+          upload_url="${upload_url%%\{*}"
+
+          upload_asset() {
+            local asset_name="$1"
+            local content_type="$2"
+            local asset_path="$3"
+            local asset_id
+            asset_id="$(gh api "repos/${GITHUB_REPOSITORY}/releases/${release_id}/assets?per_page=100" \
+              --jq ".[] | select(.name == \"${asset_name}\") | .id" \
+              | head -n 1)"
+            if [ -n "${asset_id}" ]; then
+              gh api --method DELETE "repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}"
+            fi
+            gh api --method POST "${upload_url}?name=${asset_name}" \
+              --header "Content-Type: ${content_type}" \
+              --input "${asset_path}" \
+              --silent
+          }
+
+          upload_asset "${archive_name}" "application/zip" "${FRAMEKIT_RELEASE_DIR}/${archive_name}"
+          upload_asset "${checksum_name}" "text/plain" "${FRAMEKIT_RELEASE_DIR}/${checksum_name}"
+
   publish-npm:
     if: needs.tagpr.outputs.release-tag != ''
     needs:
       - tagpr
       - validate-codex-plugin
+      - native-release-assets
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -34,14 +34,24 @@ repository. The workflow uses GitHub's OIDC identity and does not require an
 2. The `tagpr` job creates the version tag and a draft GitHub release with
    generated notes. If the merge already placed the release tag on `HEAD`,
    the workflow reuses that tag instead of trying to create it again.
-3. The `publish-npm` job installs npm 11.5.1, runs the v0.1.6 repository gate,
+3. The `native-release-assets` job runs on the configured `framekit-release`
+   macOS runner, builds and signs the Final Cut Workflow Extension, and uploads
+   `FramekitFinalCutWorkflow-<version>.zip` plus its checksum to the draft
+   release.
+4. The `publish-npm` job installs npm 11.5.1, runs the v0.1.6 repository gate,
    publishes the matching package, and verifies the version on the public
-   registry.
-4. The workflow verifies the native archive and checksum, then publishes the
+   registry. It waits for the native assets to be uploaded.
+5. The workflow verifies the native archive and checksum, then publishes the
    GitHub release and its notes.
-5. A final provenance gate verifies package, MCP server, plugin, tag, workflow,
+6. A final provenance gate verifies package, MCP server, plugin, tag, workflow,
    GitHub release, npm, native archive, and checksum alignment before the
    workflow can succeed.
+
+The `framekit-release` runner must be a trusted macOS runner with Final Cut Pro
+installed, Xcode command-line tools, and a Developer ID signing identity
+available to `codesign`. Configure the `FRAMEKIT_CODESIGN_IDENTITY` secret and
+the optional `FRAMEKIT_NOTARY_PROFILE` repository variable before merging a
+release PR. The runner must be registered with the `framekit-release` label.
 
 If npm publishing fails, the GitHub release remains a draft so the failure can
 be repaired without presenting an incomplete release as public.
@@ -64,7 +74,8 @@ from `main`, checks out that exact tag, and skips `npm publish` if the matching
 version is already present. After a publish, registry visibility is retried
 with bounded backoff. If a retry races with an earlier successful publish and
 npm reports that the version already exists, the workflow proceeds to that
-same verification path. Registry errors other than a missing version or an
+same verification path. The native release job also rebuilds and uploads the
+assets before verification. Registry errors other than a missing version or an
 immutable-version conflict fail closed.
 
 The npm Trusted Publisher relationship is configured in npm account settings;

--- a/tests/integration/release-workflow.test.ts
+++ b/tests/integration/release-workflow.test.ts
@@ -103,6 +103,7 @@ test("release workflow validates the package before publishing", async () => {
 
 test("release workflow gates publication on v0.1.6 evidence and native checksums", async () => {
   const workflow = await readFile(resolve(repository, ".github/workflows/release.yml"), "utf8");
+  const nativePackaging = workflow.indexOf("native-release-assets:");
   const gate = workflow.indexOf("pnpm run release-gate --output-dir");
   const npmPublish = workflow.indexOf("npm publish --access public");
   const npmVerification = workflow.indexOf("name: Verify npm publication");
@@ -111,7 +112,12 @@ test("release workflow gates publication on v0.1.6 evidence and native checksums
   const finalProvenance = workflow.indexOf("name: Verify complete release provenance");
 
   assert.notEqual(gate, -1);
+  assert.notEqual(nativePackaging, -1);
   assert.ok(gate < npmPublish, "release gate must run before npm publication");
+  assert.match(
+    workflow,
+    /native-release-assets:[\s\S]*?runs-on:\s*\[self-hosted, macOS, framekit-release\][\s\S]*?scripts\/package-final-cut-release\.sh[\s\S]*?upload_url[\s\S]*?gh api --method POST/,
+  );
   assert.notEqual(assetVerification, -1);
   assert.notEqual(npmVerification, -1);
   assert.ok(npmVerification < assetVerification, "native assets follow npm verification");
@@ -125,6 +131,10 @@ test("release workflow gates publication on v0.1.6 evidence and native checksums
   assert.match(workflow, /publish-npm:[\s\S]*?needs:\s*\n\s+- tagpr\n\s+- validate-codex-plugin/);
   assert.doesNotMatch(workflow, /npm install --global @openai\/codex/);
   assert.match(workflow, /RELEASE_PROVENANCE_OUTPUT_DIR: artifacts\/release-gate\/\$\{\{ github\.run_id \}\}/);
+  assert.match(
+    workflow,
+    /publish-npm:[\s\S]*?needs:\s*\n\s+- tagpr\n\s+- validate-codex-plugin\n\s+- native-release-assets/,
+  );
 });
 
 test("release workflow can retry an exact existing tag", async () => {


### PR DESCRIPTION
- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- Github issue: Not applicable; fixes the failed native release asset verification in [run #34603740964](https://github.com/morshoto/framekit/actions/runs/34603740964)

## Summary

The v0.1.6 release published npm successfully but failed because the workflow
verified native release assets without first creating or uploading them.

This PR:

- Adds a dedicated `native-release-assets` job on the trusted `framekit-release`
  macOS runner.
- Builds and signs the Final Cut Workflow Extension for the release tag.
- Uploads the versioned archive and SHA-256 checksum to the draft release using
  the GitHub upload API, including retries of an already-created release.
- Makes npm publication wait for native asset preparation.
- Documents the runner, signing identity, and optional notarization setup.

## Validation

```text
Focused release workflow test: 12 passed
pnpm install --frozen-lockfile
pnpm run build
pnpm run test                 # 656 tests passed
pnpm run check:boundaries
git diff --check
Ruby YAML parse of .github/workflows/release.yml
```

Native Xcode validation was skipped because this PR changes workflow, docs, and
workflow tests only. The release job requires a configured trusted macOS
runner with Final Cut Pro installed; that external runner configuration cannot
be validated from this worktree.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] The release contract still requires native archive and checksum
  verification before the GitHub release is made public.
- [x] Existing npm retry and provenance behavior remains unchanged.

## Safety

- [x] Native assets are built from the exact release tag.
- [x] Signing identity is read from a GitHub secret; no credentials are added
  to the repository.
- [x] Existing release assets with the same names are deleted and replaced
  before checksum verification.
- [x] No credentials, private media, raw crash dumps, or generated build
  artifacts were added.
