### PR TITLE
fix: expand native media home paths

### DIFF
--- a/adapters/final-cut/typescript/src/native.ts
+++ b/adapters/final-cut/typescript/src/native.ts
@@ -5708,6 +5708,7 @@ function resolveLocalPath(sourcePath: string): string {
   const trimmed = sourcePath.trim();
   if (trimmed === "~") return homedir();
   if (trimmed.startsWith("~/")) return resolve(homedir(), trimmed.slice(2));
+  if (trimmed.startsWith("~")) throw new Error(`INVALID_OPERATION: local media path must be absolute or start with ~/`);
   return resolve(trimmed);
 }
 

--- a/docs/mcp/final-cut-live.md
+++ b/docs/mcp/final-cut-live.md
@@ -200,11 +200,15 @@ Final Cut Browser with:
 }
 ```
 
-Call `editor.native.media.import` with the local file path. Framekit checks that
-the path is a readable file before opening Final Cut's import UI, waits for the
-basename to appear in Browser search, and returns `mediaHandle`, `sourcePath`,
-`name`, and an inferred `kind` (`video` or `audio`). The returned media handle
-can be passed to `editor.native.media.select` and
+Call `editor.native.media.import` with the local file path. Framekit trims
+surrounding whitespace, expands `~` and `~/...` against the user home, and
+resolves other relative paths against the process working directory before
+checking that the path is a readable file. Other leading-tilde forms fail with
+`INVALID_OPERATION` instead of being silently interpreted relative to the
+working directory. After validation, Framekit opens Final Cut's import UI,
+waits for the basename to appear in Browser search, and returns `mediaHandle`,
+`sourcePath`, `name`, and an inferred `kind` (`video` or `audio`). The returned
+media handle can be passed to `editor.native.media.select` and
 `editor.native.timeline.locate`. The handle is stable for the current native
 session and does not itself insert the asset into the timeline.
 

--- a/tests/integration/native.test.ts
+++ b/tests/integration/native.test.ts
@@ -2317,10 +2317,14 @@ test("native Final Cut resolves relative paths from the process cwd", async () =
     },
   });
 
-  const imported = await adapter.importMedia(relative(process.cwd(), sourcePath));
+  try {
+    const imported = await adapter.importMedia(relative(process.cwd(), sourcePath));
 
-  assert.equal(imported.sourcePath, sourcePath);
-  assert.equal(imported.name, "relative-import.mov");
+    assert.equal(imported.sourcePath, sourcePath);
+    assert.equal(imported.name, "relative-import.mov");
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
 });
 
 test("native Final Cut previews top-level supported video files in deterministic order without native mutation", async () => {

--- a/tests/integration/native.test.ts
+++ b/tests/integration/native.test.ts
@@ -2522,6 +2522,32 @@ test("native Final Cut rejects an unavailable local media path before opening im
   assert.equal(scripts.some((script) => script.includes("FRAMEKIT_IMPORT_MEDIA")), false);
 });
 
+test("native Final Cut expands home paths and rejects ambiguous tilde paths", async () => {
+  const scripts: string[] = [];
+  const adapter = new FinalCutNativeAutomationAdapter({
+    enabled: true,
+    executor: async (script) => {
+      scripts.push(script);
+      return "";
+    },
+  });
+  const homePath = join(os.homedir(), "framekit-media-does-not-exist.mov");
+
+  await assert.rejects(
+    adapter.importMedia("~/framekit-media-does-not-exist.mov"),
+    (error: unknown) => {
+      assert.match(String(error), /FINAL_CUT_NATIVE_MEDIA_PATH_UNAVAILABLE/);
+      assert.match(String(error), new RegExp(homePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+      return true;
+    },
+  );
+  await assert.rejects(
+    adapter.importMedia("~other/framekit-media-does-not-exist.mov"),
+    /INVALID_OPERATION: local media path must be absolute or start with ~\//,
+  );
+  assert.equal(scripts.some((script) => script.includes("FRAMEKIT_IMPORT_MEDIA")), false);
+});
+
 test("native Final Cut preserves explicit command errors over embedded frontmost guards", async () => {
   const adapter = new FinalCutNativeAutomationAdapter({
     enabled: true,

--- a/tests/integration/native.test.ts
+++ b/tests/integration/native.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, unlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, unlink, writeFile } from "node:fs/promises";
 import os from "node:os";
-import { join } from "node:path";
+import { dirname, join, relative } from "node:path";
 import test from "node:test";
 import { createNativeOperationLease, FinalCutNativeAutomationAdapter } from "@framekit/final-cut";
 import { finalCutBrowserAccessibilityFixture } from "../fixtures/final-cut-browser-accessibility.js";
@@ -2228,8 +2228,10 @@ test("native Final Cut imports local video and audio, waits for Browser availabi
   const audio = await adapter.importMedia(audioPath);
   assert.equal(video.name, "interview.mov");
   assert.equal(video.kind, "video");
+  assert.equal(video.sourcePath, videoPath);
   assert.equal(audio.name, "music.wav");
   assert.equal(audio.kind, "audio");
+  assert.equal(audio.sourcePath, audioPath);
   assert.notEqual(video.mediaHandle, audio.mediaHandle);
   assert.equal(searchCalls.get("interview.mov"), 2);
   assert.equal(scripts.filter((script) => script.includes("FRAMEKIT_IMPORT_MEDIA")).length, 2);
@@ -2250,6 +2252,75 @@ test("native Final Cut imports local video and audio, waits for Browser availabi
   const selected = await adapter.selectMedia(video.mediaHandle);
   assert.equal(selected.target.kind, "browser-media");
   assert.equal(selected.target.name, "interview.mov");
+});
+
+test("native Final Cut expands a user-home path before validating and importing it", async () => {
+  const homeDirectory = await mkdtemp(join(os.homedir(), ".framekit-native-media-home-"));
+  const sourcePath = join(homeDirectory, "home-import.mov");
+  await writeFile(sourcePath, "video fixture");
+
+  const separator = String.fromCharCode(31);
+  const recordSeparator = String.fromCharCode(30);
+  let searchCalls = 0;
+  const scripts: string[] = [];
+  const adapter = new FinalCutNativeAutomationAdapter({
+    enabled: true,
+    executor: async (script) => {
+      scripts.push(script);
+      if (script.includes('set frontWindow to window "Final Cut Pro"')) return context(true, "Final Cut Pro", "", 0, false);
+      if (script.includes("FRAMEKIT_IMPORT_MEDIA")) return "import-requested";
+      if (script.includes("AXBrowserMedia")) {
+        searchCalls += 1;
+        return searchCalls === 1
+          ? ""
+          : `home-import.mov${separator}AXBrowserMedia${separator}browser-home${separator}file:///imported/home-import.mov${recordSeparator}`;
+      }
+      return "";
+    },
+  });
+
+  try {
+    const requestedPath = `~/${relative(os.homedir(), sourcePath)}`;
+    const imported = await adapter.importMedia(requestedPath);
+
+    assert.equal(imported.sourcePath, sourcePath);
+    assert.equal(imported.name, "home-import.mov");
+    const importScript = scripts.find((script) => script.includes("FRAMEKIT_IMPORT_MEDIA"));
+    assert.ok(importScript);
+    assert.match(importScript, new RegExp(dirname(sourcePath).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    assert.equal(importScript.includes(requestedPath), false);
+  } finally {
+    await rm(homeDirectory, { recursive: true, force: true });
+  }
+});
+
+test("native Final Cut resolves relative paths from the process cwd", async () => {
+  const directory = await mkdtemp(join(os.tmpdir(), "framekit-native-media-relative-"));
+  const sourcePath = join(directory, "relative-import.mov");
+  await writeFile(sourcePath, "video fixture");
+
+  const separator = String.fromCharCode(31);
+  const recordSeparator = String.fromCharCode(30);
+  let searchCalls = 0;
+  const adapter = new FinalCutNativeAutomationAdapter({
+    enabled: true,
+    executor: async (script) => {
+      if (script.includes('set frontWindow to window "Final Cut Pro"')) return context(true, "Final Cut Pro", "", 0, false);
+      if (script.includes("FRAMEKIT_IMPORT_MEDIA")) return "import-requested";
+      if (script.includes("AXBrowserMedia")) {
+        searchCalls += 1;
+        return searchCalls === 1
+          ? ""
+          : `relative-import.mov${separator}AXBrowserMedia${separator}browser-relative${separator}file:///imported/relative-import.mov${recordSeparator}`;
+      }
+      return "";
+    },
+  });
+
+  const imported = await adapter.importMedia(relative(process.cwd(), sourcePath));
+
+  assert.equal(imported.sourcePath, sourcePath);
+  assert.equal(imported.name, "relative-import.mov");
 });
 
 test("native Final Cut previews top-level supported video files in deterministic order without native mutation", async () => {


### PR DESCRIPTION
<!-- Request PR review -->
- [x] Request PR review
- [ ] If you are unable to review, please set it as a PR draft.
- [x] Github issue: Closes: #213

## Summary

The native media path resolver now fails closed for ambiguous leading-tilde
paths instead of silently resolving them under the Framekit process directory.
Regression coverage verifies home expansion, absolute paths, relative paths,
unavailable paths, and the no-native-mutation validation boundary.

## TDD evidence

- Red: `native Final Cut expands home paths and rejects ambiguous tilde paths`
  failed because `~other/...` resolved under the repository working directory.
- Green: `resolveLocalPath` expands `~` and `~/...`, resolves ordinary relative
  paths as before, and rejects other leading-tilde forms with `INVALID_OPERATION`.
- Refactor: documented the input-path contract in the Final Cut live MCP guide.

## Validation

```bash
pnpm install --frozen-lockfile
pnpm run build
pnpm run test
pnpm run check:boundaries
.agents/skills/validate-framekit/scripts/validate.sh --native
xcodebuild -project adapters/final-cut/swift-bridge/FinalCutWorkflowExtension/FramekitFinalCutWorkflow.xcodeproj -list
```

All required gates passed. The full suite reported 692 passing tests. No Swift
or Xcode source changed; the native gate was run because the Final Cut adapter
changed. These are deterministic adapter tests and do not claim headed Final
Cut placement or import proof.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Public MCP behavior or package interfaces are documented if changed.
- [x] Existing adapters and test fixtures remain compatible, or the migration is explained above.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [x] Documentation reflects the changed path behavior.
