### PR TITLE
feat: enable canonical timeline.edit in headed Final Cut

### DIFF
--- a/adapters/final-cut/typescript/src/canonical.ts
+++ b/adapters/final-cut/typescript/src/canonical.ts
@@ -17,6 +17,7 @@ import {
   type ProjectSelection,
   type ProjectSnapshot,
   type RuntimeCapabilities,
+  type WorkflowOperation,
 } from "@framekit/runtime";
 import type {
   NativeFinalCutEditor,
@@ -267,6 +268,7 @@ export class FinalCutCanonicalNativeProvider implements EditorPort, LiveEditorSt
         playbackControl: false,
         projectCatalogRead: true,
         projectSelection: true,
+        compositeTransactions: true,
       },
       analyzers: {
         speechTranscribe: false,
@@ -300,6 +302,31 @@ export class FinalCutCanonicalNativeProvider implements EditorPort, LiveEditorSt
     }
     this.lastSnapshot = { ...snapshot, revision: this.revision };
     return structuredClone(this.lastSnapshot);
+  }
+
+  public async previewTransaction(
+    operations: WorkflowOperation[],
+    expectedRevision: ContextRevision,
+  ): Promise<ProjectSnapshot> {
+    const before = await this.readProject();
+    assertSameRevision(expectedRevision, before.revision);
+    const operation = supportedCanonicalOperation(operations);
+    const clip = before.timeline.clips.find(({ id }) => id === operation.clipId);
+    if (!clip) throw new Error(`CLIP_NOT_FOUND: ${operation.clipId}`);
+    const preview = structuredClone(before);
+    preview.timeline.clips = preview.timeline.clips.map((candidate) => (
+      candidate.id === operation.clipId ? { ...candidate, name: operation.name } : candidate
+    ));
+    preview.revision = previewRevision(preview, before.revision);
+    return preview;
+  }
+
+  public async applyTransaction(
+    operations: WorkflowOperation[],
+    expectedRevision: ContextRevision,
+  ): Promise<void> {
+    const operation = supportedCanonicalOperation(operations);
+    await this.apply(operation, expectedRevision);
   }
 
   public async apply(operation: EditOperation, expectedRevision: ContextRevision): Promise<ContextRevision> {
@@ -416,6 +443,23 @@ export class FinalCutCanonicalNativeProvider implements EditorPort, LiveEditorSt
       throw new Error(`TARGET_MISMATCH: exported sequence ${snapshot.timeline.name} is not active Final Cut sequence ${live.sequence.name}`);
     }
   }
+}
+
+function supportedCanonicalOperation(operations: WorkflowOperation[]): Extract<WorkflowOperation, { type: "rename-clip" }> {
+  if (operations.length !== 1 || operations[0]?.type !== "rename-clip") {
+    throw new Error("CAPABILITY_UNAVAILABLE: final-cut native canonical provider supports one rename-clip transaction");
+  }
+  const operation = operations[0];
+  if (!operation.name.trim()) throw new Error("INVALID_OPERATION: clip name cannot be empty");
+  return operation;
+}
+
+function previewRevision(snapshot: ProjectSnapshot, before: ContextRevision): ContextRevision {
+  return {
+    id: `canonical:${canonicalSnapshotDigest(snapshot)}`,
+    sequence: before.sequence + 1,
+    timestamp: new Date().toISOString(),
+  };
 }
 
 function assertSameRevision(expected: ContextRevision, actual: ContextRevision): void {

--- a/adapters/final-cut/typescript/src/canonical.ts
+++ b/adapters/final-cut/typescript/src/canonical.ts
@@ -335,6 +335,7 @@ export class FinalCutCanonicalNativeProvider implements EditorPort, LiveEditorSt
     if (operation.type !== "rename-clip") {
       throw new Error(`CAPABILITY_UNAVAILABLE: final-cut native canonical provider does not support ${operation.type}`);
     }
+    validateCanonicalRename(operation);
     const clip = before.timeline.clips.find(({ id }) => id === operation.clipId);
     if (!clip) throw new Error(`CLIP_NOT_FOUND: ${operation.clipId}`);
 
@@ -449,7 +450,12 @@ function supportedCanonicalOperation(operations: WorkflowOperation[]): Extract<W
   if (operations.length !== 1 || operations[0]?.type !== "rename-clip") {
     throw new Error("CAPABILITY_UNAVAILABLE: final-cut native canonical provider supports one rename-clip transaction");
   }
-  const operation = operations[0];
+  return validateCanonicalRename(operations[0]);
+}
+
+function validateCanonicalRename(
+  operation: Extract<EditOperation, { type: "rename-clip" }>,
+): Extract<EditOperation, { type: "rename-clip" }> {
   if (!operation.name.trim()) throw new Error("INVALID_OPERATION: clip name cannot be empty");
   return operation;
 }

