### PR TITLE
fix: reject false native timeline focus

### DIFF
--- a/adapters/final-cut/typescript/src/native.ts
+++ b/adapters/final-cut/typescript/src/native.ts
@@ -2729,11 +2729,12 @@ export class FinalCutNativeAutomationAdapter implements NativeFinalCutEditor {
 
     while (this.now() < deadline) {
       try {
-        const context = reconcileTimelineFocus(parseContext(await this.executeNativeScript(
+        const observedContext = parseContext(await this.executeNativeScript(
           timelinePreflightScript(),
           deadline,
           "FINAL_CUT_NATIVE_APPLE_EVENT_TIMEOUT",
-        )));
+        ));
+        const context = reconcileTimelineFocus(observedContext);
         lastContext = context;
         if (!context.timelineWindowAvailable) {
           lastCode = "FINAL_CUT_NATIVE_NO_TIMELINE_WINDOW";
@@ -5599,7 +5600,7 @@ function reconcileTimelineFocus(context: NativeFinalCutContext): NativeFinalCutC
   return {
     ...context,
     timelineFocused: false,
-    focusTarget: focusTarget === "unknown" ? "unknown" : focusTarget,
+    focusTarget,
   };
 }
 

--- a/adapters/final-cut/typescript/src/native.ts
+++ b/adapters/final-cut/typescript/src/native.ts
@@ -2729,11 +2729,11 @@ export class FinalCutNativeAutomationAdapter implements NativeFinalCutEditor {
 
     while (this.now() < deadline) {
       try {
-        const context = parseContext(await this.executeNativeScript(
+        const context = reconcileTimelineFocus(parseContext(await this.executeNativeScript(
           timelinePreflightScript(),
           deadline,
           "FINAL_CUT_NATIVE_APPLE_EVENT_TIMEOUT",
-        ));
+        )));
         lastContext = context;
         if (!context.timelineWindowAvailable) {
           lastCode = "FINAL_CUT_NATIVE_NO_TIMELINE_WINDOW";
@@ -5579,6 +5579,40 @@ function parseContext(output: string): NativeFinalCutContext {
     undoAvailable: undoState === "true",
     ...(undoCommandState ? { undoCommand: undoCommandState } : {}),
   };
+}
+
+function reconcileTimelineFocus(context: NativeFinalCutContext): NativeFinalCutContext {
+  if (!context.timelineFocused || context.focusTarget !== "timeline") return context;
+
+  const focusTarget = classifyNativeFocusTarget(
+    context.focusedRole,
+    context.focusedDescription,
+    context.focusedName,
+  );
+  const focusedWindowMismatch = Boolean(
+    context.frontWindow
+      && context.focusedWindowName
+      && context.frontWindow !== context.focusedWindowName,
+  );
+  if (focusTarget === "unknown" && !focusedWindowMismatch) return context;
+
+  return {
+    ...context,
+    timelineFocused: false,
+    focusTarget: focusTarget === "unknown" ? "unknown" : focusTarget,
+  };
+}
+
+function classifyNativeFocusTarget(
+  focusedRole?: string,
+  focusedDescription?: string,
+  focusedName?: string,
+): NativeFinalCutContext["focusTarget"] {
+  if (focusedRole === "AXTextField" || focusedRole === "AXSearchField") return "text-field";
+  if (focusedRole === "AXSheet" || focusedRole === "AXDialog") return "modal";
+  const focusText = [focusedDescription, focusedName].filter(Boolean).join(" ").toLowerCase();
+  if (focusText.includes("browser") || focusText.includes("search")) return "browser";
+  return "unknown";
 }
 
 function parseMediaMatches(output: string): NativeFinalCutMediaMatch[] {

--- a/tests/integration/native.test.ts
+++ b/tests/integration/native.test.ts
@@ -958,6 +958,58 @@ test("native Final Cut rejects a false timeline focus from the Effects search fi
   assert.equal(focused.focusedWindowName, "Final Cut Pro");
 });
 
+test("native Final Cut retries stale focus metadata before accepting the timeline", async () => {
+  let clock = 0;
+  let preflightCalls = 0;
+  const adapter = new FinalCutNativeAutomationAdapter({
+    enabled: true,
+    now: () => clock,
+    sleep: async (milliseconds) => { clock += milliseconds; },
+    nativePreflightTimeoutMs: 200,
+    executor: async (script) => {
+      if (!script.includes("timelineWindowAvailable")) return "";
+      preflightCalls += 1;
+      return preflightCalls === 1
+        ? contextWithFocus(true, "Final Cut Pro", "Interview", 1, true, {
+            focusedName: "Effect Library Search Field",
+            focusedRole: "AXTextField",
+            focusedDescription: "Effect Library Search Field",
+          })
+        : contextWithFocus(true, "Final Cut Pro", "Interview", 1, true);
+    },
+  });
+
+  const focused = await adapter.focusTimeline();
+  assert.equal(focused.available, true);
+  assert.equal(focused.timelineFocused, true);
+  assert.equal(focused.focusTarget, "timeline");
+  assert.equal(focused.focusedRole, "AXLayoutArea");
+  assert.equal(focused.focusedDescription, "Timeline");
+  assert.equal(preflightCalls, 2);
+});
+
+test("native Final Cut rejects timeline focus from another focused window", async () => {
+  let clock = 0;
+  const adapter = new FinalCutNativeAutomationAdapter({
+    enabled: true,
+    now: () => clock,
+    sleep: async (milliseconds) => { clock += milliseconds; },
+    nativePreflightTimeoutMs: 100,
+    executor: async (script) => script.includes("timelineWindowAvailable")
+      ? contextWithFocus(true, "Final Cut Pro", "Interview", 1, true, {
+          focusedWindowName: "Effects Library",
+        })
+      : "",
+  });
+
+  const focused = await adapter.focusTimeline();
+  assert.equal(focused.available, false);
+  assert.equal(focused.error?.code, "FINAL_CUT_NATIVE_TIMELINE_FOCUS_REQUIRED");
+  assert.equal(focused.timelineFocused, false);
+  assert.equal(focused.focusTarget, "unknown");
+  assert.equal(focused.focusedWindowName, "Effects Library");
+});
+
 test("native Final Cut preflight minimizes the Framekit overlay and raises the timeline", async () => {
   const scripts: string[] = [];
   const adapter = new FinalCutNativeAutomationAdapter({

--- a/tests/integration/native.test.ts
+++ b/tests/integration/native.test.ts
@@ -86,6 +86,40 @@ function contextWithOverlay(
   return values.join(separator);
 }
 
+function contextWithFocus(
+  frontmost: boolean,
+  windowName: string,
+  selectedName: string,
+  selectedCount: number,
+  undo: boolean,
+  options: {
+    timelineFocused?: boolean;
+    focusTarget?: string;
+    focusAttempts?: number;
+    focusedName?: string;
+    focusedRole?: string;
+    focusedDescription?: string;
+    focusedWindowName?: string;
+  } = {},
+): string {
+  const values = context(
+    frontmost,
+    windowName,
+    selectedName,
+    selectedCount,
+    undo,
+    true,
+    options.timelineFocused ?? true,
+    options.focusTarget ?? "timeline",
+    options.focusAttempts ?? 1,
+  ).split(separator);
+  values[7] = options.focusedName ?? "Timeline";
+  values[8] = options.focusedRole ?? "AXLayoutArea";
+  values[9] = options.focusedDescription ?? "Timeline";
+  values[16] = options.focusedWindowName ?? windowName;
+  return values.join(separator);
+}
+
 test("native Final Cut adapter edits the active selection and uses native undo", async () => {
   const scripts: string[] = [];
   const contextOutputs = [
@@ -895,6 +929,33 @@ test("native Final Cut focus preserves the last focus diagnostic on failure", as
   assert.equal(focused.timelineFocused, false);
   assert.equal(focused.focusTarget, "browser");
   assert.equal(focused.focusAttempts, 3);
+});
+
+test("native Final Cut rejects a false timeline focus from the Effects search field", async () => {
+  let clock = 0;
+  const adapter = new FinalCutNativeAutomationAdapter({
+    enabled: true,
+    now: () => clock,
+    sleep: async (milliseconds) => { clock += milliseconds; },
+    nativePreflightTimeoutMs: 100,
+    executor: async (script) => script.includes("timelineWindowAvailable")
+      ? contextWithFocus(true, "Final Cut Pro", "Interview", 1, true, {
+          focusedName: "Effect Library Search Field",
+          focusedRole: "AXTextField",
+          focusedDescription: "Effect Library Search Field",
+          focusedWindowName: "Final Cut Pro",
+        })
+      : "",
+  });
+
+  const focused = await adapter.focusTimeline();
+  assert.equal(focused.available, false);
+  assert.equal(focused.error?.code, "FINAL_CUT_NATIVE_TIMELINE_FOCUS_REQUIRED");
+  assert.equal(focused.timelineFocused, false);
+  assert.equal(focused.focusTarget, "text-field");
+  assert.equal(focused.focusedRole, "AXTextField");
+  assert.equal(focused.focusedDescription, "Effect Library Search Field");
+  assert.equal(focused.focusedWindowName, "Final Cut Pro");
 });
 
 test("native Final Cut preflight minimizes the Framekit overlay and raises the timeline", async () => {


### PR DESCRIPTION
- [x] Request PR review
- [x] Github issue: Closes: #216

## Summary

Reject false native timeline-focus success when Accessibility reports a text/search field or a different focused window. The adapter now preserves the observed focus diagnostics, retries stale focus within the existing bounded preflight deadline, and fails closed before native mutation.

## Validation

```bash
pnpm exec tsx --test tests/integration/native.test.ts
.agents/skills/validate-framekit/scripts/validate.sh --native
```

Validation passed:

- Focused native suite: 75/75 tests.
- Full repository suite: 692/692 tests.
- Build, package boundaries, Xcode version check, and Xcode project listing passed.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Public MCP behavior remains compatible; the existing structured focus error and diagnostics are strengthened.
- [x] Existing adapters and test fixtures remain compatible.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [x] Documentation does not require command, path, or environment-variable changes.

## TDD evidence

- Regression test covers `AXTextField` / “Effect Library Search Field” contradictory metadata.
- Retry test proves stale focus is retried before a valid timeline result is accepted.
- Focused-window test proves a different window fails closed.
