### PR TITLE
Release for v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [v0.1.7](https://github.com/morshoto/framekit/compare/v0.1.6...v0.1.7) - 2026-09-12
+
+- fix: build and upload native release assets by @morshoto in https://github.com/morshoto/framekit/pull/221
+- fix: fail closed on empty native title discovery by @morshoto in https://github.com/morshoto/framekit/pull/219
+- feat: import video directories via MCP by @morshoto in https://github.com/morshoto/framekit/pull/220
+- fix: preserve native Browser search failures in media targeting by @morshoto in https://github.com/morshoto/framekit/pull/225
+- fix: make native Browser search discovery reliable by @morshoto in https://github.com/morshoto/framekit/pull/222
+- fix: align generic transition discovery with native identities by @morshoto in https://github.com/morshoto/framekit/pull/218
+- feat: resolve native media import and append intents by @morshoto in https://github.com/morshoto/framekit/pull/224
+- feat: enable canonical timeline.edit in headed Final Cut by @morshoto in https://github.com/morshoto/framekit/pull/223
+- test: add headed rough-cut MCP acceptance gate (#217) by @morshoto in https://github.com/morshoto/framekit/pull/226
+- fix: reject false native timeline focus by @morshoto in https://github.com/morshoto/framekit/pull/228
+- fix: expand native media home paths by @morshoto in https://github.com/morshoto/framekit/pull/229
+- fix: make native media import diagnostics actionable by @morshoto in https://github.com/morshoto/framekit/pull/231
+- fix: guide directory media import errors by @morshoto in https://github.com/morshoto/framekit/pull/230
+
 ## [v0.1.6](https://github.com/morshoto/framekit/compare/v0.1.5...v0.1.6) - 2026-09-11
 
 - fix: make tagged release retries idempotent by @morshoto in https://github.com/morshoto/framekit/pull/163

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@morshoto/framekit",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "packageManager": "pnpm@12.3.4",
   "private": false,
   "type": "module",

--- a/plugins/framekit/.codex-plugin/plugin.json
+++ b/plugins/framekit/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "framekit",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Connect Codex to Framekit's MCP tools for Final Cut Pro",
   "author": {
     "name": "Framekit Contributors",


### PR DESCRIPTION
This pull request is for the next release as v0.1.7 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.7 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.6" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* fix: build and upload native release assets by @morshoto in https://github.com/morshoto/framekit/pull/221
* fix: fail closed on empty native title discovery by @morshoto in https://github.com/morshoto/framekit/pull/219
* feat: import video directories via MCP by @morshoto in https://github.com/morshoto/framekit/pull/220
* fix: preserve native Browser search failures in media targeting by @morshoto in https://github.com/morshoto/framekit/pull/225
* fix: make native Browser search discovery reliable by @morshoto in https://github.com/morshoto/framekit/pull/222
* fix: align generic transition discovery with native identities by @morshoto in https://github.com/morshoto/framekit/pull/218
* feat: resolve native media import and append intents by @morshoto in https://github.com/morshoto/framekit/pull/224
* feat: enable canonical timeline.edit in headed Final Cut by @morshoto in https://github.com/morshoto/framekit/pull/223
* test: add headed rough-cut MCP acceptance gate (#217) by @morshoto in https://github.com/morshoto/framekit/pull/226
* fix: reject false native timeline focus by @morshoto in https://github.com/morshoto/framekit/pull/228
* fix: expand native media home paths by @morshoto in https://github.com/morshoto/framekit/pull/229
* fix: make native media import diagnostics actionable by @morshoto in https://github.com/morshoto/framekit/pull/231
* fix: guide directory media import errors by @morshoto in https://github.com/morshoto/framekit/pull/230


**Full Changelog**: https://github.com/morshoto/framekit/compare/v0.1.6...tagpr-from-v0.1.6