### PR TITLE
fix: preserve native Browser search failures in media targeting

### DIFF
--- a/adapters/final-cut/typescript/src/native.ts
+++ b/adapters/final-cut/typescript/src/native.ts
@@ -891,7 +891,12 @@ export class FinalCutNativeAutomationAdapter implements NativeFinalCutEditor {
     const context = await this.ensureBrowserReady(deadline, timeoutCode);
     if (!context.frontmost) throw new Error("FINAL_CUT_NATIVE_NOT_FRONTMOST: Final Cut's Browser must be frontmost");
     try {
-      const rawMatches = parseMediaMatches(await this.executeNativeScript(searchMediaScript(query), deadline, timeoutCode));
+      const output = await this.executeNativeScript(searchMediaScript(query), deadline, timeoutCode);
+      const explicitFailure = output.trim();
+      if (explicitFailure.startsWith("FINAL_CUT_NATIVE_SEARCH_UNAVAILABLE")) {
+        throw new Error(explicitFailure);
+      }
+      const rawMatches = parseMediaMatches(output);
       const normalizedQuery = query.toLocaleLowerCase();
       if (rawMatches.some((match) => !browserMediaIdentity(match) && match.name.toLocaleLowerCase().includes(normalizedQuery))) {
         const diagnostics = await this.readBrowserMediaDiagnostics(query);
@@ -920,6 +925,7 @@ export class FinalCutNativeAutomationAdapter implements NativeFinalCutEditor {
       for (const match of matches) this.mediaHandles.set(match.handle, match);
       return matches;
     } catch (error) {
+      if (nativeErrorCode(error) === "FINAL_CUT_NATIVE_SEARCH_UNAVAILABLE") throw error;
       if (deadline !== undefined && nativeErrorCode(error) === timeoutCode) throw error;
       throw new Error(`${nativeErrorCode(error)}: ${String(error)}`);
     }

--- a/tests/integration/native.test.ts
+++ b/tests/integration/native.test.ts
@@ -1975,6 +1975,27 @@ test("native Final Cut media targeting rejects missing and ambiguous targets", a
   );
 });
 
+test("native Final Cut media targeting preserves Browser search failures", async () => {
+  const scripts: string[] = [];
+  const adapter = new FinalCutNativeAutomationAdapter({
+    enabled: true,
+    executor: async (script) => {
+      scripts.push(script);
+      if (script.includes('set frontWindow to window "Final Cut Pro"')) return context(true, "Final Cut Pro", "", 0, false);
+      if (script.includes("AXBrowserMedia")) return "FINAL_CUT_NATIVE_SEARCH_UNAVAILABLE: Browser media results were not accessible";
+      return "";
+    },
+  });
+
+  await assert.rejects(adapter.targetMedia("Interview"), (error: unknown) => {
+    assert.match(String(error), /FINAL_CUT_NATIVE_SEARCH_UNAVAILABLE/);
+    assert.doesNotMatch(String(error), /FINAL_CUT_NATIVE_MEDIA_NOT_FOUND/);
+    return true;
+  });
+  assert.equal(scripts.some((script) => script.includes("collectTimelineClipMatches")), false);
+  assert.equal(scripts.some((script) => script.includes("targetIdentity") && script.includes("AXPress")), false);
+});
+
 test("native Final Cut refuses a Blade retry without live state", async () => {
   const recordSeparator = String.fromCharCode(30);
   let bladeCalls = 0;

--- a/tests/integration/native.test.ts
+++ b/tests/integration/native.test.ts
@@ -1987,6 +1987,7 @@ test("native Final Cut media targeting preserves Browser search failures", async
     },
   });
 
+  await assert.rejects(adapter.searchMedia("Interview"), /FINAL_CUT_NATIVE_SEARCH_UNAVAILABLE/);
   await assert.rejects(adapter.targetMedia("Interview"), (error: unknown) => {
     assert.match(String(error), /FINAL_CUT_NATIVE_SEARCH_UNAVAILABLE/);
     assert.doesNotMatch(String(error), /FINAL_CUT_NATIVE_MEDIA_NOT_FOUND/);

--- a/tests/integration/native.test.ts
+++ b/tests/integration/native.test.ts
@@ -1993,7 +1993,7 @@ test("native Final Cut media targeting preserves Browser search failures", async
     return true;
   });
   assert.equal(scripts.some((script) => script.includes("collectTimelineClipMatches")), false);
-  assert.equal(scripts.some((script) => script.includes("targetIdentity") && script.includes("AXPress")), false);
+  assert.equal(scripts.some((script) => script.includes('set targetIdentity to "')), false);
 });
 
 test("native Final Cut refuses a Blade retry without live state", async () => {


### PR DESCRIPTION
- [x] Request PR review
- [ ] If you are unable to review, please set it as a PR draft.
- [x] Github issue: Closes: #206

## Summary

Preserve the upstream native Browser search failure when media targeting invokes Browser search. Previously, an explicit `FINAL_CUT_NATIVE_SEARCH_UNAVAILABLE` payload could be parsed as a non-match and rewritten as `FINAL_CUT_NATIVE_MEDIA_NOT_FOUND`.

The adapter now recognizes explicit search-unavailable responses before media parsing and keeps the original failure visible for both `editor.native.media.search` and `editor.native.media.target`. Successful zero-match, ambiguous, and unique-target behavior remains unchanged.

## Validation

Focused regression coverage:

```bash
pnpm exec tsx --test --test-name-pattern 'media targeting' tests/integration/native.test.ts
```

Full repository gates passed from the pinned Node/pnpm toolchain:

```bash
pnpm install --frozen-lockfile
pnpm run build
pnpm run test
pnpm run check:boundaries
pnpm run xcode:check
xcodebuild -project adapters/final-cut/swift-bridge/FinalCutWorkflowExtension/FramekitFinalCutWorkflow.xcodeproj -list
```

The full deterministic suite passed with 657 tests. Headed Final Cut behavior was not run; the regression is covered through the native adapter executor seam.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] No MCP tool or package interface changed.
- [x] Existing adapter behavior and fixture contracts remain compatible.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] No generated files or build artifacts were committed.
- [x] No documentation or environment-variable changes were required.