--- a/docs/final-cut/installation.md
+++ b/docs/final-cut/installation.md
@@ -142,7 +142,9 @@ metadata socket with Final Cut's own UI. It exports the active timeline through
 canonical snapshot, and removes the file after each read. It does not read or
 write `FRAMEKIT_FCPXML_PATH`. The provider supports `rename-clip` after an exact
 Browser media match and a unique timeline occurrence with matching rational
-coordinates; native Accessibility Undo and a second export verify rollback.
+coordinates; native Accessibility Undo and a second export verify rollback. Its
+canonical transaction port currently supports one `rename-clip` operation through
+`editor.timeline.edit.preview` and `editor.timeline.edit.execute`.
 
 Use it only with Final Cut Pro 10.7.1 on the repository's macOS/Xcode 16.4
 baseline until a different Final Cut version has its own headed evidence:

--- a/docs/mcp/final-cut-live.md
+++ b/docs/mcp/final-cut-live.md
@@ -91,6 +91,13 @@ and native Undo that restores the original canonical digest. Duplicate media,
 duplicate occurrences, stale coordinates, missing Accessibility identity, or
 any failed verification returns an error before claiming success.
 
+The canonical transaction port currently supports one `rename-clip` transaction.
+Call `editor.timeline.edit.preview` with the explicit project, sequence, base
+revision, and operation, confirm that the preview is non-mutating, then call
+`editor.timeline.edit.execute` with its single-use token. The execute result
+contains the read-after-write snapshot, deterministic diff, verification, and
+the transaction ID used by `edit.undo`.
+
 The headed baseline is Final Cut Pro 10.7.1 on the repository's macOS/Xcode
 16.4 environment. A different Final Cut version requires fresh headed evidence.
 Use a disposable project, open the intended sequence before connecting, and
@@ -144,7 +151,8 @@ than the open Final Cut timeline.
 
 The socket protocol also accepts `snapshot`, `apply`, and `restore` from a live
 bridge that can prove canonical guarantees. Framekit exposes that provider
-through the existing `project.list`, `project.select`, `project.inspect`, `editor.timeline.edit`, `edit.diff`, and
+through the existing `project.list`, `project.select`, `project.inspect`, `editor.timeline.edit`,
+`editor.timeline.edit.preview`, `editor.timeline.edit.execute`, `edit.diff`, and
 `edit.undo` MCP tools only when `canonicalTimelineMode` is `canonical-read` or
 `canonical-write`. The bundled Workflow Extension cannot currently supply
 those methods and fails them with `CAPABILITY_UNAVAILABLE`.

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -295,9 +295,11 @@ after 30 seconds by default and are consumed on the first execute attempt.
 Execution rechecks capabilities and the base revision, then applies the ordered
 operations through one adapter transaction. Verification failure or a partial
 adapter write restores the pre-transaction timeline and media registry. The
-deterministic fixture advertises this contract; FCPXML and live Final Cut
-backends continue to fail closed until they implement the same atomic adapter
-port.
+deterministic fixture advertises this contract. The opt-in headed native
+provider implements the same atomic adapter port for one `rename-clip`
+transaction; broader composite primitives and the metadata-only bundled
+Workflow Extension remain unavailable until they advertise atomic preview,
+execution, read-after-write, and rollback support.
 
 ## Masking workflow
 

