### PR TITLE
chore: group generated release notes by change type

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,3 +2,13 @@ changelog:
   exclude:
     labels:
       - tagpr
+  categories:
+    - title: "✨ Features"
+      labels:
+        - "Type: New Feature"
+    - title: "🐛 Fixes"
+      labels:
+        - "Problem: Bug"
+    - title: "🧰 Maintenance & Internal"
+      labels:
+        - "*"

--- a/tests/integration/release-workflow.test.ts
+++ b/tests/integration/release-workflow.test.ts
@@ -7,6 +7,36 @@ import { validateReleaseContract } from "../../scripts/validate-release-contract
 
 const repository = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 
+type ReleaseCategory = {
+  title: string;
+  labels: string[];
+};
+
+function parseReleaseCategories(config: string): ReleaseCategory[] {
+  const categories: ReleaseCategory[] = [];
+  let currentCategory: ReleaseCategory | undefined;
+
+  for (const line of config.split(/\r?\n/)) {
+    const title = line.match(/^ {4}- title: ["'](.+)["']$/)?.[1];
+    if (title) {
+      currentCategory = { title, labels: [] };
+      categories.push(currentCategory);
+      continue;
+    }
+
+    const label = line.match(/^ {8}- ["'](.+)["']$/)?.[1];
+    if (label && currentCategory) currentCategory.labels.push(label);
+  }
+
+  return categories;
+}
+
+function categorizeRelease(labels: string[], categories: ReleaseCategory[]): string | undefined {
+  return categories.find((category) => (
+    category.labels.includes("*") || labels.some((label) => category.labels.includes(label))
+  ))?.title;
+}
+
 const canonicalManifest = {
   name: "@morshoto/framekit",
   version: "0.1.1",
@@ -245,4 +275,36 @@ test("release documentation provides the exact npm trust command", async () => {
   assert.match(documentation, /--file\s+release\.yml/);
   assert.match(documentation, /--allow-publish/);
   assert.match(documentation, /--yes/);
+});
+
+test("release notes classify representative v0.1.7 changes by label", async () => {
+  const config = await readFile(resolve(repository, ".github/release.yml"), "utf8");
+  const categories = parseReleaseCategories(config);
+
+  assert.deepEqual(categories, [
+    { title: "✨ Features", labels: ["Type: New Feature"] },
+    { title: "🐛 Fixes", labels: ["Problem: Bug"] },
+    { title: "🧰 Maintenance & Internal", labels: ["*"] },
+  ]);
+
+  const representativeChanges = [
+    { pullRequest: 220, labels: ["Type: New Feature"], category: "✨ Features" },
+    { pullRequest: 228, labels: ["Problem: Bug"], category: "🐛 Fixes" },
+    { pullRequest: 226, labels: ["Type: Document"], category: "🧰 Maintenance & Internal" },
+  ];
+
+  for (const change of representativeChanges) {
+    assert.equal(
+      categorizeRelease(change.labels, categories),
+      change.category,
+      `PR #${change.pullRequest} should use its label category`,
+    );
+  }
+});
+
+test("release notes continue excluding Tag PRs", async () => {
+  const config = await readFile(resolve(repository, ".github/release.yml"), "utf8");
+
+  assert.match(config, /exclude:\s+labels:\s+- tagpr/);
+  assert.doesNotMatch(config, /title: ["'].*tagpr/i);
 });

--- a/tests/integration/release-workflow.test.ts
+++ b/tests/integration/release-workflow.test.ts
@@ -6,6 +6,13 @@ import { fileURLToPath } from "node:url";
 import { validateReleaseContract } from "../../scripts/validate-release-contract.mjs";
 
 const repository = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const releaseConfigPath = resolve(repository, ".github/release.yml");
+
+const expectedReleaseCategories = [
+  { title: "✨ Features", labels: ["Type: New Feature"] },
+  { title: "🐛 Fixes", labels: ["Problem: Bug"] },
+  { title: "🧰 Maintenance & Internal", labels: ["*"] },
+];
 
 type ReleaseCategory = {
   title: string;
@@ -29,6 +36,15 @@ function parseReleaseCategories(config: string): ReleaseCategory[] {
   }
 
   return categories;
+}
+
+function parseExcludedLabels(config: string): string[] {
+  const categoriesStart = config.indexOf("  categories:");
+  const exclusions = categoriesStart === -1 ? config : config.slice(0, categoriesStart);
+
+  return exclusions.split(/\r?\n/)
+    .map((line) => line.match(/^ {6}- (.+)$/)?.[1])
+    .filter((label): label is string => label !== undefined);
 }
 
 function categorizeRelease(labels: string[], categories: ReleaseCategory[]): string | undefined {
@@ -278,14 +294,10 @@ test("release documentation provides the exact npm trust command", async () => {
 });
 
 test("release notes classify representative v0.1.7 changes by label", async () => {
-  const config = await readFile(resolve(repository, ".github/release.yml"), "utf8");
+  const config = await readFile(releaseConfigPath, "utf8");
   const categories = parseReleaseCategories(config);
 
-  assert.deepEqual(categories, [
-    { title: "✨ Features", labels: ["Type: New Feature"] },
-    { title: "🐛 Fixes", labels: ["Problem: Bug"] },
-    { title: "🧰 Maintenance & Internal", labels: ["*"] },
-  ]);
+  assert.deepEqual(categories, expectedReleaseCategories);
 
   const representativeChanges = [
     { pullRequest: 220, labels: ["Type: New Feature"], category: "✨ Features" },
@@ -303,8 +315,7 @@ test("release notes classify representative v0.1.7 changes by label", async () =
 });
 
 test("release notes continue excluding Tag PRs", async () => {
-  const config = await readFile(resolve(repository, ".github/release.yml"), "utf8");
+  const config = await readFile(releaseConfigPath, "utf8");
 
-  assert.match(config, /exclude:\s+labels:\s+- tagpr/);
-  assert.doesNotMatch(config, /title: ["'].*tagpr/i);
+  assert.deepEqual(parseExcludedLabels(config), ["tagpr"]);
 });


### PR DESCRIPTION
## Summary

- Add ordered `Features`, `Fixes`, and `Maintenance & Internal` generated release-note categories.
- Route categories using the existing `Type: New Feature` and `Problem: Bug` labels.
- Preserve the `tagpr` exclusion and add regression coverage using representative v0.1.7 pull requests.

Closes #233

## Validation

- `pnpm exec tsx --test tests/integration/release-workflow.test.ts` — 14 passed.
- `./.agents/skills/validate-framekit/scripts/validate.sh` — frozen install, build, 702 tests, and package boundaries passed.
- Ruby YAML parsing check passed for the final release configuration.
- Native/Xcode checks were skipped because no native files changed.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Public MCP behavior or package interfaces are documented if changed.
- [x] Existing adapters and test fixtures remain compatible, or the migration is explained above.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [x] Documentation reflects any changed commands, paths, or environment variables.
