### PR TITLE
feat: resolve native media import and append intents

### DIFF
--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -718,6 +718,17 @@ function normalizeConnectionStatus(value: unknown): unknown {
   };
 }
 
+function nativeMediaIntentCapabilities(nativeEditor?: NativeFinalCutEditor): Record<string, boolean> {
+  const capabilities = nativeEditor?.capabilities();
+  return {
+    "native.mediaImport": Boolean(capabilities?.mediaImport),
+    "native.mediaSelection": Boolean(capabilities?.mediaSelection),
+    "native.mediaAppendSelected": Boolean(capabilities?.mediaAppendSelected),
+    "native.mediaAppend": Boolean(capabilities?.mediaAppend),
+    "native.mediaInsert": Boolean(capabilities?.mediaInsert),
+  };
+}
+
 function isRuntimeCapabilities(value: unknown): value is RuntimeCapabilities {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const capabilities = value as Record<string, unknown>;
@@ -882,7 +893,9 @@ export function createMcpServer(runtime: AgentVideoRuntime, options: McpServerOp
   server.registerTool("editing.intent.resolve", {
     description: "Map a supported natural-language editing request to one explicit operation without executing it.",
     inputSchema: { request: z.string().trim().min(1) },
-  }, async ({ request }) => jsonResult(resolveEditingIntent(request)));
+  }, async ({ request }) => jsonResult(resolveEditingIntent(request, {
+    availableCapabilities: nativeMediaIntentCapabilities(options.nativeEditor),
+  })));
 
   server.registerTool("editing.route", {
     description: "Resolve an editor-first path after capability checks; never bypass a connected editor, and require explicit external fallback selection.",

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -29,7 +29,7 @@ this routing tool.
 | --- | --- | --- |
 | `connection.status` | Framekit Final Cut setup and connection state | Available during live setup and reconnect |
 | `editor.inspect` | Editor identity and capabilities | Available when a backend is selected |
-| `editing.intent.resolve` | Map one supported natural-language request to an explicit operation and affected range | Read-only; ambiguous requests return clarification and no operation; resolved destructive requests set `previewRequired` |
+| `editing.intent.resolve` | Map one supported natural-language request to an explicit editing or native media workflow | Read-only; ambiguous requests return clarification and no operation; native media requests expose required capabilities and guarded tool sequences |
 | `editing.route` | Select an editor-first operation path after connection and capability checks | Read-only; fails closed when the editor is unavailable or insufficient; external rendering requires explicit `fallback: "external-renderer"` |
 | `editing.duration.plan` | Compare requested duration with usable footage and return explicit editorial alternatives | Read-only; ambiguous duration requests default to a soft constraint; reuse, slow motion, and generated assets are never implicit |
 | `editor.native.inspect` | Active native Final Cut selection/playhead and UI focus diagnostics | Requires native writes opt-in and Accessibility permission |
@@ -322,19 +322,35 @@ Native evidence does not claim canonical timeline enumeration.
 
 ## Explicit editing intent
 
-`editing.intent.resolve` accepts a request string and recognizes only these
+`editing.intent.resolve` accepts a request string and recognizes these explicit
 forms:
 
 - `Cut at 30 seconds and remove the rest` → `trim_to_duration`
 - `Blade at 30 seconds` → `blade_at_playhead`
 - `Remove 10–15 seconds` → `delete_range`
+- `Import "/tmp/interview.mov"` → `media_import`
+- `Select Browser media with handle media-42` → `media_select`
+- `Append the selected media to the active timeline` → `media_append_selected`
+- `Append media with handle media-42 to the timeline` → `media_append`
+- `Insert media with handle media-42 at the playhead` → `media_insert`
+- `Import "/tmp/interview.mov" and append it to the active timeline` → `media_import_then_append`
 
-The result includes the selected operation, the affected range,
-`previewRequired: true`, and the exact `previewTool` to call. The resolver never
-mutates the editor. Callers must use that operation-specific native preview tool
-before an execute call; native execute tools accept only their short-lived
-preview tokens. An unrecognized or ambiguous destructive request returns
-`clarification_required` without an operation or preview tool.
+Destructive timeline resolutions include the selected operation,
+`requiredCapabilities`, explicit `requiredParameters`, the active project
+target, `previewRequired: true`, and the exact `previewTool`, `executeTool`, and
+`workflow` sequence to call. Handle-based append and insert workflows select the
+Browser handle before previewing; selected-media append uses the selected-media
+preview pair directly. Import-and-append remains a sequence of separately
+confirmed native steps, with the append still protected by its own preview
+token. The resolver never mutates the editor.
+
+The MCP server checks the advertised native capabilities while resolving media
+intents. If a required capability is unavailable, resolution returns
+`capability_unavailable` with `requiredCapabilities`, `missingCapabilities`, and
+the relevant operation option; it never claims that a preview or execute path
+is available. Missing paths, handles, placements, and unsupported wording
+return `clarification_required` without inventing values. Existing destructive
+intent mappings retain their original response shape and preview contract.
 
 ## Generic Skills
 

--- a/packages/runtime/src/editing/intent.ts
+++ b/packages/runtime/src/editing/intent.ts
@@ -99,7 +99,7 @@ export type EditingIntentResolution =
     }
   | {
       status: "clarification_required";
-      destructive: true;
+      destructive: boolean;
       previewRequired: false;
       question: string;
       options: EditingIntentOperation["type"][];
@@ -190,6 +190,7 @@ export function resolveEditingIntent(
     return mediaClarification(
       "Which local media path should Framekit import?",
       ["media_import"],
+      false,
     );
   }
 
@@ -209,6 +210,7 @@ export function resolveEditingIntent(
     return mediaClarification(
       "Which Browser media handle should Framekit select?",
       ["media_select"],
+      false,
     );
   }
 
@@ -376,10 +378,11 @@ function mediaResolution(input: {
 function mediaClarification(
   question: string,
   options: Extract<EditingIntentOperation["type"], `media_${string}`>[],
+  destructive = true,
 ): EditingIntentResolution {
   return {
     status: "clarification_required",
-    destructive: true,
+    destructive,
     previewRequired: false,
     question,
     options,

--- a/packages/runtime/src/editing/intent.ts
+++ b/packages/runtime/src/editing/intent.ts
@@ -15,6 +15,38 @@ export type EditingIntentOperation =
         start: RationalTime;
         end: RationalTime;
       };
+    }
+  | {
+      type: "media_import";
+      path: string;
+      targetProject: "active";
+    }
+  | {
+      type: "media_select";
+      mediaHandle: string;
+    }
+  | {
+      type: "media_append_selected";
+      targetProject: "active";
+      placement: "append";
+    }
+  | {
+      type: "media_append";
+      mediaHandle: string;
+      targetProject: "active";
+      placement: "append";
+    }
+  | {
+      type: "media_insert";
+      mediaHandle: string;
+      targetProject: "active";
+      placement: "insert";
+    }
+  | {
+      type: "media_import_then_append";
+      path: string;
+      targetProject: "active";
+      placement: "append";
     };
 
 export type EditingIntentAffectedRange =
@@ -46,6 +78,26 @@ export type EditingIntentResolution =
       affectedRange: EditingIntentAffectedRange;
     }
   | {
+      status: "resolved";
+      destructive: boolean;
+      previewRequired: boolean;
+      previewTool?: MediaPreviewTool;
+      executeTool?: MediaExecuteTool;
+      operation: MediaEditingIntentOperation;
+      requiredCapabilities: string[];
+      requiredParameters: MediaIntentParameter[];
+      workflow: string[];
+    }
+  | {
+      status: "capability_unavailable";
+      destructive: boolean;
+      previewRequired: false;
+      question: string;
+      options: MediaEditingIntentOperation["type"][];
+      requiredCapabilities: string[];
+      missingCapabilities: string[];
+    }
+  | {
       status: "clarification_required";
       destructive: true;
       previewRequired: false;
@@ -53,15 +105,192 @@ export type EditingIntentResolution =
       options: EditingIntentOperation["type"][];
     };
 
+type MediaEditingIntentOperation = Extract<
+  EditingIntentOperation,
+  { type: `media_${string}` }
+>;
+
+type MediaPreviewTool =
+  | "editor.native.media.append.preview"
+  | "editor.native.media.append.selected.preview"
+  | "editor.native.media.insert.preview";
+
+type MediaExecuteTool =
+  | "editor.native.media.append.execute"
+  | "editor.native.media.append.selected.execute"
+  | "editor.native.media.insert.execute";
+
+type MediaIntentParameter = "path" | "mediaHandle" | "project" | "placement";
+
+export interface EditingIntentResolutionContext {
+  /** When present, native media intent resolution fails closed for unavailable capabilities. */
+  availableCapabilities: Readonly<Record<string, boolean>>;
+}
+
 const CLARIFICATION_OPTIONS: EditingIntentOperation["type"][] = [
   "trim_to_duration",
   "blade_at_playhead",
   "delete_range",
 ];
 
+const ACTIVE_PROJECT = "active" as const;
+
 /** Resolve only the explicit destructive language supported by Framekit. */
-export function resolveEditingIntent(request: string): EditingIntentResolution {
-  const normalized = request.trim().replace(/\s+/g, " ").toLowerCase();
+export function resolveEditingIntent(
+  request: string,
+  context?: EditingIntentResolutionContext,
+): EditingIntentResolution {
+  const collapsed = request.trim().replace(/\s+/g, " ");
+  const normalized = collapsed.toLowerCase();
+
+  const importAndAppendPath = parseMediaPath(collapsed, true);
+  if (importAndAppendPath) {
+    return mediaResolution({
+      destructive: true,
+      previewRequired: true,
+      previewTool: "editor.native.media.append.preview",
+      executeTool: "editor.native.media.append.execute",
+      operation: {
+        type: "media_import_then_append",
+        path: importAndAppendPath,
+        targetProject: ACTIVE_PROJECT,
+        placement: "append",
+      },
+      requiredCapabilities: ["native.mediaImport", "native.mediaSelection", "native.mediaAppend"],
+      requiredParameters: ["path", "project", "placement"],
+      workflow: [
+        "editor.native.media.import",
+        "editor.native.media.select",
+        "editor.native.media.append.preview",
+        "editor.native.media.append.execute",
+      ],
+    }, context);
+  }
+
+  if (/^import\b/i.test(collapsed) && /\band\s+append\b/i.test(collapsed)) {
+    return mediaClarification(
+      "Which local media path should Framekit import before appending?",
+      ["media_import_then_append", "media_import"],
+    );
+  }
+
+  const importPath = parseMediaPath(collapsed, false);
+  if (importPath) {
+    return mediaResolution({
+      destructive: false,
+      previewRequired: false,
+      operation: { type: "media_import", path: importPath, targetProject: ACTIVE_PROJECT },
+      requiredCapabilities: ["native.mediaImport"],
+      requiredParameters: ["path"],
+      workflow: ["editor.native.media.import"],
+    }, context);
+  }
+
+  if (/^import\b/i.test(collapsed)) {
+    return mediaClarification(
+      "Which local media path should Framekit import?",
+      ["media_import"],
+    );
+  }
+
+  const selectHandle = parseMediaHandle(collapsed, "select");
+  if (selectHandle) {
+    return mediaResolution({
+      destructive: false,
+      previewRequired: false,
+      operation: { type: "media_select", mediaHandle: selectHandle },
+      requiredCapabilities: ["native.mediaSelection"],
+      requiredParameters: ["mediaHandle"],
+      workflow: ["editor.native.media.select"],
+    }, context);
+  }
+
+  if (/^select\b/i.test(collapsed)) {
+    return mediaClarification(
+      "Which Browser media handle should Framekit select?",
+      ["media_select"],
+    );
+  }
+
+  if (isAppendSelectedRequest(normalized)) {
+    return mediaResolution({
+      destructive: true,
+      previewRequired: true,
+      previewTool: "editor.native.media.append.selected.preview",
+      executeTool: "editor.native.media.append.selected.execute",
+      operation: {
+        type: "media_append_selected",
+        targetProject: ACTIVE_PROJECT,
+        placement: "append",
+      },
+      requiredCapabilities: ["native.mediaAppendSelected"],
+      requiredParameters: ["project", "placement"],
+      workflow: [
+        "editor.native.media.append.selected.preview",
+        "editor.native.media.append.selected.execute",
+      ],
+    }, context);
+  }
+
+  const insertHandle = parseMediaHandle(collapsed, "insert");
+  if (insertHandle) {
+    return mediaResolution({
+      destructive: true,
+      previewRequired: true,
+      previewTool: "editor.native.media.insert.preview",
+      executeTool: "editor.native.media.insert.execute",
+      operation: {
+        type: "media_insert",
+        mediaHandle: insertHandle,
+        targetProject: ACTIVE_PROJECT,
+        placement: "insert",
+      },
+      requiredCapabilities: ["native.mediaSelection", "native.mediaInsert"],
+      requiredParameters: ["mediaHandle", "project", "placement"],
+      workflow: [
+        "editor.native.media.select",
+        "editor.native.media.insert.preview",
+        "editor.native.media.insert.execute",
+      ],
+    }, context);
+  }
+
+  const appendHandle = parseMediaHandle(collapsed, "append");
+  if (appendHandle) {
+    return mediaResolution({
+      destructive: true,
+      previewRequired: true,
+      previewTool: "editor.native.media.append.preview",
+      executeTool: "editor.native.media.append.execute",
+      operation: {
+        type: "media_append",
+        mediaHandle: appendHandle,
+        targetProject: ACTIVE_PROJECT,
+        placement: "append",
+      },
+      requiredCapabilities: ["native.mediaSelection", "native.mediaAppend"],
+      requiredParameters: ["mediaHandle", "project", "placement"],
+      workflow: [
+        "editor.native.media.select",
+        "editor.native.media.append.preview",
+        "editor.native.media.append.execute",
+      ],
+    }, context);
+  }
+
+  if (/^append\b/i.test(collapsed)) {
+    return mediaClarification(
+      "Should Framekit append the currently selected Browser media or use a media handle?",
+      ["media_append_selected", "media_append"],
+    );
+  }
+
+  if (/^insert\b/i.test(collapsed)) {
+    return mediaClarification(
+      "Which Browser media handle should Framekit insert at the playhead?",
+      ["media_insert", "media_select"],
+    );
+  }
 
   const trimMatch = normalized.match(/^cut at (\d+(?:\.\d+)?) seconds? and remove the rest$/);
   if (trimMatch) {
@@ -112,6 +341,80 @@ export function resolveEditingIntent(request: string): EditingIntentResolution {
     question: "Which editing operation should Framekit perform?",
     options: [...CLARIFICATION_OPTIONS],
   };
+}
+
+function mediaResolution(input: {
+  destructive: boolean;
+  previewRequired: boolean;
+  previewTool?: MediaPreviewTool;
+  executeTool?: MediaExecuteTool;
+  operation: MediaEditingIntentOperation;
+  requiredCapabilities: string[];
+  requiredParameters: MediaIntentParameter[];
+  workflow: string[];
+}, context?: EditingIntentResolutionContext): EditingIntentResolution {
+  const missingCapabilities = context
+    ? input.requiredCapabilities.filter((capability) => context.availableCapabilities[capability] !== true)
+    : [];
+  if (missingCapabilities.length > 0) {
+    return {
+      status: "capability_unavailable",
+      destructive: input.destructive,
+      previewRequired: false,
+      question: "The connected editor cannot perform this native media operation.",
+      options: [input.operation.type],
+      requiredCapabilities: [...input.requiredCapabilities],
+      missingCapabilities,
+    };
+  }
+  return {
+    status: "resolved",
+    ...input,
+  };
+}
+
+function mediaClarification(
+  question: string,
+  options: Extract<EditingIntentOperation["type"], `media_${string}`>[],
+): EditingIntentResolution {
+  return {
+    status: "clarification_required",
+    destructive: true,
+    previewRequired: false,
+    question,
+    options,
+  };
+}
+
+function isAppendSelectedRequest(request: string): boolean {
+  return /^append(?:\s+the)?\s+(?:currently\s+)?(?:selected\s+)?(?:browser\s+)?media(?:\s+to\s+(?:the\s+)?(?:active\s+)?timeline)?$/.test(request)
+    && /\bselected\b/.test(request);
+}
+
+function parseMediaPath(request: string, withAppend: boolean): string | undefined {
+  const suffix = withAppend
+    ? "\\s+and\\s+append(?:\\s+it)?(?:\\s+to\\s+(?:the\\s+)?(?:active\\s+)?timeline)?"
+    : "";
+  const match = request.match(new RegExp(
+    `^import(?:\\s+(?:this|the))?(?:\\s+(?:local\\s+)?(?:video|audio|media))?\\s+(?:from\\s+)?(?:\\\"([^\\\"]+)\\\"|'([^']+)'|(\\S+?))${suffix}$`,
+    "i",
+  ));
+  const path = match?.[1] ?? match?.[2] ?? match?.[3];
+  return path && !["video", "audio", "media"].includes(path.toLowerCase()) ? path : undefined;
+}
+
+function parseMediaHandle(request: string, operation: "select" | "append" | "insert"): string | undefined {
+  const action = operation === "select" ? "select" : operation;
+  const suffix = operation === "insert"
+    ? "\\s+at\\s+(?:the\\s+)?playhead"
+    : operation === "append"
+      ? "(?:\\s+to\\s+(?:the\\s+)?(?:active\\s+)?timeline)?"
+      : "";
+  const match = request.match(new RegExp(
+    `^${action}(?:\\s+(?:the\\s+)?)?(?:\\s+browser)?\\s+media(?:\\s+with)?(?:\\s+handle)?\\s+(?:\\\"([^\\\"]+)\\\"|'([^']+)'|(\\S+?))${suffix}$`,
+    "i",
+  ));
+  return (match?.[1] ?? match?.[2] ?? match?.[3])?.trim();
 }
 
 function secondsToRational(seconds: string): RationalTime {

--- a/tests/integration/editing-intent.test.ts
+++ b/tests/integration/editing-intent.test.ts
@@ -314,6 +314,16 @@ test("editing intent asks whether append should use a handle or current selectio
   });
 });
 
+test("editing intent treats an incomplete Browser selection as non-destructive", () => {
+  assert.deepEqual(resolveEditingIntent("Select Browser media"), {
+    status: "clarification_required",
+    destructive: false,
+    previewRequired: false,
+    question: "Which Browser media handle should Framekit select?",
+    options: ["media_select"],
+  });
+});
+
 test("editing intent fails closed when a required native capability is unavailable", () => {
   assert.deepEqual(resolveEditingIntent("Insert media with handle media-42 at the playhead", {
     availableCapabilities: {

--- a/tests/integration/editing-intent.test.ts
+++ b/tests/integration/editing-intent.test.ts
@@ -171,3 +171,188 @@ test("MCP intent resolution does not select or preview an ambiguous request", as
     await server.close();
   }
 });
+
+test("editing intent maps local media import to the native import workflow", () => {
+  assert.deepEqual(resolveEditingIntent('Import "/tmp/framekit-Interview Clip.mov"'), {
+    status: "resolved",
+    destructive: false,
+    previewRequired: false,
+    operation: {
+      type: "media_import",
+      path: "/tmp/framekit-Interview Clip.mov",
+      targetProject: "active",
+    },
+    requiredCapabilities: ["native.mediaImport"],
+    requiredParameters: ["path"],
+    workflow: ["editor.native.media.import"],
+  });
+});
+
+test("editing intent maps Browser media selection to the native select workflow", () => {
+  assert.deepEqual(resolveEditingIntent("Select Browser media with handle media-42"), {
+    status: "resolved",
+    destructive: false,
+    previewRequired: false,
+    operation: {
+      type: "media_select",
+      mediaHandle: "media-42",
+    },
+    requiredCapabilities: ["native.mediaSelection"],
+    requiredParameters: ["mediaHandle"],
+    workflow: ["editor.native.media.select"],
+  });
+});
+
+test("editing intent maps append-selected to its guarded preview and execute pair", () => {
+  assert.deepEqual(resolveEditingIntent("Append the selected media to the active timeline"), {
+    status: "resolved",
+    destructive: true,
+    previewRequired: true,
+    previewTool: "editor.native.media.append.selected.preview",
+    executeTool: "editor.native.media.append.selected.execute",
+    operation: {
+      type: "media_append_selected",
+      targetProject: "active",
+      placement: "append",
+    },
+    requiredCapabilities: ["native.mediaAppendSelected"],
+    requiredParameters: ["project", "placement"],
+    workflow: [
+      "editor.native.media.append.selected.preview",
+      "editor.native.media.append.selected.execute",
+    ],
+  });
+});
+
+test("editing intent maps append-by-handle through selection and guarded append", () => {
+  assert.deepEqual(resolveEditingIntent("Append media with handle media-42 to the timeline"), {
+    status: "resolved",
+    destructive: true,
+    previewRequired: true,
+    previewTool: "editor.native.media.append.preview",
+    executeTool: "editor.native.media.append.execute",
+    operation: {
+      type: "media_append",
+      mediaHandle: "media-42",
+      targetProject: "active",
+      placement: "append",
+    },
+    requiredCapabilities: ["native.mediaSelection", "native.mediaAppend"],
+    requiredParameters: ["mediaHandle", "project", "placement"],
+    workflow: [
+      "editor.native.media.select",
+      "editor.native.media.append.preview",
+      "editor.native.media.append.execute",
+    ],
+  });
+});
+
+test("editing intent maps insert-at-playhead through selection and guarded insert", () => {
+  assert.deepEqual(resolveEditingIntent("Insert media with handle media-42 at the playhead"), {
+    status: "resolved",
+    destructive: true,
+    previewRequired: true,
+    previewTool: "editor.native.media.insert.preview",
+    executeTool: "editor.native.media.insert.execute",
+    operation: {
+      type: "media_insert",
+      mediaHandle: "media-42",
+      targetProject: "active",
+      placement: "insert",
+    },
+    requiredCapabilities: ["native.mediaSelection", "native.mediaInsert"],
+    requiredParameters: ["mediaHandle", "project", "placement"],
+    workflow: [
+      "editor.native.media.select",
+      "editor.native.media.insert.preview",
+      "editor.native.media.insert.execute",
+    ],
+  });
+});
+
+test("editing intent keeps import-then-append as explicit native stages", () => {
+  assert.deepEqual(resolveEditingIntent('Import "/tmp/framekit-Interview.mov" and append it to the active timeline'), {
+    status: "resolved",
+    destructive: true,
+    previewRequired: true,
+    previewTool: "editor.native.media.append.preview",
+    executeTool: "editor.native.media.append.execute",
+    operation: {
+      type: "media_import_then_append",
+      path: "/tmp/framekit-Interview.mov",
+      targetProject: "active",
+      placement: "append",
+    },
+    requiredCapabilities: ["native.mediaImport", "native.mediaSelection", "native.mediaAppend"],
+    requiredParameters: ["path", "project", "placement"],
+    workflow: [
+      "editor.native.media.import",
+      "editor.native.media.select",
+      "editor.native.media.append.preview",
+      "editor.native.media.append.execute",
+    ],
+  });
+});
+
+test("editing intent asks for a path rather than inventing one for an import request", () => {
+  assert.deepEqual(resolveEditingIntent("Import this video and append it to the active timeline"), {
+    status: "clarification_required",
+    destructive: true,
+    previewRequired: false,
+    question: "Which local media path should Framekit import before appending?",
+    options: ["media_import_then_append", "media_import"],
+  });
+});
+
+test("editing intent asks whether append should use a handle or current selection", () => {
+  assert.deepEqual(resolveEditingIntent("Append media to the active timeline"), {
+    status: "clarification_required",
+    destructive: true,
+    previewRequired: false,
+    question: "Should Framekit append the currently selected Browser media or use a media handle?",
+    options: ["media_append_selected", "media_append"],
+  });
+});
+
+test("editing intent fails closed when a required native capability is unavailable", () => {
+  assert.deepEqual(resolveEditingIntent("Insert media with handle media-42 at the playhead", {
+    availableCapabilities: {
+      "native.mediaSelection": true,
+      "native.mediaInsert": false,
+    },
+  }), {
+    status: "capability_unavailable",
+    destructive: true,
+    previewRequired: false,
+    question: "The connected editor cannot perform this native media operation.",
+    options: ["media_insert"],
+    requiredCapabilities: ["native.mediaSelection", "native.mediaInsert"],
+    missingCapabilities: ["native.mediaInsert"],
+  });
+});
+
+test("MCP intent resolution reports unavailable native media capabilities", async () => {
+  const server = createMcpServer(new AgentVideoRuntime(new InMemoryEditorAdapter({
+    projectId: "project-1",
+    projectName: "Intent Fixture",
+    timelineId: "timeline-1",
+    timelineName: "Main Edit",
+    clips: [],
+  })));
+  const client = new Client({ name: "editing-intent-capability-test", version: "0.1.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  try {
+    await Promise.all([client.connect(clientTransport), server.connect(serverTransport)]);
+
+    const unavailable = JSON.parse(textFrom(await client.callTool({
+      name: "editing.intent.resolve",
+      arguments: { request: "Append selected media to the active timeline" },
+    })));
+    assert.equal(unavailable.status, "capability_unavailable");
+    assert.deepEqual(unavailable.missingCapabilities, ["native.mediaAppendSelected"]);
+    assert.deepEqual(unavailable.options, ["media_append_selected"]);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});


### PR DESCRIPTION
## Summary

Added explicit native media intent resolution for issue #208:

- local media import
- Browser media selection
- append-selected and append-by-handle
- insert-at-playhead
- import-then-append as separately confirmed native stages

Resolved media intents expose required capabilities, required parameters, the active project target, and the exact native workflow. MCP resolution fails closed with `capability_unavailable` when a required native capability is not advertised. Ambiguous or incomplete requests return targeted clarification options. Existing trim, blade, and delete intent responses remain compatible.

Closes: #208

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm run test` — 666 tests passed
- `pnpm run check:boundaries`
- Focused intent and documentation tests passed

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Public MCP behavior and documentation were updated.
- [x] Existing destructive intent mappings and test fixtures remain compatible.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [x] Documentation reflects the changed intent contract.

Headed Final Cut sequence validation was not run because this PR changes intent resolution and MCP routing only; no native adapter or Swift bridge files changed.