--- a/tests/integration/canonical-native-mcp.test.ts
+++ b/tests/integration/canonical-native-mcp.test.ts
@@ -205,3 +205,64 @@ test("canonical native provider satisfies the MCP targeting, edit, verify, and U
     await server.close();
   }
 });
+
+test("canonical native provider exposes a non-mutating preview-token transaction through MCP", async () => {
+  const calls: string[] = [];
+  const { client, server } = await connect(createRuntime(calls));
+
+  try {
+    const editor = JSON.parse(textFrom(await client.callTool({ name: "editor.inspect", arguments: {} })));
+    assert.equal(editor.capabilities.editor.compositeTransactions, true);
+    assert.equal(editor.capabilities.families.editing.compositeTransactions.available, true);
+
+    const before = JSON.parse(textFrom(await client.callTool({ name: "project.inspect", arguments: {} })));
+    const timeline = JSON.parse(textFrom(await client.callTool({ name: "timeline.inspect", arguments: {} })));
+    assert.deepEqual(timeline, before.timeline);
+
+    const preview = JSON.parse(textFrom(await client.callTool({
+      name: "editor.timeline.edit.preview",
+      arguments: {
+        projectId: before.projectId,
+        sequenceId: before.timeline.id,
+        baseRevision: before.revision,
+        operations: [{
+          type: "rename-clip",
+          clipId: before.timeline.clips[0].id,
+          name: "Preview-token rename",
+        }],
+      },
+    })));
+    assert.equal(preview.operations[0].type, "rename-clip");
+    assert.equal(preview.target.projectId, before.projectId);
+    assert.equal(preview.target.sequenceId, before.timeline.id);
+    assert.deepEqual(JSON.parse(textFrom(await client.callTool({ name: "project.inspect", arguments: {} }))), before);
+    assert.deepEqual(calls, []);
+
+    const transaction = JSON.parse(textFrom(await client.callTool({
+      name: "editor.timeline.edit.execute",
+      arguments: { previewToken: preview.previewToken },
+    })));
+    assert.equal(transaction.status, "VERIFIED");
+    assert.equal(transaction.after.timeline.clips[0].name, "Preview-token rename");
+    assert.ok(transaction.diff.modified.some((item: { itemId: string }) => item.itemId === before.timeline.clips[0].id));
+    assert.ok(transaction.after.revision.sequence > before.revision.sequence);
+    assert.deepEqual(calls, ["edit"]);
+
+    const replay = await client.callTool({
+      name: "editor.timeline.edit.execute",
+      arguments: { previewToken: preview.previewToken },
+    });
+    assert.equal(replay.isError, true);
+    assert.match(textFrom(replay), /PREVIEW_TOKEN_INVALID/);
+
+    const restored = JSON.parse(textFrom(await client.callTool({
+      name: "edit.undo",
+      arguments: { transactionId: transaction.id },
+    })));
+    assert.equal(restored.timeline.clips[0].name, "Original");
+    assert.deepEqual(calls, ["edit", "undo"]);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});

--- a/tests/integration/canonical-native-provider.test.ts
+++ b/tests/integration/canonical-native-provider.test.ts
@@ -145,6 +145,23 @@ test("canonical native provider previews and applies its supported timeline tran
   assert.deepEqual(calls, ["edit"]);
 });
 
