### PR TITLE
Release for v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [v0.1.8](https://github.com/morshoto/framekit/compare/v0.1.7...v0.1.8) - 2026-09-12
+
+### ✨ Features
+- test: strengthen canonical headed safety evidence by @morshoto in https://github.com/morshoto/framekit/pull/244
+- test: guard unsupported native project APIs by @morshoto in https://github.com/morshoto/framekit/pull/246
+### 🐛 Fixes
+- fix: keep Swift CodeQL check present by @morshoto in https://github.com/morshoto/framekit/pull/232
+- fix: return media-specific search unavailability by @morshoto in https://github.com/morshoto/framekit/pull/239
+- test: complete Basic Editing MVP evaluation by @morshoto in https://github.com/morshoto/framekit/pull/245
+- fix: align live MCP runtime (#234) by @morshoto in https://github.com/morshoto/framekit/pull/241
+- fix: fail fast when release runner unavailable by @morshoto in https://github.com/morshoto/framekit/pull/243
+- fix: Align metadata-only project inspection capabilities by @morshoto in https://github.com/morshoto/framekit/pull/240
+### 🧰 Maintenance & Internal
+- chore: group generated release notes by change type by @morshoto in https://github.com/morshoto/framekit/pull/238
+- chore: generate milestone release reports by @morshoto in https://github.com/morshoto/framekit/pull/242
+- chore: collapse maintenance release notes by @morshoto in https://github.com/morshoto/framekit/pull/247
+
 ## [v0.1.7](https://github.com/morshoto/framekit/compare/v0.1.6...v0.1.7) - 2026-09-12
 
 - fix: build and upload native release assets by @morshoto in https://github.com/morshoto/framekit/pull/221

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@morshoto/framekit",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "packageManager": "pnpm@12.3.4",
   "private": false,
   "type": "module",

--- a/plugins/framekit/.codex-plugin/plugin.json
+++ b/plugins/framekit/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "framekit",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Connect Codex to Framekit's MCP tools for Final Cut Pro",
   "author": {
     "name": "Framekit Contributors",


### PR DESCRIPTION
This pull request is for the next release as v0.1.8 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.8 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.7" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### ✨ Features
* test: strengthen canonical headed safety evidence by @morshoto in https://github.com/morshoto/framekit/pull/244
* test: guard unsupported native project APIs by @morshoto in https://github.com/morshoto/framekit/pull/246
### 🐛 Fixes
* fix: keep Swift CodeQL check present by @morshoto in https://github.com/morshoto/framekit/pull/232
* fix: return media-specific search unavailability by @morshoto in https://github.com/morshoto/framekit/pull/239
* test: complete Basic Editing MVP evaluation by @morshoto in https://github.com/morshoto/framekit/pull/245
* fix: align live MCP runtime (#234) by @morshoto in https://github.com/morshoto/framekit/pull/241
* fix: fail fast when release runner unavailable by @morshoto in https://github.com/morshoto/framekit/pull/243
* fix: Align metadata-only project inspection capabilities by @morshoto in https://github.com/morshoto/framekit/pull/240
<details>
<summary>🧰 Maintenance & Internal</summary>

* chore: group generated release notes by change type by @morshoto in https://github.com/morshoto/framekit/pull/238
* chore: generate milestone release reports by @morshoto in https://github.com/morshoto/framekit/pull/242
* chore: collapse maintenance release notes by @morshoto in https://github.com/morshoto/framekit/pull/247

</details>

**Full Changelog**: https://github.com/morshoto/framekit/compare/v0.1.7...tagpr-from-v0.1.7
