### PR TITLE
fix: make native Browser search discovery reliable

### DIFF
--- a/adapters/final-cut/typescript/src/native.ts
+++ b/adapters/final-cut/typescript/src/native.ts
@@ -3657,7 +3657,7 @@ function selectedBrowserMediaScript(): string {
     set seenSourceIdentities to {}
     set browserRoot to mainWindow
     try
-      set browserSearchResult to my findBrowserSearchControl(mainWindow, 0, origin, size of mainWindow)
+      set browserSearchResult to my findBrowserSearchControl(mainWindow, 0, false, missing value)
       if browserSearchResult is not missing value then set browserRoot to item 2 of browserSearchResult
     end try
     try
@@ -3706,62 +3706,14 @@ end tell`;
 
 function browserSearchFieldScript(): string {
   return `
-    set origin to position of mainWindow
-    set windowSize to size of mainWindow
     set searchFieldFound to false
     set searchField to missing value
     set searchButton to missing value
-    set browserRoot to mainWindow
-    -- The Transitions browser may already be open. Prefer the bounded
-    -- Browser search control so its Effects Library field cannot capture a
-    -- media query.
-    try
-      set searchField to UI element 4 of UI element 5 of UI element 3 of UI element 1 of UI element 2 of UI element 1 of UI element 1 of UI element 1 of mainWindow
-      set searchFieldFound to true
-    on error
-      set searchField to missing value
-    end try
-    try
-      if not searchFieldFound then
-        set focusedCandidate to value of attribute "AXFocusedUIElement"
-        set focusedRole to role of focusedCandidate as text
-        set focusedDescription to ""
-        try
-          set focusedDescription to description of focusedCandidate as text
-        end try
-        if (focusedRole is "AXSearchField" or (focusedRole is "AXTextField" and (focusedDescription contains "search" or focusedDescription contains "Search"))) and my browserSearchCandidateVisible(focusedCandidate, origin, windowSize) then
-          set searchField to focusedCandidate
-          set searchFieldFound to true
-        end if
-      end if
-    end try
-    if not searchFieldFound then
-      repeat with searchOffset in {368, 400, 340, 561, 531, 501}
-        repeat with searchY in {52, 38}
-          try
-            click at {(item 1 of origin) + (searchOffset as integer), (item 2 of origin) + (searchY as integer)}
-            delay 0.15
-            set focusedCandidate to value of attribute "AXFocusedUIElement"
-            set focusedRole to role of focusedCandidate as text
-            set focusedDescription to ""
-            try
-              set focusedDescription to description of focusedCandidate as text
-            end try
-            if (focusedRole is "AXSearchField" or (focusedRole is "AXTextField" and (focusedDescription contains "search" or focusedDescription contains "Search"))) then
-              set searchField to focusedCandidate
-              set searchFieldFound to true
-              exit repeat
-            end if
-          end try
-        end repeat
-        if searchFieldFound then exit repeat
-      end repeat
-    end if
     try
       if my revealBrowser(mainWindow, 0) then delay 0.5
     end try
     try
-      set searchControlResult to my findBrowserSearchControl(mainWindow, 0, origin, windowSize)
+      set searchControlResult to my findBrowserSearchControl(mainWindow, 0, false, missing value)
       if searchControlResult is not missing value then
         set searchControl to item 1 of searchControlResult
         set browserRoot to item 2 of searchControlResult
@@ -3774,9 +3726,11 @@ function browserSearchFieldScript(): string {
         end if
       end if
     end try
-    if not searchFieldFound then
+    if not searchFieldFound and searchButton is not missing value then
       try
-        set searchControlResult to my findBrowserSearchControl(mainWindow, 0, origin, windowSize)
+        perform action "AXPress" of searchButton
+        delay 0.2
+        set searchControlResult to my findBrowserSearchControl(mainWindow, 0, false, missing value)
         if searchControlResult is not missing value then
           set searchControl to item 1 of searchControlResult
           set browserRoot to item 2 of searchControlResult
@@ -3784,40 +3738,11 @@ function browserSearchFieldScript(): string {
           if searchRole is "AXSearchField" or searchRole is "AXTextField" then
             set searchField to searchControl
             set searchFieldFound to true
-          else if searchRole is "AXButton" then
-            set searchButton to searchControl
           end if
         end if
       end try
     end if
-    if not searchFieldFound and searchButton is missing value then
-      try
-        set directSearchButton to UI element 3 of UI element 3 of UI element 1 of UI element 2 of UI element 1 of UI element 1 of UI element 1 of mainWindow
-        set directSearchDescription to description of directSearchButton as text
-        if directSearchDescription contains "search" or directSearchDescription contains "Search" then
-          set searchButton to directSearchButton
-        end if
-      end try
-    end if
-    if not searchFieldFound then
-      if searchButton is not missing value then
-        try
-          perform action "AXPress" of searchButton
-          delay 0.2
-          set focusedCandidate to value of attribute "AXFocusedUIElement"
-          set focusedRole to role of focusedCandidate as text
-          set focusedDescription to ""
-          try
-            set focusedDescription to description of focusedCandidate as text
-          end try
-          if (focusedRole is "AXSearchField" or (focusedRole is "AXTextField" and (focusedDescription contains "search" or focusedDescription contains "Search"))) then
-            set searchField to focusedCandidate
-            set searchFieldFound to true
-          end if
-        end try
-      end if
-    end if
-    if not searchFieldFound then error "FINAL_CUT_NATIVE_SEARCH_UNAVAILABLE: Browser search field was not found through Accessibility or coordinate fallback"
+    if not searchFieldFound then error "FINAL_CUT_NATIVE_SEARCH_UNAVAILABLE: Browser search control was not exposed by Accessibility"
     set searchRole to role of searchField as text
     if searchRole is not "AXTextField" and searchRole is not "AXSearchField" then error "FINAL_CUT_NATIVE_SEARCH_UNAVAILABLE: Browser search field was not hit"
     try
@@ -3832,28 +3757,53 @@ function browserSearchFieldScript(): string {
 function browserSearchControlFinderScript(): string {
   return `
   using terms from application "System Events"
-    on browserSearchCandidateVisible(candidate, mainOrigin, mainSize)
+    on browserSearchContainer(candidate)
       try
-        set candidatePosition to position of candidate
-        set candidateX to item 1 of candidatePosition
-        set candidateY to item 2 of candidatePosition
-        return candidateX is less than ((item 1 of mainOrigin) + ((item 1 of mainSize) * 0.60)) and candidateY is less than ((item 2 of mainOrigin) + ((item 2 of mainSize) * 0.60))
+        set candidateRole to role of candidate as text
+        if candidateRole is not "AXGroup" and candidateRole is not "AXScrollArea" and candidateRole is not "AXSplitGroup" and candidateRole is not "AXLayoutArea" and candidateRole is not "AXToolbar" and candidateRole is not "AXList" and candidateRole is not "AXOutline" and candidateRole is not "AXCollection" then return false
+        set candidateText to ""
+        try
+          set candidateText to description of candidate as text
+        end try
+        if candidateText is "" then
+          try
+            set candidateText to name of candidate as text
+          end try
+        end if
+        if candidateText is "" then
+          try
+            set candidateText to value of candidate as text
+          end try
+        end if
+        return candidateText contains "Browser" or candidateText contains "browser" or candidateText contains "Events" or candidateText contains "events" or candidateText contains "Event" or candidateText contains "event"
       on error
         return false
       end try
-    end browserSearchCandidateVisible
+    end browserSearchContainer
 
-    on findBrowserSearchControl(containerItem, depth, mainOrigin, mainSize)
+    on findBrowserSearchControl(containerItem, depth, inheritedBrowserContext, inheritedBrowserRoot)
       if depth > 12 then return missing value
+      set browserContext to inheritedBrowserContext
+      set browserRoot to inheritedBrowserRoot
+      if my browserSearchContainer(containerItem) then
+        set browserContext to true
+        set browserRoot to containerItem
+      end if
       set candidateItems to UI elements of containerItem
       repeat with candidateIndex in my orderedChildIndices(containerItem)
         try
           set candidate to item (contents of candidateIndex) of candidateItems
-          set candidateRole to role of candidate as text
-          if candidateRole is "AXSearchField" and my browserSearchCandidateVisible(candidate, mainOrigin, mainSize) then
-            return {candidate, containerItem}
+          set candidateBrowserContext to browserContext
+          set candidateBrowserRoot to browserRoot
+          if my browserSearchContainer(candidate) then
+            set candidateBrowserContext to true
+            set candidateBrowserRoot to candidate
           end if
-          if candidateRole is "AXTextField" then
+          set candidateRole to role of candidate as text
+          if candidateBrowserContext and candidateRole is "AXSearchField" then
+            return {candidate, candidateBrowserRoot}
+          end if
+          if candidateBrowserContext and candidateRole is "AXTextField" then
             set candidateName to ""
             set candidateDescription to ""
             try
@@ -3862,19 +3812,19 @@ function browserSearchControlFinderScript(): string {
             try
               set candidateDescription to description of candidate as text
             end try
-            if (candidateName contains "search" or candidateName contains "Search" or candidateDescription contains "search" or candidateDescription contains "Search") and my browserSearchCandidateVisible(candidate, mainOrigin, mainSize) then
-              return {candidate, containerItem}
+            if candidateName contains "search" or candidateName contains "Search" or candidateDescription contains "search" or candidateDescription contains "Search" then
+              return {candidate, candidateBrowserRoot}
             end if
           end if
-          if candidateRole is "AXButton" then
+          if candidateBrowserContext and candidateRole is "AXButton" then
             set candidateDescription to description of candidate as text
-            if (candidateDescription contains "search" or candidateDescription contains "Search") and my browserSearchCandidateVisible(candidate, mainOrigin, mainSize) then
-              return {candidate, containerItem}
+            if candidateDescription contains "search" or candidateDescription contains "Search" then
+              return {candidate, candidateBrowserRoot}
             end if
           end if
         end try
         try
-          set nestedCandidate to my findBrowserSearchControl(candidate, depth + 1, mainOrigin, mainSize)
+          set nestedCandidate to my findBrowserSearchControl(candidate, depth + 1, candidateBrowserContext, candidateBrowserRoot)
           if nestedCandidate is not missing value then
             return nestedCandidate
           end if

--- a/docs/final-cut/installation.md
+++ b/docs/final-cut/installation.md
@@ -214,8 +214,9 @@ It does not report success until Final Cut has produced a non-empty file and
 unless the request includes `overwrite: true`.
 
 Framekit activates Final Cut and focuses the timeline before timeline-native
-operations using Accessibility hierarchy discovery with bounded coordinate
-fallbacks. If the visible Framekit extension window overlaps the editor,
+operations using bounded Accessibility hierarchy discovery. Browser search
+also requires a labelled Browser or Events Accessibility relationship; it does
+not use ambiguous screen-coordinate fallback. If the visible Framekit extension window overlaps the editor,
 Framekit minimizes it with `AXMinimize`, raises Final Cut's timeline window,
 and verifies the focused window after each attempt. It never clicks the
 Framekit close button. The user must open the intended project timeline and

--- a/docs/final-cut/native-media-insertion-breakthrough.md
+++ b/docs/final-cut/native-media-insertion-breakthrough.md
@@ -46,11 +46,12 @@ not a canonical Final Cut media ID.
 ### Search has two UI states
 
 The Browser may expose an open `AXTextField` or only its magnifying-glass
-button. The adapter first reuses a focused search field, then uses bounded
-layout fallbacks, and only then performs the deeper Accessibility search.
-This ordering matters: sorting or walking the entire Final Cut tree can
-consume the native automation deadline even when the search control is
-visible.
+button. The adapter reveals a hidden Browser through Accessibility, then walks
+bounded, indexed Accessibility relationships rooted in the labelled Browser or
+Events container. It does not target a search field by screen coordinates or
+accept an unrelated Effects or Transitions search control. This ordering keeps
+the native automation bounded and returns
+`FINAL_CUT_NATIVE_SEARCH_UNAVAILABLE` when the Browser control is not exposed.
 
 ### Selecting media changes keyboard focus
 

--- a/tests/integration/native.test.ts
+++ b/tests/integration/native.test.ts
@@ -1484,6 +1484,34 @@ test("native Final Cut Browser discovery accepts generic Events media and reuses
   assert.equal(scripts.some((script) => script.includes("on orderedChildIndices(containerItem)")), true);
 });
 
+test("native Final Cut Browser search stays scoped to Accessibility relationships", async () => {
+  const scripts: string[] = [];
+  const adapter = new FinalCutNativeAutomationAdapter({
+    enabled: true,
+    executor: async (script) => {
+      scripts.push(script);
+      if (script.includes('set frontWindow to window "Final Cut Pro"')) return context(true, "Final Cut Pro", "", 0, false, true, true);
+      if (script.includes("set value of searchField to searchQuery")) return serializeBrowserFixture();
+      return "";
+    },
+  });
+
+  const matches = await adapter.searchMedia("Blue Steel Guitar");
+  assert.equal(matches.length, 2);
+
+  const searchScript = scripts.find((script) => script.includes("set value of searchField to searchQuery"));
+  assert.ok(searchScript);
+  assert.match(searchScript, /on browserSearchContainer\(candidate\)/);
+  assert.match(searchScript, /on findBrowserSearchControl\(containerItem, depth, inheritedBrowserContext, inheritedBrowserRoot\)/);
+  assert.match(searchScript, /findBrowserSearchControl\(mainWindow, 0, false, missing value\)/);
+  assert.match(searchScript, /candidateBrowserContext/);
+  assert.match(searchScript, /candidateBrowserRoot/);
+  assert.match(searchScript, /return \{candidate, candidateBrowserRoot\}/);
+  assert.equal(searchScript.includes("searchOffset"), false);
+  assert.equal(searchScript.includes("click at"), false);
+  assert.equal(searchScript.includes("coordinate fallback"), false);
+});
+
 test("native Final Cut selected-media traversal returns the stable generic Browser identity", async () => {
   const recordSeparator = String.fromCharCode(30);
   const selected = finalCutBrowserAccessibilityFixture.media[0];

--- a/tests/integration/native.test.ts
+++ b/tests/integration/native.test.ts
@@ -1361,7 +1361,7 @@ test("native Final Cut adapter searches, locates, previews, and verifies a Blade
   assert.equal(matches[0].sourceIdentity, "media-source-1");
   assert.equal(scripts.some((script) => script.includes('candidateDescription contains "search"') && script.includes('perform action "AXPress" of searchButton')), true);
   assert.equal(scripts.some((script) => script.includes('return "browser-focused"')), true);
-  assert.equal(scripts.some((script) => script.includes("repeat with searchOffset in {368, 400, 340, 561, 531, 501}")), true);
+  assert.equal(scripts.some((script) => script.includes("repeat with searchOffset")), false);
   assert.equal(scripts.some((script) => script.includes('set searchFieldFound to false') && script.includes('candidateRole is "AXSearchField"')), true);
   assert.equal(scripts.some((script) => script.includes('value of attribute "AXFocusedUIElement"')), true);
   const searchScript = scripts.find((script) => script.includes("set value of searchField to searchQuery"));
@@ -1371,11 +1371,11 @@ test("native Final Cut adapter searches, locates, previews, and verifies a Blade
   assert.ok(activationIndex >= 0);
   assert.ok(frontmostGuardIndex > activationIndex);
   assert.equal(searchScript.includes('tell application "Final Cut Pro" to activate'), false);
-  assert.match(searchScript, /on findBrowserSearchControl\(containerItem, depth, mainOrigin, mainSize\)/);
+  assert.match(searchScript, /on findBrowserSearchControl\(containerItem, depth, inheritedBrowserContext, inheritedBrowserRoot\)/);
   assert.match(searchScript, /on revealBrowser\(containerItem, depth\)/);
   assert.match(searchScript, /candidateDescription contains "Browser"/);
   assert.match(searchScript, /if depth > 12 then return missing value/);
-  assert.match(searchScript, /findBrowserSearchControl\(mainWindow, 0, origin, windowSize\)/);
+  assert.match(searchScript, /findBrowserSearchControl\(mainWindow, 0, false, missing value\)/);
   assert.match(searchScript, /on collectBrowserMedia\(containerItem, depth, searchQuery, origin, inheritedContext, seenIdentities, browserPath\)/);
   assert.match(searchScript, /on collectSelectedBrowserMedia\(containerItem, depth, origin, inheritedContext, seenIdentities, browserPath\)/);
   assert.match(searchScript, /containerText contains "Events"/);
@@ -1386,8 +1386,8 @@ test("native Final Cut adapter searches, locates, previews, and verifies a Blade
   assert.match(searchScript, /set candidateItems to UI elements of containerItem/);
   assert.match(searchScript, /set candidatePath to browserPath & "\/" & \(candidateIndex as text\)/);
   assert.match(searchScript, /if depth > 12 then return ""/);
-  assert.match(searchScript, /focusedDescription to ""\s+try\s+set focusedDescription to description of focusedCandidate as text/);
-  assert.equal(searchScript.match(/set origin to position of mainWindow/g)?.length, 2);
+  assert.equal(searchScript.includes('value of attribute "AXFocusedUIElement"'), false);
+  assert.equal(searchScript.match(/set origin to position of mainWindow/g)?.length, 1);
   assert.ok(searchScript.indexOf("set origin to position of mainWindow") < searchScript.indexOf("set searchFieldFound to false"));
   assert.equal(scripts.some((script) => script.includes('perform action "AXConfirm" of searchField')), false);
   assert.equal(scripts.some((script) => script.includes('keystroke "f" using {command down}')), false);
@@ -1507,9 +1507,13 @@ test("native Final Cut Browser search stays scoped to Accessibility relationship
   assert.match(searchScript, /candidateBrowserContext/);
   assert.match(searchScript, /candidateBrowserRoot/);
   assert.match(searchScript, /return \{candidate, candidateBrowserRoot\}/);
-  assert.equal(searchScript.includes("searchOffset"), false);
-  assert.equal(searchScript.includes("click at"), false);
-  assert.equal(searchScript.includes("coordinate fallback"), false);
+  const searchFieldSection = searchScript.slice(
+    searchScript.indexOf("set searchFieldFound"),
+    searchScript.indexOf("set searchQuery"),
+  );
+  assert.equal(searchFieldSection.includes("searchOffset"), false);
+  assert.equal(searchFieldSection.includes("click at"), false);
+  assert.equal(searchFieldSection.includes("coordinate fallback"), false);
 });
 
 test("native Final Cut selected-media traversal returns the stable generic Browser identity", async () => {


### PR DESCRIPTION
- [x] Request PR review
- [ ] This PR is intentionally a draft while real headed native evidence is unavailable.
- [x] Github issue: Closes: #205

## Summary

- scope native Browser search discovery to bounded Accessibility relationships rooted in the Browser or Events container
- support both exposed search fields and search buttons, re-discovering the field after button activation
- remove hardcoded layout paths, global focused-element reuse, and ambiguous coordinate fallback
- preserve the structured `FINAL_CUT_NATIVE_SEARCH_UNAVAILABLE` failure when the Browser control is inaccessible
- update the native Browser documentation to describe the Accessibility-only contract

## Validation

```bash
pnpm install --frozen-lockfile
pnpm run build
pnpm run test
pnpm run check:boundaries
pnpm run xcode:check
xcodebuild -project adapters/final-cut/swift-bridge/FinalCutWorkflowExtension/FramekitFinalCutWorkflow.xcodeproj -list
```

All required gates pass. The full suite reports 657 passing tests; the focused native suite reports 68 passing tests. The deliberate red regression checkpoint is `bc7cd3a`; the green implementation commit is `bcc97d7`.

No headed Final Cut result is claimed: the headed verifier requires a prepared disposable project and query, and those environment variables were not configured for this worktree.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Public MCP behavior and package interfaces remain unchanged; native documentation is aligned.
- [x] Existing adapters and deterministic fixtures remain compatible.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [x] Documentation reflects the changed native search behavior.
