### PR TITLE
fix: return media-specific search unavailability

### DIFF
--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -5,6 +5,7 @@ import {
   AgentVideoRuntime,
   createCapabilityPreflight,
   resolveEditingIntent,
+  serializeCapabilityUnavailableError,
   withCapabilityFamilies,
   type CapabilityProcessMode,
   type RuntimeCapabilities,
@@ -694,6 +695,15 @@ function nativeMediaImportErrorResult(error: unknown) {
         guidance: error.guidance,
       }),
     }],
+  };
+}
+
+function capabilityUnavailableErrorResult(error: unknown) {
+  const serialized = serializeCapabilityUnavailableError(error);
+  if (!serialized) throw error;
+  return {
+    isError: true,
+    content: [{ type: "text" as const, text: JSON.stringify(serialized) }],
   };
 }
 
@@ -1412,7 +1422,13 @@ export function createMcpServer(runtime: AgentVideoRuntime, options: McpServerOp
   server.registerTool("media.search", {
     description: "Search normalized media references by id or source path.",
     inputSchema: { query: z.string() },
-  }, async ({ query }) => jsonResult(await runtime.searchMedia(query)));
+  }, async ({ query }) => {
+    try {
+      return jsonResult(await runtime.searchMedia(query));
+    } catch (error) {
+      return capabilityUnavailableErrorResult(error);
+    }
+  });
 
   server.registerTool("media.index", {
     description: "Query analyzed media by semantic properties, source identity, capabilities, and usable ranges.",

--- a/docs/mcp/capabilities-and-errors.md
+++ b/docs/mcp/capabilities-and-errors.md
@@ -58,6 +58,27 @@ The descriptor means:
 - `unavailableReason`: a stable explanation required for unavailable
   operations; unavailable operations must fail with `CAPABILITY_UNAVAILABLE`.
 
+`media.search` requires `capabilities.families.observation.media`. When that
+descriptor is unavailable, the MCP tool returns an error payload that preserves
+the capability's backend, guarantee, and unavailable reason instead of
+attempting a canonical snapshot:
+
+```json
+{
+  "code": "CAPABILITY_UNAVAILABLE",
+  "message": "media.search requires observation.media",
+  "operation": "media.search",
+  "capability": "observation.media",
+  "available": false,
+  "backend": "workflow-extension-ipc",
+  "guarantee": "none",
+  "unavailableReason": "media observation is unavailable"
+}
+```
+
+This unavailable result is distinct from a successful search with no matching
+media, which remains the empty array `[]`.
+
 The families are:
 
 | Family | Operation examples | Meaning |

--- a/docs/mcp/tools.md
+++ b/docs/mcp/tools.md
@@ -89,7 +89,7 @@ this routing tool.
 | `music.add.execute` | Execute a music preview and return the verified transaction | Deterministic fixture; undo with `edit.undo` |
 | `timeline.export` | Export the active Final Cut timeline to a local video file and verify completion, existence, duration, resolution, frame rate, audio presence, and optional transaction-bound manifest | Requires live Final Cut native writes, `ffprobe`, and one of the `master` or `web` presets; `transactionId` requires a verified transaction for the active project and sequence; existing outputs require `overwrite: true` |
 | `media.inspect` | Normalized media context | Fixture/FCPXML-backed Final Cut session |
-| `media.search` | Search media references | Fixture/FCPXML-backed Final Cut session |
+| `media.search` | Search media references | Requires `observation.media`; unavailable sessions return structured `CAPABILITY_UNAVAILABLE`; capable sessions may return `[]` |
 | `media.index` | Query analyzed media by semantic properties, capabilities, and usable ranges | Fixture or configured analyzer providers; unconfigured capabilities are explicit |
 | `speech.analyze` | Speech and filler analysis | Fixture or configured local JSON provider |
 | `audio.analyze` | Loudness, peak, and silence analysis | Fixture or configured local JSON provider |

--- a/packages/runtime/src/application/media-analysis-service.ts
+++ b/packages/runtime/src/application/media-analysis-service.ts
@@ -25,6 +25,7 @@ import type { TimeRange } from "../domain/primitives.js";
 import { ContextEngine } from "../context/context-engine.js";
 import { ProjectService } from "./project-service.js";
 import type { RuntimeOptions } from "./runtime-options.js";
+import { CapabilityUnavailableError } from "../domain/capabilities.js";
 import { planRoughCut } from "../planning/rough-cut.js";
 import { bindSpeechAnalysis } from "../speech/analysis.js";
 import { parseRational } from "../timeline/rational-time.js";
@@ -194,6 +195,11 @@ export class MediaAnalysisService {
   }
 
   public async searchMedia(query: string): Promise<MediaContext[]> {
+    const inspected = await this.project.inspectEditor();
+    const mediaObservation = inspected.capabilities.families?.observation.media;
+    if (mediaObservation && !mediaObservation.available) {
+      throw new CapabilityUnavailableError("media.search", "observation.media", mediaObservation);
+    }
     const project = await this.project.inspectProject();
     const normalized = query.trim().toLowerCase();
     return project.media.filter((media) =>

--- a/packages/runtime/src/domain/capabilities.ts
+++ b/packages/runtime/src/domain/capabilities.ts
@@ -82,6 +82,56 @@ export interface CapabilityDescriptor {
   unavailableReason?: string;
 }
 
+export interface CapabilityUnavailableErrorPayload {
+  code: "CAPABILITY_UNAVAILABLE";
+  message: string;
+  operation: string;
+  capability: string;
+  available: false;
+  backend: string;
+  guarantee: "none";
+  unavailableReason: string;
+}
+
+export class CapabilityUnavailableError extends Error {
+  public readonly code = "CAPABILITY_UNAVAILABLE" as const;
+  public readonly available = false as const;
+  public readonly backend: string;
+  public readonly guarantee = "none" as const;
+  public readonly unavailableReason: string;
+
+  public constructor(
+    public readonly operation: string,
+    public readonly capability: string,
+    descriptor: CapabilityDescriptor,
+  ) {
+    const unavailableReason = descriptor.unavailableReason ?? `${capability} is unavailable`;
+    super(`CAPABILITY_UNAVAILABLE: ${operation} requires ${capability}: ${unavailableReason}`);
+    this.name = "CapabilityUnavailableError";
+    this.backend = descriptor.backend;
+    this.unavailableReason = unavailableReason;
+  }
+
+  public toJSON(): CapabilityUnavailableErrorPayload {
+    return {
+      code: this.code,
+      message: `${this.operation} requires ${this.capability}`,
+      operation: this.operation,
+      capability: this.capability,
+      available: this.available,
+      backend: this.backend,
+      guarantee: this.guarantee,
+      unavailableReason: this.unavailableReason,
+    };
+  }
+}
+
+export function serializeCapabilityUnavailableError(
+  error: unknown,
+): CapabilityUnavailableErrorPayload | undefined {
+  return error instanceof CapabilityUnavailableError ? error.toJSON() : undefined;
+}
+
 export type EditingCapabilityOperation =
   | "compositeTransactions"
   | "titlePlacement"

--- a/tests/integration/media-search.test.ts
+++ b/tests/integration/media-search.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { AgentVideoRuntime, type RuntimeCapabilities } from "@framekit/runtime";
+import {
+  FinalCutLiveAdapter,
+  FinalCutSessionAdapter,
+  type FinalCutLiveRequest,
+  type FinalCutLiveResponse,
+} from "@framekit/final-cut";
+import { createMcpServer } from "../../apps/mcp-server/src/server.js";
+
+const metadataOnlyCapabilities: RuntimeCapabilities = {
+  editor: {
+    projectRead: true,
+    timelineSnapshotRead: false,
+    timelineWrite: false,
+    timelineArtifactWrite: false,
+    readAfterWrite: false,
+    incrementalChanges: true,
+    rollback: false,
+    assetDiscovery: false,
+    liveStateRead: true,
+    playheadWrite: false,
+    frameCapture: false,
+  },
+  analyzers: {
+    speechTranscribe: false,
+    speechVad: false,
+    audioLoudness: false,
+    visualTrack: false,
+  },
+};
+
+function textFrom(result: unknown): string {
+  const content = (result as { content?: unknown }).content;
+  assert.ok(Array.isArray(content));
+  const first = content[0] as { text?: unknown } | undefined;
+  assert.equal(typeof first?.text, "string");
+  return first?.text as string;
+}
+
+test("media.search returns structured media observation unavailability", async () => {
+  const live = new FinalCutLiveAdapter({
+    request: async (request: FinalCutLiveRequest): Promise<FinalCutLiveResponse> => ({
+      version: 1,
+      id: request.id,
+      ok: true,
+      result: {
+        identity: { name: "Final Cut Pro", version: "test", backend: "workflow-extension-ipc" },
+        capabilities: metadataOnlyCapabilities,
+      },
+    }),
+  });
+  const runtime = new AgentVideoRuntime(new FinalCutSessionAdapter({ live }));
+  const server = createMcpServer(runtime);
+  const client = new Client({ name: "media-search-test", version: "0.1.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  try {
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+    const editor = JSON.parse(textFrom(await client.callTool({ name: "editor.inspect", arguments: {} })));
+    assert.deepEqual(editor.capabilities.families.observation.media, {
+      available: false,
+      backend: "workflow-extension-ipc",
+      guarantee: "none",
+      unavailableReason: "media observation is unavailable",
+    });
+
+    const result = await client.callTool({ name: "media.search", arguments: { query: "video" } });
+
+    assert.equal(result.isError, true);
+    assert.deepEqual(JSON.parse(textFrom(result)), {
+      code: "CAPABILITY_UNAVAILABLE",
+      message: "media.search requires observation.media",
+      operation: "media.search",
+      capability: "observation.media",
+      available: false,
+      backend: "workflow-extension-ipc",
+      guarantee: "none",
+      unavailableReason: "media observation is unavailable",
+    });
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});

--- a/tests/integration/media-search.test.ts
+++ b/tests/integration/media-search.test.ts
@@ -9,6 +9,7 @@ import {
   type FinalCutLiveRequest,
   type FinalCutLiveResponse,
 } from "@framekit/final-cut";
+import { InMemoryEditorAdapter } from "@framekit/testkit";
 import { createMcpServer } from "../../apps/mcp-server/src/server.js";
 
 const metadataOnlyCapabilities: RuntimeCapabilities = {
@@ -81,6 +82,31 @@ test("media.search returns structured media observation unavailability", async (
       guarantee: "none",
       unavailableReason: "media observation is unavailable",
     });
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
+
+test("media.search preserves successful empty results", async () => {
+  const runtime = new AgentVideoRuntime(new InMemoryEditorAdapter({
+    projectId: "project-1",
+    projectName: "Search Fixture",
+    timelineId: "timeline-1",
+    timelineName: "Main",
+    clips: [],
+    media: [{ mediaId: "media-1", source: "interview.mov" }],
+  }));
+  const server = createMcpServer(runtime);
+  const client = new Client({ name: "media-search-empty-test", version: "0.1.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  try {
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+    const result = await client.callTool({ name: "media.search", arguments: { query: "missing" } });
+
+    assert.notEqual(result.isError, true);
+    assert.deepEqual(JSON.parse(textFrom(result)), []);
   } finally {
     await client.close();
     await server.close();


### PR DESCRIPTION
- [x] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [x] Github issue: Closes: #204

## Summary

`media.search` now checks the versioned `observation.media` capability before
requesting a canonical project snapshot. Metadata-only Final Cut sessions
return a structured `CAPABILITY_UNAVAILABLE` payload with the operation,
capability, backend, guarantee, and unavailable reason. Capable backends retain
the existing media array response, including successful empty searches.

## Validation

Focused TDD coverage:

```bash
pnpm exec tsx --test tests/integration/media-search.test.ts
```

Repository gates:

```bash
.agents/skills/validate-framekit/scripts/validate.sh
```

Passed frozen install, build, 701 tests, and package boundary checks. Native
Xcode checks were not required because no native files changed.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Public MCP behavior or package interfaces are documented if changed.
- [x] Existing adapters and test fixtures remain compatible, or the migration is explained above.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [x] Documentation reflects any changed commands, paths, or environment variables.
