### PR TITLE
fix: keep Swift CodeQL check present

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -113,22 +113,29 @@ jobs:
   analyze-swift:
     name: Analyze (swift)
     needs: changes
-    # A detector failure must fail open to a full scan, not skip a required check.
-    if: ${{ !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.swift == 'true') }}
+    # Keep the required check present; skip its work inside the job when Swift is unchanged.
+    if: ${{ !cancelled() }}
     runs-on: macos-26
     timeout-minutes: 40
 
     steps:
+      - name: Skip Swift CodeQL analysis (no Swift changes)
+        if: ${{ needs.changes.result == 'success' && needs.changes.outputs.swift != 'true' }}
+        run: echo "No Swift-related files changed; skipping Swift CodeQL analysis."
+
       - name: Check out repository
+        if: ${{ needs.changes.result != 'success' || needs.changes.outputs.swift == 'true' }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Initialize CodeQL
+        if: ${{ needs.changes.result != 'success' || needs.changes.outputs.swift == 'true' }}
         uses: github/codeql-action/init@b96794f015dfd88f77b49b1c93e0fa7110f94c63 # v4
         with:
           languages: swift
           build-mode: manual
 
       - name: Type-check Swift sources for CodeQL extraction
+        if: ${{ needs.changes.result != 'success' || needs.changes.outputs.swift == 'true' }}
         timeout-minutes: 25
         run: |
           xcrun --sdk macosx swiftc \
@@ -142,6 +149,7 @@ jobs:
             .github/codeql/FinalCutWorkflowExtensionShim.swift
 
       - name: Analyze with CodeQL
+        if: ${{ needs.changes.result != 'success' || needs.changes.outputs.swift == 'true' }}
         uses: github/codeql-action/analyze@b96794f015dfd88f77b49b1c93e0fa7110f94c63 # v4
         with:
           category: /language:swift

--- a/docs/ci/codeql.md
+++ b/docs/ci/codeql.md
@@ -18,15 +18,17 @@ commits while leaving different pull requests independent.
 Pull requests first run the lightweight `Detect CodeQL paths` job on
 `ubuntu-latest`. The JavaScript/TypeScript analysis runs when a JavaScript or
 TypeScript source, its package or TypeScript configuration, the CodeQL
-configuration, or this workflow changes. The Swift analysis runs when the
-Swift bridge, the CodeQL configuration, or this workflow changes.
+configuration, or this workflow changes. The Swift job always starts so its
+required check remains present. When the detector succeeds and no Swift bridge,
+CodeQL configuration, or workflow file changed, the job runs a successful
+no-op step and skips checkout and Swift CodeQL analysis. Otherwise, the Swift
+analysis runs normally.
 
 Pushes to `main`, scheduled scans, and manual scans analyze both languages so
-that path filtering does not reduce default-branch coverage. The language jobs
-use job-level conditions rather than workflow-level path filters: a skipped
-job reports success for a required pull-request check, while a skipped
-workflow would leave its check pending and block merging. If path detection
-fails, both language jobs deliberately fall back to a full scan.
+that path filtering does not reduce default-branch coverage. The Swift job uses
+conditions inside the job rather than a job-level path filter, while the
+JavaScript/TypeScript job retains its existing job-level filter. If path
+detection fails, both language jobs deliberately fall back to a full scan.
 
 The policy intentionally does not suppress genuine CodeQL failures, delete
 historical analyses, or change the configured security rules and query suites.

--- a/tests/integration/codeql-workflow.test.ts
+++ b/tests/integration/codeql-workflow.test.ts
@@ -39,7 +39,40 @@ test("CodeQL filters language jobs by changed paths", async () => {
   assert.match(workflow, /swift_pattern=/);
   assert.match(workflow, /needs: changes/);
   assert.match(workflow, /if: \$\{\{ !cancelled\(\) && \(needs\.changes\.result != 'success' \|\| needs\.changes\.outputs\.javascript_typescript == 'true'\) \}\}/);
-  assert.match(workflow, /if: \$\{\{ !cancelled\(\) && \(needs\.changes\.result != 'success' \|\| needs\.changes\.outputs\.swift == 'true'\) \}\}/);
+});
+
+test("Swift CodeQL keeps its required check successful when unchanged", async () => {
+  const workflow = await readRepositoryFile(".github/workflows/codeql.yml");
+  const swiftJob = workflow.match(
+    /\n  analyze-swift:\n[\s\S]*?(?=\n  [a-z][a-z0-9-]*:\n|$)/,
+  )?.[0];
+
+  assert.ok(swiftJob, "Swift CodeQL job should be present");
+  assert.match(swiftJob, /\n    if: \$\{\{ !cancelled\(\) \}\}/);
+  assert.match(
+    swiftJob,
+    /name: Skip Swift CodeQL analysis \(no Swift changes\)[\s\S]*?if: \$\{\{ needs\.changes\.result == 'success' && needs\.changes\.outputs\.swift != 'true' \}\}/,
+  );
+  assert.match(
+    swiftJob,
+    /name: Check out repository[\s\S]*?if: \$\{\{ needs\.changes\.result != 'success' \|\| needs\.changes\.outputs\.swift == 'true' \}\}/,
+  );
+  assert.match(
+    swiftJob,
+    /name: Initialize CodeQL[\s\S]*?if: \$\{\{ needs\.changes\.result != 'success' \|\| needs\.changes\.outputs\.swift == 'true' \}\}/,
+  );
+  assert.match(
+    swiftJob,
+    /name: Type-check Swift sources for CodeQL extraction[\s\S]*?if: \$\{\{ needs\.changes\.result != 'success' \|\| needs\.changes\.outputs\.swift == 'true' \}\}/,
+  );
+  assert.match(
+    swiftJob,
+    /name: Analyze with CodeQL[\s\S]*?if: \$\{\{ needs\.changes\.result != 'success' \|\| needs\.changes\.outputs\.swift == 'true' \}\}/,
+  );
+  assert.doesNotMatch(
+    swiftJob,
+    /needs: changes\n    if: \$\{\{ !cancelled\(\) && \(needs\.changes\.result != 'success' \|\| needs\.changes\.outputs\.swift == 'true'\) \}\}/,
+  );
 });
 
 test("CodeQL concurrency policy is documented for operators", async () => {
@@ -82,7 +115,7 @@ test("CodeQL preserves JavaScript analysis and adds a bounded Swift job", async 
   assert.match(workflow, /timeout-minutes: 25/);
   assert.match(
     workflow,
-    /\n      - name: Type-check Swift sources for CodeQL extraction\n        timeout-minutes: 25\n        run: \|/,
+    /\n      - name: Type-check Swift sources for CodeQL extraction\n        if: \$\{\{ needs\.changes\.result != 'success' \|\| needs\.changes\.outputs\.swift == 'true' \}\}\n        timeout-minutes: 25\n        run: \|/,
   );
 });
 


### PR DESCRIPTION
<!-- Title naming policy -->

- [x] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [ ] Github issue: Closes: #

## Summary

Follow-up to #227. Keep the required `Analyze (swift)` check present on every pull-request CodeQL run, while skipping Swift CodeQL work inside the job when the detector finds no Swift-related changes.

The Swift job now runs an explicit successful no-op step when unchanged. Checkout, CodeQL initialization, extraction, and analysis remain guarded and still run when Swift, CodeQL, or workflow files change. The workflow operations documentation and regression tests describe the required-check behavior.

## Validation

```bash
pnpm install --frozen-lockfile
pnpm run build
pnpm run test
pnpm run check:boundaries
```

All passed: 700 tests, build, and package-boundary checks. Native Xcode validation was skipped because no Swift source, Xcode project, or native adapter files changed.

The no-op path is covered by the workflow contract test. This PR itself changes `.github/workflows/codeql.yml`, which intentionally matches the Swift path pattern, so its remote Swift CodeQL run is expected to execute the full analysis; a later non-Swift-only PR will exercise the remote no-op path.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Public MCP behavior or package interfaces are documented if changed.
- [x] Existing adapters and test fixtures remain compatible, or the migration is explained above.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [x] Documentation reflects the changed CodeQL workflow behavior.
