### PR TITLE
fix: Align metadata-only project inspection capabilities

### DIFF
--- a/adapters/final-cut/swift-bridge/FinalCutWorkflowExtension/FinalCutLiveWorkflowExtension.swift
+++ b/adapters/final-cut/swift-bridge/FinalCutWorkflowExtension/FinalCutLiveWorkflowExtension.swift
@@ -470,7 +470,7 @@ public final class FinalCutLiveWorkflowExtension: NSViewController {
     private func handle(_ request: BridgeRequest) -> BridgeResponse {
         let identity = Identity(name: "Final Cut Pro", version: "Workflow Extension", backend: "workflow-extension-ipc")
         let capabilities = RuntimeCapabilities(
-            editor: EditorCapabilities(canonicalTimelineMode: "metadata-only", projectRead: true, timelineSnapshotRead: false, timelineWrite: false, timelineArtifactWrite: false, readAfterWrite: false, incrementalChanges: true, rollback: false, assetDiscovery: false, liveStateRead: true, playheadWrite: false, frameCapture: false, playbackControl: false, projectCatalogRead: false, projectSelection: false),
+            editor: EditorCapabilities(canonicalTimelineMode: "metadata-only", projectRead: false, timelineSnapshotRead: false, timelineWrite: false, timelineArtifactWrite: false, readAfterWrite: false, incrementalChanges: true, rollback: false, assetDiscovery: false, liveStateRead: true, playheadWrite: false, frameCapture: false, playbackControl: false, projectCatalogRead: false, projectSelection: false),
             analyzers: AnalyzerCapabilities(speechTranscribe: false, speechVad: false, audioLoudness: false, visualTrack: false),
             schemaVersion: 1,
             families: metadataOnlyCapabilityFamilies()

--- a/adapters/final-cut/typescript/src/connection.ts
+++ b/adapters/final-cut/typescript/src/connection.ts
@@ -5,7 +5,7 @@ import { promisify } from "node:util";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import type { EditorIdentity, RuntimeCapabilities } from "@framekit/runtime";
-import { withCapabilityFamilies } from "@framekit/runtime";
+import { withCanonicalTimelineMode, withCapabilityFamilies } from "@framekit/runtime";
 import { createFinalCutLiveAdapter, DEFAULT_FINAL_CUT_LIVE_SOCKET } from "./live.js";
 
 const execFile = promisify(execFileCallback);
@@ -291,10 +291,10 @@ export class FinalCutConnectionManager {
   }
 
   private ready(result: { identity: EditorIdentity; capabilities: RuntimeCapabilities }): FinalCutConnectionStatus {
-    const capabilities = withCapabilityFamilies(result.capabilities, {
+    const capabilities = withCanonicalTimelineMode(withCapabilityFamilies(result.capabilities, {
       backend: result.identity.backend,
       connectionBackend: result.identity.backend,
-    });
+    }));
     if (this.canonicalProviderRequired && capabilities.editor.canonicalTimelineMode !== "canonical-write") {
       return this.fail(
         "FINAL_CUT_CANONICAL_PROVIDER_REQUIRED",

--- a/adapters/final-cut/typescript/src/live.ts
+++ b/adapters/final-cut/typescript/src/live.ts
@@ -2,7 +2,7 @@ import { createConnection, type Socket } from "node:net";
 import { randomUUID } from "node:crypto";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { withCapabilityFamilies } from "@framekit/runtime";
+import { withCanonicalTimelineMode, withCapabilityFamilies } from "@framekit/runtime";
 import type {
   ContextRevision,
   EditOperation,
@@ -134,7 +134,7 @@ export class FinalCutLiveAdapter implements LiveEditorStatePort {
 
   public async getCapabilities(): Promise<RuntimeCapabilities> {
     const response = await this.request({ method: "capabilities" });
-    return withCapabilityFamilies(response.capabilities, { backend: response.identity.backend });
+    return withCanonicalTimelineMode(withCapabilityFamilies(response.capabilities, { backend: response.identity.backend }));
   }
 
   public async read(): Promise<ProjectSnapshot> {

--- a/adapters/final-cut/typescript/src/session.ts
+++ b/adapters/final-cut/typescript/src/session.ts
@@ -105,7 +105,8 @@ export class FinalCutSessionAdapter implements EditorPort, LiveEditorStatePort {
       && canReadAfterWrite,
     );
     const operationFamilies = operationRuntimeCapabilities?.families;
-    const readFamilies = readCapabilities?.families;
+    const readFamilies = readCapabilities?.families
+      ?? (!this.options.snapshot && !this.options.mutation ? live?.families : undefined);
     return withCapabilityFamilies({
       editor: {
         ...operationCapabilities,

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -3,6 +3,7 @@ import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import {
   AgentVideoRuntime,
+  CapabilityUnavailableError,
   createCapabilityPreflight,
   resolveEditingIntent,
   withCanonicalTimelineMode,
@@ -698,6 +699,22 @@ function nativeMediaImportErrorResult(error: unknown) {
   };
 }
 
+function capabilityErrorResult(error: unknown) {
+  if (!(error instanceof CapabilityUnavailableError)) throw error;
+  return {
+    isError: true,
+    content: [{
+      type: "text" as const,
+      text: JSON.stringify({
+        code: error.code,
+        message: error.message,
+        operation: error.operation,
+        capability: error.capability,
+      }),
+    }],
+  };
+}
+
 function isDirectoryMediaImportError(error: unknown): error is Error & {
   code: typeof NATIVE_MEDIA_IMPORT_DIRECTORY_ERROR_CODE;
   guidance: { previewTool: string; executeTool: string };
@@ -888,7 +905,13 @@ export function createMcpServer(runtime: AgentVideoRuntime, options: McpServerOp
 
   server.registerTool("project.inspect", {
     description: "Read the current canonical project snapshot before editing.route selects a capability-checked path.",
-  }, async () => jsonResult(await runtime.inspectProject()));
+  }, async () => {
+    try {
+      return jsonResult(await runtime.inspectProject());
+    } catch (error) {
+      return capabilityErrorResult(error);
+    }
+  });
 
   server.registerTool("artifact.inspect", {
     description: "Identify the managed FCPXML artifact used by artifact.edit and artifact.publish.",

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -5,6 +5,7 @@ import {
   AgentVideoRuntime,
   createCapabilityPreflight,
   resolveEditingIntent,
+  withCanonicalTimelineMode,
   withCapabilityFamilies,
   type CapabilityProcessMode,
   type RuntimeCapabilities,
@@ -749,10 +750,10 @@ function normalizeConnectionStatus(value: unknown): unknown {
   const backend = typeof identity?.backend === "string" ? identity.backend : undefined;
   return {
     ...status,
-    capabilities: withCapabilityFamilies(status.capabilities, {
+    capabilities: withCanonicalTimelineMode(withCapabilityFamilies(status.capabilities, {
       ...(backend ? { backend, connectionBackend: backend } : {}),
       connection: status.state === "ready",
-    }),
+    })),
   };
 }
 

--- a/docs/architecture/capability-model.md
+++ b/docs/architecture/capability-model.md
@@ -64,9 +64,9 @@ Cut, `editor.canonicalTimelineMode` is one of `metadata-only`,
 `canonical-read`, or `canonical-write`. The mode is derived from the guarantees
 below; a bridge cannot promote itself to `canonical-write` without complete
 snapshot read, canonical mutation, read-after-write, and rollback. The current
-Workflow Extension reports `metadata-only`: `editor.projectRead`,
-`editor.liveStateRead`, and `editor.incrementalChanges` are enabled, while
-complete snapshot and timeline writes remain disabled. An FCPXML document provider reports
+Workflow Extension reports `metadata-only`: `editor.projectRead` is disabled
+because `project.inspect` has no canonical snapshot provider, while
+`editor.liveStateRead` and `editor.incrementalChanges` remain enabled. An FCPXML document provider reports
 `editor.timelineSnapshotRead` and `editor.timelineArtifactWrite`, never
 `editor.timelineWrite`. Analyzer availability is negotiated independently.
 

--- a/docs/mcp/capabilities-and-errors.md
+++ b/docs/mcp/capabilities-and-errors.md
@@ -107,7 +107,7 @@ FCPXML artifact results remain separate evidence tiers.
 {
   "editor": {
     "canonicalTimelineMode": "metadata-only",
-    "projectRead": true,
+    "projectRead": false,
     "timelineSnapshotRead": false,
     "timelineWrite": false,
     "timelineArtifactWrite": false,

--- a/docs/mcp/capabilities-and-errors.md
+++ b/docs/mcp/capabilities-and-errors.md
@@ -58,6 +58,23 @@ The descriptor means:
 - `unavailableReason`: a stable explanation required for unavailable
   operations; unavailable operations must fail with `CAPABILITY_UNAVAILABLE`.
 
+When a capability-gated operation is rejected before its provider is called,
+the MCP error preserves the complete operation descriptor:
+
+```json
+{
+  "code": "CAPABILITY_UNAVAILABLE",
+  "message": "CAPABILITY_UNAVAILABLE: canonical timeline reads are unavailable",
+  "operation": "canonicalDocument.read",
+  "capability": {
+    "available": false,
+    "backend": "workflow-extension-ipc",
+    "guarantee": "none",
+    "unavailableReason": "canonical timeline reads are unavailable"
+  }
+}
+```
+
 The families are:
 
 | Family | Operation examples | Meaning |

--- a/packages/runtime/src/application/project-service.ts
+++ b/packages/runtime/src/application/project-service.ts
@@ -4,7 +4,7 @@ import type { ProjectCatalog, ProjectSelection } from "../domain/context.js";
 import type { RationalTime } from "../domain/primitives.js";
 import type { ProjectSnapshot } from "../domain/project.js";
 import type { TimelineFrameCapture, VisualAnalysis } from "../domain/media.js";
-import { withCapabilityFamilies } from "../capabilities.js";
+import { withCanonicalTimelineMode, withCapabilityFamilies } from "../capabilities.js";
 import { isWithinClip, parseRational, rationalDifferenceSeconds } from "../timeline/rational-time.js";
 import type { RuntimeOptions } from "./runtime-options.js";
 
@@ -16,6 +16,11 @@ export class ProjectService {
   ) {}
 
   public async inspectProject(): Promise<ProjectSnapshot> {
+    const capabilities = withCanonicalTimelineMode(withCapabilityFamilies(await this.adapter.getCapabilities()));
+    const projectRead = capabilities.families!.canonicalDocument.read;
+    if (!projectRead.available) {
+      throw new Error(`CAPABILITY_UNAVAILABLE: ${projectRead.unavailableReason ?? "canonical timeline reads are unavailable"}`);
+    }
     return this.context.inspectProject();
   }
 

--- a/packages/runtime/src/application/project-service.ts
+++ b/packages/runtime/src/application/project-service.ts
@@ -4,7 +4,11 @@ import type { ProjectCatalog, ProjectSelection } from "../domain/context.js";
 import type { RationalTime } from "../domain/primitives.js";
 import type { ProjectSnapshot } from "../domain/project.js";
 import type { TimelineFrameCapture, VisualAnalysis } from "../domain/media.js";
-import { withCanonicalTimelineMode, withCapabilityFamilies } from "../capabilities.js";
+import {
+  CapabilityUnavailableError,
+  withCanonicalTimelineMode,
+  withCapabilityFamilies,
+} from "../capabilities.js";
 import { isWithinClip, parseRational, rationalDifferenceSeconds } from "../timeline/rational-time.js";
 import type { RuntimeOptions } from "./runtime-options.js";
 
@@ -16,10 +20,13 @@ export class ProjectService {
   ) {}
 
   public async inspectProject(): Promise<ProjectSnapshot> {
-    const capabilities = withCanonicalTimelineMode(withCapabilityFamilies(await this.adapter.getCapabilities()));
+    const identity = await this.adapter.getIdentity();
+    const capabilities = withCanonicalTimelineMode(withCapabilityFamilies(await this.adapter.getCapabilities(), {
+      backend: identity.backend,
+    }));
     const projectRead = capabilities.families!.canonicalDocument.read;
     if (!projectRead.available) {
-      throw new Error(`CAPABILITY_UNAVAILABLE: ${projectRead.unavailableReason ?? "canonical timeline reads are unavailable"}`);
+      throw new CapabilityUnavailableError("canonicalDocument.read", projectRead);
     }
     return this.context.inspectProject();
   }

--- a/packages/runtime/src/capabilities.ts
+++ b/packages/runtime/src/capabilities.ts
@@ -26,6 +26,18 @@ export interface CapabilityPreflight {
   capabilities: CapabilityFamilies;
 }
 
+export class CapabilityUnavailableError extends Error {
+  public readonly code = "CAPABILITY_UNAVAILABLE" as const;
+
+  public constructor(
+    public readonly operation: string,
+    public readonly capability: CapabilityDescriptor,
+  ) {
+    super(`CAPABILITY_UNAVAILABLE: ${capability.unavailableReason ?? `${operation} is unavailable`}`);
+    this.name = "CapabilityUnavailableError";
+  }
+}
+
 export function canonicalTimelineMode(capabilities: RuntimeCapabilities): CanonicalTimelineMode {
   const editor = capabilities.editor;
   const hasCanonicalProjectRead = canonicalProjectReadAvailable(editor);

--- a/packages/runtime/src/capabilities.ts
+++ b/packages/runtime/src/capabilities.ts
@@ -28,19 +28,26 @@ export interface CapabilityPreflight {
 
 export function canonicalTimelineMode(capabilities: RuntimeCapabilities): CanonicalTimelineMode {
   const editor = capabilities.editor;
-  const hasExplicitTargeting = Boolean(editor.projectCatalogRead && editor.projectSelection);
+  const hasCanonicalProjectRead = canonicalProjectReadAvailable(editor);
   if (
-    editor.projectRead
-    && editor.timelineSnapshotRead
-    && hasExplicitTargeting
+    hasCanonicalProjectRead
     && editor.timelineWrite
     && editor.readAfterWrite
     && editor.rollback
   ) {
     return "canonical-write";
   }
-  if (editor.projectRead && editor.timelineSnapshotRead && hasExplicitTargeting) return "canonical-read";
+  if (hasCanonicalProjectRead) return "canonical-read";
   return "metadata-only";
+}
+
+function canonicalProjectReadAvailable(editor: RuntimeCapabilities["editor"]): boolean {
+  return Boolean(
+    editor.projectRead
+    && editor.timelineSnapshotRead
+    && editor.projectCatalogRead
+    && editor.projectSelection,
+  );
 }
 
 export function withCanonicalTimelineMode(capabilities: RuntimeCapabilities): RuntimeCapabilities {
@@ -48,6 +55,7 @@ export function withCanonicalTimelineMode(capabilities: RuntimeCapabilities): Ru
     ...capabilities,
     editor: {
       ...capabilities.editor,
+      projectRead: canonicalProjectReadAvailable(capabilities.editor),
       canonicalTimelineMode: canonicalTimelineMode(capabilities),
     },
   };
@@ -136,6 +144,7 @@ export function withCapabilityFamilies(
     schemaVersion: CAPABILITY_SCHEMA_VERSION,
     editor: {
       ...capabilities.editor,
+      projectRead: canonicalProjectReadAvailable(capabilities.editor),
       canonicalTimelineMode: canonicalTimelineMode(capabilities),
     },
   };

--- a/tests/integration/capabilities.test.ts
+++ b/tests/integration/capabilities.test.ts
@@ -416,6 +416,8 @@ test("capability documentation describes the versioned operation contract", asyn
   assert.match(documentation, /projectCreation/);
   assert.match(documentation, /clipInsertion/);
   assert.match(documentation, /clipMovement/);
+  assert.match(architecture, /`editor\.projectRead` is disabled/);
+  assert.match(mcp, /"projectRead": false/);
 });
 
 test("MCP connection status normalizes injected capability payloads", async () => {

--- a/tests/integration/project-inspect-capabilities.test.ts
+++ b/tests/integration/project-inspect-capabilities.test.ts
@@ -44,6 +44,13 @@ const metadataIdentity = {
   backend: "workflow-extension-ipc",
 };
 
+const unavailableCanonicalRead = {
+  available: false,
+  backend: "workflow-extension-ipc",
+  guarantee: "none",
+  unavailableReason: "canonical timeline reads are unavailable",
+};
+
 function textFrom(result: unknown): string {
   const content = (result as { content?: unknown }).content;
   assert.ok(Array.isArray(content));
@@ -93,16 +100,22 @@ test("metadata-only project inspection has one capability contract across MCP su
     assert.equal(status.capabilities.editor.projectRead, false);
     assert.equal(editor.capabilities.editor.projectRead, false);
     assert.deepEqual(statusRead, editorRead);
-    assert.deepEqual(editorRead, {
-      available: false,
-      backend: "workflow-extension-ipc",
-      guarantee: "none",
-      unavailableReason: "canonical timeline reads are unavailable",
-    });
+    assert.deepEqual(editorRead, unavailableCanonicalRead);
 
     const project = await client.callTool({ name: "project.inspect", arguments: {} });
     assert.equal(project.isError, true);
-    assert.match(textFrom(project), /CAPABILITY_UNAVAILABLE: canonical timeline reads are unavailable/);
+    const projectError = JSON.parse(textFrom(project)) as {
+      code?: unknown;
+      message?: unknown;
+      operation?: unknown;
+      capability?: unknown;
+    };
+    assert.deepEqual(projectError, {
+      code: "CAPABILITY_UNAVAILABLE",
+      message: "CAPABILITY_UNAVAILABLE: canonical timeline reads are unavailable",
+      operation: "canonicalDocument.read",
+      capability: unavailableCanonicalRead,
+    });
     assert.equal(snapshotCalls, 0);
   } finally {
     await client.close();
@@ -126,10 +139,18 @@ test("project inspection rejects before invoking an unavailable snapshot provide
     return readProject();
   };
 
-  await assert.rejects(
-    new AgentVideoRuntime(adapter).inspectProject(),
-    /CAPABILITY_UNAVAILABLE: canonical timeline reads are unavailable/,
-  );
+  await assert.rejects(new AgentVideoRuntime(adapter).inspectProject(), (error: unknown) => {
+    assert.ok(error instanceof Error);
+    const value = error as Error & {
+      code?: unknown;
+      operation?: unknown;
+      capability?: unknown;
+    };
+    assert.equal(value.code, "CAPABILITY_UNAVAILABLE");
+    assert.equal(value.operation, "canonicalDocument.read");
+    assert.deepEqual(value.capability, unavailableCanonicalRead);
+    return true;
+  });
   assert.equal(readCalls, 0);
 });
 

--- a/tests/integration/project-inspect-capabilities.test.ts
+++ b/tests/integration/project-inspect-capabilities.test.ts
@@ -138,6 +138,7 @@ test("project inspection rejects before invoking an unavailable snapshot provide
     readCalls += 1;
     return readProject();
   };
+  adapter.getIdentity = async () => metadataIdentity;
 
   await assert.rejects(new AgentVideoRuntime(adapter).inspectProject(), (error: unknown) => {
     assert.ok(error instanceof Error);

--- a/tests/integration/project-inspect-capabilities.test.ts
+++ b/tests/integration/project-inspect-capabilities.test.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import {
+  FinalCutConnectionManager,
+  FinalCutLiveAdapter,
+  FinalCutSessionAdapter,
+  type FinalCutLiveRequest,
+  type FinalCutLiveResponse,
+} from "@framekit/final-cut";
+import type { ProjectSnapshot, RuntimeCapabilities } from "@framekit/runtime";
+import { AgentVideoRuntime, withCapabilityFamilies } from "@framekit/runtime";
+import { InMemoryEditorAdapter } from "@framekit/testkit";
+import { createMcpServer } from "../../apps/mcp-server/src/server.js";
+
+const metadataOnlyCapabilities: RuntimeCapabilities = {
+  editor: {
+    projectRead: true,
+    timelineSnapshotRead: false,
+    timelineWrite: false,
+    timelineArtifactWrite: false,
+    readAfterWrite: false,
+    incrementalChanges: true,
+    rollback: false,
+    assetDiscovery: false,
+    liveStateRead: true,
+    playheadWrite: false,
+    frameCapture: false,
+    projectCatalogRead: false,
+    projectSelection: false,
+  },
+  analyzers: {
+    speechTranscribe: false,
+    speechVad: false,
+    audioLoudness: false,
+    visualTrack: false,
+  },
+};
+
+const metadataIdentity = {
+  name: "Final Cut Pro",
+  version: "test",
+  backend: "workflow-extension-ipc",
+};
+
+function textFrom(result: unknown): string {
+  const content = (result as { content?: unknown }).content;
+  assert.ok(Array.isArray(content));
+  const first = content[0] as { text?: unknown } | undefined;
+  assert.equal(typeof first?.text, "string");
+  return first?.text as string;
+}
+
+function metadataResponse(request: FinalCutLiveRequest): FinalCutLiveResponse {
+  return {
+    version: 1,
+    id: request.id,
+    ok: true,
+    result: {
+      identity: metadataIdentity,
+      capabilities: metadataOnlyCapabilities,
+    },
+  };
+}
+
+test("metadata-only project inspection has one capability contract across MCP surfaces", async () => {
+  let snapshotCalls = 0;
+  const live = new FinalCutLiveAdapter({
+    request: async (request) => {
+      if (request.method === "snapshot") snapshotCalls += 1;
+      return metadataResponse(request);
+    },
+  });
+  const runtime = new AgentVideoRuntime(new FinalCutSessionAdapter({ live }));
+  const connection = new FinalCutConnectionManager({
+    headless: true,
+    probe: async () => ({ identity: metadataIdentity, capabilities: metadataOnlyCapabilities }),
+  });
+  await connection.ensureConnected();
+  const server = createMcpServer(runtime, { connectionStatus: () => connection.getStatus() });
+  const client = new Client({ name: "project-inspect-capability-test", version: "0.1.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  try {
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+    const status = JSON.parse(textFrom(await client.callTool({ name: "connection.status", arguments: {} })));
+    const editor = JSON.parse(textFrom(await client.callTool({ name: "editor.inspect", arguments: {} })));
+    const statusRead = status.capabilities.families.canonicalDocument.read;
+    const editorRead = editor.capabilities.families.canonicalDocument.read;
+
+    assert.equal(status.capabilities.editor.projectRead, false);
+    assert.equal(editor.capabilities.editor.projectRead, false);
+    assert.deepEqual(statusRead, editorRead);
+    assert.deepEqual(editorRead, {
+      available: false,
+      backend: "workflow-extension-ipc",
+      guarantee: "none",
+      unavailableReason: "canonical timeline reads are unavailable",
+    });
+
+    const project = await client.callTool({ name: "project.inspect", arguments: {} });
+    assert.equal(project.isError, true);
+    assert.match(textFrom(project), /CAPABILITY_UNAVAILABLE: canonical timeline reads are unavailable/);
+    assert.equal(snapshotCalls, 0);
+  } finally {
+    await client.close();
+    await server.close();
+  }
+});
+
+test("project inspection rejects before invoking an unavailable snapshot provider", async () => {
+  const adapter = new InMemoryEditorAdapter({
+    projectId: "metadata-project",
+    projectName: "Metadata-only",
+    timelineId: "metadata-sequence",
+    timelineName: "Main",
+    clips: [],
+  });
+  const readProject = adapter.readProject.bind(adapter);
+  let readCalls = 0;
+  adapter.getCapabilities = async () => metadataOnlyCapabilities;
+  adapter.readProject = async (): Promise<ProjectSnapshot> => {
+    readCalls += 1;
+    return readProject();
+  };
+
+  await assert.rejects(
+    new AgentVideoRuntime(adapter).inspectProject(),
+    /CAPABILITY_UNAVAILABLE: canonical timeline reads are unavailable/,
+  );
+  assert.equal(readCalls, 0);
+});
+
+test("metadata-only capability normalization remains explicit", () => {
+  const capabilities = withCapabilityFamilies(metadataOnlyCapabilities, { backend: metadataIdentity.backend });
+
+  assert.equal(capabilities.editor.canonicalTimelineMode, "metadata-only");
+  assert.equal(capabilities.families.canonicalDocument.read.available, false);
+});


### PR DESCRIPTION
## Summary

- Align metadata-only `projectRead` reporting with the canonical snapshot contract.
- Preserve the live provider backend and unavailable descriptor through Final Cut sessions and connection probes.
- Reject `project.inspect` before invoking an unavailable snapshot provider.
- Update the bundled Workflow Extension payload and capability documentation.

## TDD

- Added failing MCP and runtime regressions first.
- Implemented the smallest capability normalization and preflight gates.
- Added a documentation contract assertion and updated the canonical examples.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm run test` — 702 passed
- `pnpm run check:boundaries`
- `pnpm run xcode:check`
- `xcodebuild -project adapters/final-cut/swift-bridge/FinalCutWorkflowExtension/FramekitFinalCutWorkflow.xcodeproj -list`

Closes #203


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Capability reporting now consistently includes canonical timeline mode across Final Cut integrations and MCP connection status.
  - Capability information is normalized across connection status, editor inspection, and project inspection.
  - Unsupported project inspection requests now return structured `CAPABILITY_UNAVAILABLE` errors instead of failing without details.

- **Bug Fixes**
  - Final Cut correctly reports project reading as unavailable when no canonical snapshot is supported.
  - Capability checks now prevent unsupported project inspections before unavailable providers are called.

- **Documentation**
  - Updated capability guidance and examples to reflect metadata-only access and structured capability errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->