+test("canonical native provider rejects whitespace-only direct renames before mutation", async () => {
+  const calls: string[] = [];
+  const provider = providerFor([snapshot("Original"), snapshot("Original")], calls);
+  const before = await provider.readProject();
+
+  await assert.rejects(
+    provider.apply({
+      type: "rename-clip",
+      clipId: "final-cut:occurrence:clip-1",
+      name: "   ",
+      baseRevision: before.revision,
+    }, before.revision),
+    /INVALID_OPERATION: clip name cannot be empty/,
+  );
+  assert.deepEqual(calls, []);
+});
+
 test("canonical native provider rejects stale targets before native mutation", async () => {
   const calls: string[] = [];
   const provider = providerFor([snapshot("Original"), snapshot("Original")], calls);

--- a/tests/integration/canonical-native-provider.test.ts
+++ b/tests/integration/canonical-native-provider.test.ts
@@ -118,6 +118,33 @@ test("canonical native provider exposes one explicit active project and sequence
   assert.equal((await provider.getCapabilities()).editor.canonicalTimelineMode, "canonical-write");
 });
 
+test("canonical native provider previews and applies its supported timeline transaction", async () => {
+  const calls: string[] = [];
+  const provider = providerFor([
+    snapshot("Original"),
+    snapshot("Original"),
+    snapshot("Original"),
+    snapshot("Original"),
+    snapshot("Renamed"),
+  ], calls);
+  const before = await provider.readProject();
+  const operation = {
+    type: "rename-clip" as const,
+    clipId: "final-cut:occurrence:clip-1",
+    name: "Renamed",
+  };
+
+  const preview = await provider.previewTransaction([operation], before.revision);
+
+  assert.equal(preview.timeline.clips[0]?.name, "Renamed");
+  assert.deepEqual(await provider.readProject(), before);
+  assert.deepEqual(calls, []);
+
+  await provider.applyTransaction([operation], before.revision);
+
+  assert.deepEqual(calls, ["edit"]);
+});
+
 test("canonical native provider rejects stale targets before native mutation", async () => {
   const calls: string[] = [];
   const provider = providerFor([snapshot("Original"), snapshot("Original")], calls);

--- a/tests/integration/editing-surface-docs.test.ts
+++ b/tests/integration/editing-surface-docs.test.ts
@@ -33,6 +33,8 @@ test("editing surface docs distinguish artifact, publish, and live targets", asy
   assert.match(finalCutLive, /canonical-write/);
   assert.match(finalCutLive, /FRAMEKIT_FINAL_CUT_CANONICAL_PROVIDER=native/);
   assert.match(finalCutLive, /Export XML/);
+  assert.match(finalCutLive, /editor\.timeline\.edit\.preview/);
+  assert.match(finalCutLive, /one `rename-clip` transaction/);
   assert.match(finalCutLive, /metadata-only/);
   assert.doesNotMatch(mcpTools, /\| `timeline\.edit` \|/);
   assert.doesNotMatch(mcpTools, /\| `timeline\.publish\.new-project` \|/);


### PR DESCRIPTION
Closes #211

## Summary

Implemented the minimum supported canonical live `timeline.edit` transaction path for the headed Final Cut provider.

- Added provider-level preview and execute transaction support.
- Advertised the composite transaction capability only for the supported canonical path.
- Scoped the native write gate to one `rename-clip` operation and kept unsupported operations fail-closed.
- Added MCP coverage for non-mutating preview, target/revision binding, read-after-write, diff, verification, single-use tokens, and Undo restoration.
- Documented the supported operation and the broader capability boundary.

## Validation

```bash
pnpm install --frozen-lockfile
pnpm run build
pnpm run test
pnpm run check:boundaries
```

All required gates passed: build, 658 tests, and package boundary checks. Native Xcode gates were not needed because this PR changes no native Swift/Xcode files. A disposable headed Final Cut mutation was not run; deterministic canonical-live evidence is reported separately from headed-native evidence.

## Acceptance mapping

- [x] Supported `timeline.edit` operations route through the canonical provider.
- [x] Project and timeline inspection use the same canonical target and revision.
- [x] Preview is non-mutating and binds the operation, target, and base revision.
- [x] Execute returns read-after-write, deterministic diff, and verification evidence.
- [x] Undo restores the pre-edit canonical state.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Public MCP behavior is covered by integration tests and documented.
- [x] Existing adapters and fixtures remain compatible.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [x] Documentation reflects the supported canonical transaction boundary.
