### PR TITLE
chore: generate milestone release reports

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,13 +203,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          mapfile -t milestone_tags < <(git tag --list 'v*.*.0' --sort=-v:refname)
+          mapfile -t milestone_tags < <(git tag --list 'v*.*.0' --sort=v:refname)
           baseline_tag=""
           for candidate in "${milestone_tags[@]}"; do
-            if [ "${candidate}" != "${RELEASE_TAG}" ]; then
-              baseline_tag="${candidate}"
+            if [ "${candidate}" = "${RELEASE_TAG}" ]; then
               break
             fi
+            baseline_tag="${candidate}"
           done
           if [ -z "${baseline_tag}" ]; then
             echo "No previous milestone tag found for ${RELEASE_TAG}" >&2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release-tag: ${{ steps.requested-tag.outputs.tag || steps.existing-tag.outputs.tag || steps.run-tagpr.outputs.tag }}
+      milestone-release: ${{ steps.classify.outputs.milestone }}
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -77,6 +78,19 @@ jobs:
         uses: Songmu/tagpr@7ebae2dcc300132baa7cc9dd108c8923b07fc366 # v1
         env:
           GITHUB_TOKEN: ${{ secrets.TAGPR_TOKEN }}
+
+      - id: classify
+        name: Classify milestone release
+        env:
+          RELEASE_TAG: ${{ steps.requested-tag.outputs.tag || steps.existing-tag.outputs.tag || steps.run-tagpr.outputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.0$ ]]; then
+            echo "milestone=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "milestone=false" >> "$GITHUB_OUTPUT"
+          fi
 
   native-release-assets:
     if: needs.tagpr.outputs.release-tag != ''
@@ -144,12 +158,98 @@ jobs:
           upload_asset "${archive_name}" "application/zip" "${FRAMEKIT_RELEASE_DIR}/${archive_name}"
           upload_asset "${checksum_name}" "text/plain" "${FRAMEKIT_RELEASE_DIR}/${checksum_name}"
 
+  milestone-report:
+    if: needs.tagpr.outputs.release-tag != ''
+    needs: tagpr
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: read
+      pull-requests: read
+    steps:
+      - name: Skip milestone report for patch release
+        if: needs.tagpr.outputs.milestone-release != 'true'
+        run: echo "Patch release; skipping milestone report generation."
+
+      - name: Check out release tag
+        if: needs.tagpr.outputs.milestone-release == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ needs.tagpr.outputs.release-tag }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up pnpm
+        if: needs.tagpr.outputs.milestone-release == 'true'
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+
+      - name: Set up Node.js
+        if: needs.tagpr.outputs.milestone-release == 'true'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24.21.0
+          cache: pnpm
+
+      - name: Install dependencies
+        if: needs.tagpr.outputs.milestone-release == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate and attach milestone report
+        if: needs.tagpr.outputs.milestone-release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          RELEASE_TAG: ${{ needs.tagpr.outputs.release-tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t milestone_tags < <(git tag --list 'v*.*.0' --sort=-v:refname)
+          baseline_tag=""
+          for candidate in "${milestone_tags[@]}"; do
+            if [ "${candidate}" != "${RELEASE_TAG}" ]; then
+              baseline_tag="${candidate}"
+              break
+            fi
+          done
+          if [ -z "${baseline_tag}" ]; then
+            echo "No previous milestone tag found for ${RELEASE_TAG}" >&2
+            exit 1
+          fi
+
+          current_coverage="${RUNNER_TEMP}/framekit-current-coverage"
+          baseline_coverage="${RUNNER_TEMP}/framekit-baseline-coverage"
+          baseline_worktree="${RUNNER_TEMP}/framekit-baseline-worktree"
+          C8_REPORTS_DIR="${current_coverage}" pnpm run test:coverage
+          git worktree add --detach "${baseline_worktree}" "${baseline_tag}"
+          trap 'git worktree remove --force "${baseline_worktree}"' EXIT
+          pnpm --dir "${baseline_worktree}" install --frozen-lockfile
+          pnpm exec c8 \
+            --reporter=json-summary \
+            --reporter=text \
+            --reports-dir "${baseline_coverage}" \
+            pnpm --dir "${baseline_worktree}" test
+          pnpm run release-report -- \
+            --baseline-tag "${baseline_tag}" \
+            --current-tag "${RELEASE_TAG}" \
+            --baseline-coverage "${baseline_coverage}/coverage-summary.json" \
+            --current-coverage "${current_coverage}/coverage-summary.json" \
+            --output-dir artifacts/release-report
+          gh release upload "${RELEASE_TAG}" \
+            artifacts/release-report/report.json \
+            artifacts/release-report/report.md \
+            artifacts/release-report/charts/coverage.svg \
+            artifacts/release-report/charts/roadmap-progress.svg \
+            artifacts/release-report/charts/contributors.svg \
+            --repo "${GITHUB_REPOSITORY}" \
+            --clobber
+
   publish-npm:
     if: needs.tagpr.outputs.release-tag != ''
     needs:
       - tagpr
       - validate-codex-plugin
       - native-release-assets
+      - milestone-report
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 dist/
 dist-package/
 artifacts/
+coverage/
 .DS_Store
 
 PLAN.md

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -82,6 +82,44 @@ The npm Trusted Publisher relationship is configured in npm account settings;
 repository permissions alone cannot create or repair that relationship. The
 workflow can only use the OIDC identity after the relationship exists.
 
+## Milestone status reports
+
+Patch releases keep the normal lightweight release flow. For a milestone tag
+such as `v0.2.0`, the workflow compares it with the previous patch-zero tag,
+runs the reproducible c8 test-coverage command for both revisions, reads the
+matching GitHub milestone and public activity, and uploads these assets to the
+draft release:
+
+```text
+artifacts/release-report/
+  report.json
+  report.md
+  charts/coverage.svg
+  charts/roadmap-progress.svg
+  charts/contributors.svg
+```
+
+The same report can be regenerated locally from explicit coverage summaries and
+an optional saved GitHub snapshot:
+
+```sh
+C8_REPORTS_DIR=artifacts/release-report/current-coverage pnpm run test:coverage
+pnpm run release-report -- \
+  --baseline-tag v0.1.0 \
+  --current-tag v0.2.0 \
+  --baseline-coverage artifacts/release-report/baseline-coverage/coverage-summary.json \
+  --current-coverage artifacts/release-report/current-coverage/coverage-summary.json \
+  --data-file github-release-data.json \
+  --output-dir artifacts/release-report
+```
+
+Without `--data-file`, the generator uses `gh api` for the public GitHub
+milestone, merged pull requests, and closed issues in the exact tag window.
+The roadmap percentage is based on the GitHub milestone's closed and open issue
+counts; contributor totals exclude accounts marked as bots or ending in
+`[bot]`. The report has no generated timestamp, so identical inputs produce
+identical JSON, Markdown, and SVG output.
+
 ## Local validation
 
 Run the standard checks before merging a release pull request:

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "build:package": "tsc -p tsconfig.package.json && tsc-alias -p tsconfig.package.json",
-    "test": "tsx --test tests/integration/*.test.ts tests/evaluation/*.test.ts tests/filler-removal/*.test.ts tests/speech/*.test.ts tests/golden/*.test.ts tests/release-gate/*.test.ts",
+    "test": "tsx --test tests/integration/*.test.ts tests/evaluation/*.test.ts tests/filler-removal/*.test.ts tests/speech/*.test.ts tests/golden/*.test.ts tests/release-gate/*.test.ts tests/release-report/*.test.ts",
+    "test:coverage": "c8 --reporter=json-summary --reporter=text --reports-dir=\"${C8_REPORTS_DIR:-coverage}\" pnpm test",
     "test:filler-removal": "tsx --test tests/filler-removal/*.test.ts",
     "benchmark:filler-removal": "tsx scripts/run-filler-removal-benchmark.ts",
     "test:golden": "tsx --test tests/golden/*.test.ts",
@@ -72,6 +73,7 @@
   "devDependencies": {
     "@openai/codex": "0.144.1",
     "@types/node": "24.13.3",
+    "c8": "10.1.3",
     "tsc-alias": "1.9.4",
     "tsx": "4.23.13",
     "typescript": "7.0.2"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:golden": "tsx --test tests/golden/*.test.ts",
     "test:release-gate": "tsx --test tests/release-gate/*.test.ts",
     "release-gate": "tsx scripts/run-release-gate.ts",
+    "release-report": "tsx scripts/generate-release-report.ts",
     "verify-release-provenance": "tsx scripts/verify-release-provenance.ts",
     "test:codex-plugin": "node scripts/codex-plugin-smoke.mjs",
     "test:clean-mcp-clients": "node scripts/clean-mcp-client-smoke.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
       '@types/node':
         specifier: 24.13.3
         version: 24.13.3
+      c8:
+        specifier: 10.1.3
+        version: 10.1.3
       tsc-alias:
         specifier: 1.9.4
         version: 1.9.4
@@ -235,6 +238,10 @@ packages:
   '@babel/helper-validator-identifier@7.29.7':
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@commitlint/config-validator@21.2.0':
     resolution: {integrity: sha512-t7AzNHAKeIdo/3NRGwzpufKHsKkPHmFs/56N2Fnsh0/r0rGtnQzTxk6vnFgjaGr4hdSQKNB50/KAhR9Yk4LJKA==}
@@ -427,6 +434,24 @@ packages:
       '@types/node':
         optional: true
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@istanbuljs/schema@0.1.6':
+    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
+    engines: {node: '>=8'}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.6.0':
+    resolution: {integrity: sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
   '@modelcontextprotocol/sdk@1.30.0':
     resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
     engines: {node: '>=18'}
@@ -493,9 +518,16 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+
   '@simple-libs/stream-utils@2.0.0':
     resolution: {integrity: sha512-fCTuZK4QBa+39Oz9l4OGfJfz+GpwCp3AqO7Zch3to99xHPgstVsRFpeQ8LNd2o1Gv8raL2mCFwiaHh7bFSp5DQ==}
     engines: {node: '>=22'}
+
+  '@types/istanbul-lib-coverage@2.0.6':
+    resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
 
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
@@ -643,6 +675,10 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-regex@6.3.0:
+    resolution: {integrity: sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==}
+    engines: {node: '>=12'}
+
   ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
     engines: {node: '>=4'}
@@ -650,6 +686,10 @@ packages:
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
@@ -676,6 +716,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -693,6 +737,13 @@ packages:
   brace-expansion@1.1.18:
     resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
+
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
+
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
@@ -703,6 +754,16 @@ packages:
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
+
+  c8@10.1.3:
+    resolution: {integrity: sha512-LvcyrOAaOnrrlMpW22n690PUvxiq4Uf9WMhQwNJ9vgagkL/ph1+D4uvjvDA5XCbykrc0sx+ay6pVi9YZ1GnhyA==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      monocart-coverage-reports: ^2
+    peerDependenciesMeta:
+      monocart-coverage-reports:
+        optional: true
 
   cachedir@2.4.0:
     resolution: {integrity: sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==}
@@ -746,6 +807,10 @@ packages:
   cli-width@3.0.0:
     resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
     engines: {node: '>= 10'}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
 
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
@@ -795,6 +860,9 @@ packages:
     resolution: {integrity: sha512-O+x4N2yH+ijvqWlIyTHsXTAP+algNWgGbjY2duCe8w2vUMvUB95cLRslCPfTMQyLAKlet3bhZTdu6ozn4M+QJQ==}
     engines: {node: '>=22'}
     hasBin: true
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
@@ -868,11 +936,17 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
@@ -904,6 +978,10 @@ packages:
     resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -976,9 +1054,17 @@ packages:
   find-root@1.1.0:
     resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
 
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
   findup-sync@4.0.0:
     resolution: {integrity: sha512-6jvvn/12IC4quLBL1KNokxC7wWTvYncaVUYSoxWw7YykPLuRrnv4qdHcSOywOI5RpkOVGeQRtWM8/q+G6W6qfQ==}
     engines: {node: '>= 8'}
+
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -1003,6 +1089,10 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -1021,6 +1111,11 @@ packages:
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
+
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -1072,6 +1167,9 @@ packages:
   hono@4.13.7:
     resolution: {integrity: sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==}
     engines: {node: '>=16.9.0'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -1169,6 +1267,21 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
@@ -1198,6 +1311,10 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
   lodash.map@4.6.0:
     resolution: {integrity: sha512-worNHGKLDetmcEYDvh2stPCrrQRkP20E4l0iIS7F8EvzMqBBi7ltvFN5m1HvTf1P7Jk1txKhvFcmYsCr8O2F1Q==}
 
@@ -1211,6 +1328,13 @@ packages:
   longest@2.0.1:
     resolution: {integrity: sha512-Ajzxb8CM6WAnFjgiloPsI3bF+WCxcvhdIG3KNA2KN962+tdBsHcuQ4k4qX/EcS/2CRkcc0iAkR956Nib6aXU/Q==}
     engines: {node: '>=0.10.0'}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -1247,11 +1371,23 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1294,6 +1430,17 @@ packages:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
     engines: {node: '>=10'}
 
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -1310,6 +1457,10 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
   path-expression-matcher@1.6.2:
     resolution: {integrity: sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==}
     engines: {node: '>=14.0.0'}
@@ -1321,6 +1472,10 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
@@ -1375,6 +1530,10 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -1422,6 +1581,11 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
@@ -1460,6 +1624,10 @@ packages:
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -1472,12 +1640,20 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-bom@4.0.0:
     resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
@@ -1497,6 +1673,10 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
@@ -1549,6 +1729,10 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  v8-to-istanbul@9.3.0:
+    resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
+    engines: {node: '>=10.12.0'}
+
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
@@ -1573,12 +1757,36 @@ packages:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   xml-naming@0.3.0:
     resolution: {integrity: sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==}
     engines: {node: '>=16.0.0'}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.3:
+    resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
+    engines: {node: '>=12'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
 
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
@@ -1599,6 +1807,8 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.29.7':
     optional: true
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@commitlint/config-validator@21.2.0':
     dependencies:
@@ -1729,6 +1939,26 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.13.3
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/schema@0.1.6': {}
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.6.0': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.6.0
+
   '@modelcontextprotocol/sdk@1.30.0(supports-color@7.2.0)(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 2.1.1(hono@4.13.7)
@@ -1792,8 +2022,13 @@ snapshots:
   '@openai/codex@0.144.1-win32-x64':
     optional: true
 
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
   '@simple-libs/stream-utils@2.0.0':
     optional: true
+
+  '@types/istanbul-lib-coverage@2.0.6': {}
 
   '@types/node@24.13.3':
     dependencies:
@@ -1881,6 +2116,8 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
+  ansi-regex@6.3.0: {}
+
   ansi-styles@3.2.1:
     dependencies:
       color-convert: 1.9.3
@@ -1888,6 +2125,8 @@ snapshots:
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
 
   anymatch@3.1.3:
     dependencies:
@@ -1907,6 +2146,8 @@ snapshots:
   at-least-node@1.0.0: {}
 
   balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
 
@@ -1937,6 +2178,14 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
+  brace-expansion@2.1.4:
+    dependencies:
+      balanced-match: 1.0.2
+
+  brace-expansion@5.0.9:
+    dependencies:
+      balanced-match: 4.0.4
+
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
@@ -1947,6 +2196,20 @@ snapshots:
       ieee754: 1.2.1
 
   bytes@3.1.2: {}
+
+  c8@10.1.3:
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@istanbuljs/schema': 0.1.6
+      find-up: 5.0.0
+      foreground-child: 3.3.1
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      test-exclude: 7.0.2
+      v8-to-istanbul: 9.3.0
+      yargs: 17.7.3
+      yargs-parser: 21.1.1
 
   cachedir@2.4.0: {}
 
@@ -1995,6 +2258,12 @@ snapshots:
   cli-spinners@2.9.2: {}
 
   cli-width@3.0.0: {}
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
 
   clone@1.0.4: {}
 
@@ -2047,6 +2316,8 @@ snapshots:
       '@simple-libs/stream-utils': 2.0.0
       argue-cli: 3.2.0
     optional: true
+
+  convert-source-map@2.0.0: {}
 
   cookie-signature@1.2.2: {}
 
@@ -2123,9 +2394,13 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  eastasianwidth@0.2.0: {}
+
   ee-first@1.1.1: {}
 
   emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   encodeurl@2.0.0: {}
 
@@ -2176,6 +2451,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.28.2
       '@esbuild/win32-ia32': 0.28.2
       '@esbuild/win32-x64': 0.28.2
+
+  escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
 
@@ -2290,12 +2567,22 @@ snapshots:
 
   find-root@1.1.0: {}
 
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
   findup-sync@4.0.0:
     dependencies:
       detect-file: 1.0.0
       is-glob: 4.0.3
       micromatch: 4.0.8
       resolve-dir: 1.0.1
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
 
   forwarded@0.2.0: {}
 
@@ -2314,6 +2601,8 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  get-caller-file@2.0.5: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -2342,6 +2631,15 @@ snapshots:
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
 
   glob@7.2.3:
     dependencies:
@@ -2399,6 +2697,8 @@ snapshots:
       parse-passwd: 1.0.0
 
   hono@4.13.7: {}
+
+  html-escaper@2.0.2: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -2492,6 +2792,25 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
   jiti@2.6.1:
     optional: true
 
@@ -2521,6 +2840,10 @@ snapshots:
   lines-and-columns@1.2.4:
     optional: true
 
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
   lodash.map@4.6.0: {}
 
   lodash@4.18.1: {}
@@ -2531,6 +2854,12 @@ snapshots:
       is-unicode-supported: 0.1.0
 
   longest@2.0.1: {}
+
+  lru-cache@10.4.3: {}
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.5
 
   math-intrinsics@1.1.0: {}
 
@@ -2555,11 +2884,21 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
+  minimatch@10.2.6:
+    dependencies:
+      brace-expansion: 5.0.9
+
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.18
 
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.4
+
   minimist@1.2.8: {}
+
+  minipass@7.1.3: {}
 
   ms@2.1.3: {}
 
@@ -2601,6 +2940,16 @@ snapshots:
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
 
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  package-json-from-dist@1.0.1: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -2618,11 +2967,18 @@ snapshots:
 
   parseurl@1.3.3: {}
 
+  path-exists@4.0.0: {}
+
   path-expression-matcher@1.6.2: {}
 
   path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   path-to-regexp@8.4.2: {}
 
@@ -2672,6 +3028,8 @@ snapshots:
     dependencies:
       picomatch: 2.3.2
 
+  require-directory@2.1.1: {}
+
   require-from-string@2.0.2: {}
 
   resolve-dir@1.0.1:
@@ -2717,6 +3075,8 @@ snapshots:
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
+
+  semver@7.8.5: {}
 
   send@1.2.1(supports-color@7.2.0):
     dependencies:
@@ -2781,6 +3141,8 @@ snapshots:
 
   signal-exit@3.0.7: {}
 
+  signal-exit@4.1.0: {}
+
   slash@3.0.0: {}
 
   statuses@2.0.2: {}
@@ -2791,6 +3153,12 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -2798,6 +3166,10 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.3.0
 
   strip-bom@4.0.0: {}
 
@@ -2814,6 +3186,12 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 10.5.0
+      minimatch: 10.2.6
 
   through@2.3.8: {}
 
@@ -2880,6 +3258,12 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  v8-to-istanbul@9.3.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/istanbul-lib-coverage': 2.0.6
+      convert-source-map: 2.0.0
+
   vary@1.1.2: {}
 
   wcwidth@1.0.1:
@@ -2902,9 +3286,37 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
+
   wrappy@1.0.2: {}
 
   xml-naming@0.3.0: {}
+
+  y18n@5.0.8: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.3:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
+  yocto-queue@0.1.0: {}
 
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:

--- a/scripts/generate-release-report.ts
+++ b/scripts/generate-release-report.ts
@@ -1,0 +1,55 @@
+import { readFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseReleaseReportArgs, type ReleaseReportCliOptions } from "./release-report/args.js";
+import { writeReleaseReportArtifacts, type ReleaseReportArtifactPaths } from "./release-report/artifacts.js";
+import { fetchGitHubData, repositoryFromGitRemote } from "./release-report/github.js";
+import { buildReportFromData, type ReleaseReportDataFile } from "./release-report/generator.js";
+
+export async function generateReleaseReport(
+  options: ReleaseReportCliOptions,
+  cwd = process.cwd(),
+): Promise<ReleaseReportArtifactPaths> {
+  const currentCoverage = await readJson(resolve(cwd, options.currentCoveragePath));
+  const baselineCoverage = await readJson(resolve(cwd, options.baselineCoveragePath));
+  const data = options.dataFilePath
+    ? await readJson(resolve(cwd, options.dataFilePath)) as ReleaseReportDataFile
+    : await fetchGitHubData({
+      repository: await repositoryFromGitRemote(cwd),
+      baselineTag: options.baselineTag,
+      currentTag: options.currentTag,
+      cwd,
+    });
+  const report = buildReportFromData({
+    baselineTag: options.baselineTag,
+    currentTag: options.currentTag,
+    currentCoverage,
+    baselineCoverage,
+    data,
+  });
+  return writeReleaseReportArtifacts(report, resolve(cwd, options.outputDirectory));
+}
+
+async function main(): Promise<void> {
+  try {
+    const options = parseReleaseReportArgs(
+      process.argv.slice(2),
+      join(process.cwd(), "artifacts", "release-report"),
+    );
+    const paths = await generateReleaseReport(options);
+    console.log(`report=${paths.reportJson}`);
+    console.log(`markdown=${paths.reportMarkdown}`);
+    console.log(`charts=${Object.values(paths.charts).join(",")}`);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}
+
+async function readJson(path: string): Promise<unknown> {
+  return JSON.parse(await readFile(path, "utf8"));
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/scripts/release-report/args.ts
+++ b/scripts/release-report/args.ts
@@ -1,0 +1,79 @@
+export interface ReleaseReportCliOptions {
+  baselineTag: string;
+  currentTag: string;
+  baselineCoveragePath: string;
+  currentCoveragePath: string;
+  dataFilePath?: string;
+  outputDirectory: string;
+}
+
+export function parseReleaseReportArgs(
+  args: string[],
+  defaultOutputDirectory: string,
+): ReleaseReportCliOptions {
+  let baselineTag: string | undefined;
+  let currentTag: string | undefined;
+  let baselineCoveragePath: string | undefined;
+  let currentCoveragePath: string | undefined;
+  let dataFilePath: string | undefined;
+  let outputDirectory: string | undefined;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    const option = optionName(argument);
+    if (!option) throw usage("only named options are supported");
+    const value = argument.includes("=") ? argument.slice(argument.indexOf("=") + 1) : args[++index];
+    if (!value || value.startsWith("--")) throw usage(`${option} requires a value`);
+
+    switch (option) {
+      case "--baseline-tag":
+        baselineTag = assignOnce(option, baselineTag, value);
+        break;
+      case "--current-tag":
+        currentTag = assignOnce(option, currentTag, value);
+        break;
+      case "--baseline-coverage":
+        baselineCoveragePath = assignOnce(option, baselineCoveragePath, value);
+        break;
+      case "--current-coverage":
+        currentCoveragePath = assignOnce(option, currentCoveragePath, value);
+        break;
+      case "--data-file":
+        dataFilePath = assignOnce(option, dataFilePath, value);
+        break;
+      case "--output-dir":
+        outputDirectory = assignOnce(option, outputDirectory, value);
+        break;
+      default:
+        throw usage(`unsupported option ${option}`);
+    }
+  }
+
+  if (!baselineTag || !currentTag || !baselineCoveragePath || !currentCoveragePath) {
+    throw usage("baseline/current tags and coverage paths are required");
+  }
+
+  return {
+    baselineTag,
+    currentTag,
+    baselineCoveragePath,
+    currentCoveragePath,
+    ...(dataFilePath ? { dataFilePath } : {}),
+    outputDirectory: outputDirectory ?? defaultOutputDirectory,
+  };
+}
+
+function optionName(argument: string | undefined): string | undefined {
+  if (!argument) return undefined;
+  const equalsIndex = argument.indexOf("=");
+  return equalsIndex === -1 ? argument : argument.slice(0, equalsIndex);
+}
+
+function assignOnce(option: string, current: string | undefined, value: string): string {
+  if (current !== undefined) throw usage(`specify ${option} once`);
+  return value;
+}
+
+function usage(message: string): Error {
+  return new Error(`USAGE: ${message}`);
+}

--- a/scripts/release-report/artifacts.ts
+++ b/scripts/release-report/artifacts.ts
@@ -1,0 +1,49 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  renderContributorsChart,
+  renderCoverageChart,
+  renderReleaseMarkdown,
+  renderRoadmapChart,
+  serializeReleaseReport,
+  type ReleaseReport,
+} from "./report.js";
+
+export interface ReleaseReportArtifactPaths {
+  outputDirectory: string;
+  reportJson: string;
+  reportMarkdown: string;
+  charts: {
+    coverage: string;
+    roadmapProgress: string;
+    contributors: string;
+  };
+}
+
+export async function writeReleaseReportArtifacts(
+  report: ReleaseReport,
+  outputDirectory: string,
+): Promise<ReleaseReportArtifactPaths> {
+  const chartsDirectory = join(outputDirectory, "charts");
+  await mkdir(chartsDirectory, { recursive: true });
+
+  const paths: ReleaseReportArtifactPaths = {
+    outputDirectory,
+    reportJson: join(outputDirectory, "report.json"),
+    reportMarkdown: join(outputDirectory, "report.md"),
+    charts: {
+      coverage: join(chartsDirectory, "coverage.svg"),
+      roadmapProgress: join(chartsDirectory, "roadmap-progress.svg"),
+      contributors: join(chartsDirectory, "contributors.svg"),
+    },
+  };
+
+  await Promise.all([
+    writeFile(paths.reportJson, serializeReleaseReport(report), "utf8"),
+    writeFile(paths.reportMarkdown, renderReleaseMarkdown(report), "utf8"),
+    writeFile(paths.charts.coverage, renderCoverageChart(report), "utf8"),
+    writeFile(paths.charts.roadmapProgress, renderRoadmapChart(report), "utf8"),
+    writeFile(paths.charts.contributors, renderContributorsChart(report), "utf8"),
+  ]);
+  return paths;
+}

--- a/scripts/release-report/generator.ts
+++ b/scripts/release-report/generator.ts
@@ -1,0 +1,46 @@
+import {
+  buildReleaseReport,
+  type ReleaseReport,
+} from "./report.js";
+import {
+  normalizeGitHubActivity,
+  parseCoverageSummary,
+  selectGitHubMilestone,
+  type GitHubActivitySnapshot,
+  type GitHubMilestoneRecord,
+} from "./sources.js";
+
+export interface ReleaseReportDataFile {
+  milestones: GitHubMilestoneRecord[];
+  activity: GitHubActivitySnapshot;
+}
+
+export interface BuildReportFromDataInput {
+  baselineTag: string;
+  currentTag: string;
+  currentCoverage: unknown;
+  baselineCoverage: unknown;
+  data: ReleaseReportDataFile;
+}
+
+export function buildReportFromData(input: BuildReportFromDataInput): ReleaseReport {
+  const milestone = input.data.milestones.find(
+    (candidate) => candidate.title === `Release for ${input.currentTag}`,
+  );
+  const source = selectGitHubMilestone(input.data.milestones, input.currentTag);
+
+  return buildReleaseReport({
+    baselineTag: input.baselineTag,
+    currentTag: input.currentTag,
+    coverage: {
+      current: parseCoverageSummary(input.currentCoverage, "current"),
+      baseline: parseCoverageSummary(input.baselineCoverage, "baseline"),
+    },
+    roadmap: {
+      completed: milestone?.closed_issues ?? 0,
+      total: (milestone?.closed_issues ?? 0) + (milestone?.open_issues ?? 0),
+      source,
+    },
+    activity: normalizeGitHubActivity(input.data.activity),
+  });
+}

--- a/scripts/release-report/github.ts
+++ b/scripts/release-report/github.ts
@@ -1,0 +1,81 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { ReleaseReportDataFile } from "./generator.js";
+import type {
+  GitHubActivitySnapshot,
+  GitHubIssueRecord,
+  GitHubMilestoneRecord,
+  GitHubPullRequestRecord,
+} from "./sources.js";
+
+const execFileAsync = promisify(execFile);
+
+export interface GitHubDataOptions {
+  repository: string;
+  baselineTag: string;
+  currentTag: string;
+  cwd?: string;
+}
+
+export function parseGitHubRepository(remote: string): string {
+  const match = /github\.com[/:]([^/]+\/[^/]+?)(?:\.git)?$/.exec(remote.trim());
+  if (!match) throw new Error(`RELEASE_REPORT_GITHUB_REPOSITORY_INVALID: invalid GitHub repository remote ${remote}`);
+  return match[1];
+}
+
+export function flattenGitHubPages<T>(value: unknown): T[] {
+  if (!Array.isArray(value)) throw new Error("RELEASE_REPORT_GITHUB_RESPONSE_INVALID: expected an array");
+  if (value.every((page) => Array.isArray(page))) return value.flat() as T[];
+  return value as T[];
+}
+
+export async function fetchGitHubData(options: GitHubDataOptions): Promise<ReleaseReportDataFile> {
+  const cwd = options.cwd ?? process.cwd();
+  const [baselineDate, currentDate] = await Promise.all([
+    gitDate(options.baselineTag, cwd),
+    gitDate(options.currentTag, cwd),
+  ]);
+  const [milestones, pullRequests, issues] = await Promise.all([
+    ghApi<GitHubMilestoneRecord>(`repos/${options.repository}/milestones?state=all&per_page=100`),
+    ghApi<GitHubPullRequestRecord>(`repos/${options.repository}/pulls?state=closed&base=main&per_page=100`),
+    ghApi<GitHubIssueRecord>(`repos/${options.repository}/issues?state=closed&since=${encodeURIComponent(baselineDate)}&per_page=100`),
+  ]);
+
+  const activity: GitHubActivitySnapshot = {
+    baselineDate,
+    currentDate,
+    pullRequests,
+    issues,
+  };
+  return { milestones, activity };
+}
+
+export async function repositoryFromGitRemote(cwd = process.cwd()): Promise<string> {
+  const remote = await runCommand("git", ["config", "--get", "remote.origin.url"], cwd);
+  return parseGitHubRepository(remote.trim());
+}
+
+async function ghApi<T>(endpoint: string): Promise<T[]> {
+  const output = await runCommand("gh", ["api", "--paginate", "--slurp", endpoint], process.cwd());
+  return flattenGitHubPages<T>(JSON.parse(output));
+}
+
+async function gitDate(tag: string, cwd: string): Promise<string> {
+  return (await runCommand("git", ["show", "-s", "--format=%cI", tag], cwd)).trim();
+}
+
+async function runCommand(command: string, args: string[], cwd: string): Promise<string> {
+  try {
+    const result = await execFileAsync(command, args, {
+      cwd,
+      maxBuffer: 16 * 1024 * 1024,
+      encoding: "utf8",
+    });
+    return result.stdout;
+  } catch (error) {
+    const stderr = error && typeof error === "object" && "stderr" in error
+      ? String(error.stderr)
+      : String(error);
+    throw new Error(`RELEASE_REPORT_COMMAND_FAILED: ${command} ${args.join(" ")}\n${stderr.trim()}`);
+  }
+}

--- a/scripts/release-report/metrics.ts
+++ b/scripts/release-report/metrics.ts
@@ -1,0 +1,177 @@
+export interface CoverageMetricInput {
+  total: number;
+  covered: number;
+  skipped: number;
+  pct: number;
+}
+
+export interface CoverageSummaryInput {
+  lines?: CoverageMetricInput;
+  statements?: CoverageMetricInput;
+  functions: CoverageMetricInput;
+}
+
+export interface CoverageMetric {
+  current: number;
+  baseline: number;
+  delta: number;
+}
+
+export interface CoverageMetrics {
+  statements: CoverageMetric;
+  functions: CoverageMetric;
+}
+
+export interface RoadmapProgress {
+  completed: number;
+  total: number;
+  percentage: number | null;
+}
+
+export interface PullRequestActivity {
+  number: number;
+  authorLogin: string;
+  authorType: string;
+  merged: boolean;
+}
+
+export interface ActivityInput {
+  pullRequests: PullRequestActivity[];
+  closedIssues: number;
+}
+
+export interface ContributorActivity {
+  login: string;
+  mergedPullRequests: number;
+}
+
+export interface ActivityMetrics {
+  mergedPullRequests: number;
+  closedIssues: number;
+  humanContributors: number;
+  botContributors: number;
+  contributors: ContributorActivity[];
+}
+
+interface ReleaseVersion {
+  tag: string;
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+export function isMilestoneRelease(tag: string): boolean {
+  const version = parseReleaseVersion(tag);
+  return version?.patch === 0;
+}
+
+export function selectPreviousMilestoneTag(currentTag: string, tags: string[]): string {
+  const current = parseReleaseVersion(currentTag);
+  if (!current || current.patch !== 0) {
+    throw new Error(`RELEASE_REPORT_MILESTONE_REQUIRED: ${currentTag}`);
+  }
+
+  const previous = tags
+    .map(parseReleaseVersion)
+    .filter((version): version is ReleaseVersion => version !== undefined)
+    .filter((version) => version.patch === 0 && compareVersions(version, current) < 0)
+    .sort(compareVersions)
+    .at(-1);
+
+  if (!previous) {
+    throw new Error(`RELEASE_REPORT_PREVIOUS_MILESTONE_TAG_REQUIRED: previous milestone tag required for ${currentTag}`);
+  }
+  return previous.tag;
+}
+
+export function calculateCoverageMetrics(
+  current: CoverageSummaryInput,
+  baseline: CoverageSummaryInput,
+): CoverageMetrics {
+  const currentStatements = current.statements ?? current.lines;
+  const baselineStatements = baseline.statements ?? baseline.lines;
+  if (!currentStatements || !baselineStatements) {
+    throw new Error("RELEASE_REPORT_COVERAGE_MISSING: statements or lines coverage is required");
+  }
+
+  return {
+    statements: percentageDelta(currentStatements.pct, baselineStatements.pct),
+    functions: percentageDelta(current.functions.pct, baseline.functions.pct),
+  };
+}
+
+export function calculateRoadmapProgress(input: {
+  completed: number;
+  total: number;
+}): RoadmapProgress {
+  if (!Number.isInteger(input.completed) || input.completed < 0) {
+    throw new Error("RELEASE_REPORT_ROADMAP_INVALID: completed must be a non-negative integer");
+  }
+  if (!Number.isInteger(input.total) || input.total < input.completed) {
+    throw new Error("RELEASE_REPORT_ROADMAP_INVALID: total must contain completed items");
+  }
+
+  return {
+    completed: input.completed,
+    total: input.total,
+    percentage: input.total === 0 ? null : round(input.completed / input.total * 100),
+  };
+}
+
+export function calculateActivityMetrics(input: ActivityInput): ActivityMetrics {
+  const humanContributors = new Map<string, number>();
+  const botContributors = new Set<string>();
+  const mergedPullRequests = input.pullRequests.filter((pullRequest) => pullRequest.merged);
+
+  for (const pullRequest of mergedPullRequests) {
+    if (isBotAccount(pullRequest.authorLogin, pullRequest.authorType)) {
+      botContributors.add(pullRequest.authorLogin);
+      continue;
+    }
+    humanContributors.set(
+      pullRequest.authorLogin,
+      (humanContributors.get(pullRequest.authorLogin) ?? 0) + 1,
+    );
+  }
+
+  return {
+    mergedPullRequests: mergedPullRequests.length,
+    closedIssues: input.closedIssues,
+    humanContributors: humanContributors.size,
+    botContributors: botContributors.size,
+    contributors: [...humanContributors.entries()]
+      .map(([login, mergedPullRequests]) => ({ login, mergedPullRequests }))
+      .sort((left, right) => left.login.localeCompare(right.login)),
+  };
+}
+
+function parseReleaseVersion(tag: string): ReleaseVersion | undefined {
+  const match = /^v(\d+)\.(\d+)\.(\d+)$/.exec(tag);
+  if (!match) return undefined;
+  return {
+    tag,
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+}
+
+function compareVersions(left: ReleaseVersion, right: ReleaseVersion): number {
+  return left.major - right.major || left.minor - right.minor || left.patch - right.patch;
+}
+
+function percentageDelta(current: number, baseline: number): CoverageMetric {
+  return {
+    current: round(current),
+    baseline: round(baseline),
+    delta: round(current - baseline),
+  };
+}
+
+function round(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function isBotAccount(login: string, type: string): boolean {
+  return type.toLowerCase() === "bot" || login.toLowerCase().endsWith("[bot]");
+}

--- a/scripts/release-report/report.ts
+++ b/scripts/release-report/report.ts
@@ -1,0 +1,198 @@
+import {
+  calculateActivityMetrics,
+  calculateCoverageMetrics,
+  calculateRoadmapProgress,
+  type ActivityInput,
+  type ActivityMetrics,
+  type CoverageSummaryInput,
+  type CoverageMetrics,
+  type RoadmapProgress,
+  isMilestoneRelease,
+} from "./metrics.js";
+
+export interface RoadmapSource {
+  kind: "github-milestone";
+  number: number;
+  title: string;
+  url: string;
+}
+
+export interface ReleaseReport {
+  schemaVersion: 1;
+  release: {
+    baselineTag: string;
+    currentTag: string;
+  };
+  quality: {
+    coverage: CoverageMetrics;
+  };
+  product: {
+    roadmap: RoadmapProgress & { source: RoadmapSource };
+  };
+  activity: ActivityMetrics;
+}
+
+export interface ReleaseReportInput {
+  baselineTag: string;
+  currentTag: string;
+  coverage: {
+    current: CoverageSummaryInput;
+    baseline: CoverageSummaryInput;
+  };
+  roadmap: {
+    completed: number;
+    total: number;
+    source: RoadmapSource;
+  };
+  activity: ActivityInput;
+}
+
+export function buildReleaseReport(input: ReleaseReportInput): ReleaseReport {
+  if (!isMilestoneRelease(input.currentTag)) {
+    throw new Error(`RELEASE_REPORT_MILESTONE_REQUIRED: ${input.currentTag}`);
+  }
+  if (input.baselineTag === input.currentTag) {
+    throw new Error("RELEASE_REPORT_BASELINE_REQUIRED: baseline and current tags must differ");
+  }
+
+  return {
+    schemaVersion: 1,
+    release: {
+      baselineTag: input.baselineTag,
+      currentTag: input.currentTag,
+    },
+    quality: {
+      coverage: calculateCoverageMetrics(input.coverage.current, input.coverage.baseline),
+    },
+    product: {
+      roadmap: {
+        ...calculateRoadmapProgress(input.roadmap),
+        source: input.roadmap.source,
+      },
+    },
+    activity: calculateActivityMetrics(input.activity),
+  };
+}
+
+export function serializeReleaseReport(report: ReleaseReport): string {
+  return `${JSON.stringify(report, null, 2)}\n`;
+}
+
+export function renderReleaseMarkdown(report: ReleaseReport): string {
+  const { baselineTag, currentTag } = report.release;
+  const { statements, functions } = report.quality.coverage;
+  const { roadmap } = report.product;
+  const { activity } = report;
+  const roadmapPercentage = formatPercentage(roadmap.percentage);
+
+  return [
+    `# Framekit milestone report: ${currentTag}`,
+    "",
+    `Compared with baseline **${baselineTag}**. This report is generated from repository and public GitHub metadata; it does not infer progress from LOC or commit counts.`,
+    "",
+    "## Coverage",
+    "",
+    "| Metric | Current | Baseline | Delta |",
+    "| --- | ---: | ---: | ---: |",
+    `| Statements | ${formatPercentage(statements.current)} | ${formatPercentage(statements.baseline)} | ${formatDelta(statements.delta)} percentage points |`,
+    `| Functions | ${formatPercentage(functions.current)} | ${formatPercentage(functions.baseline)} | ${formatDelta(functions.delta)} percentage points |`,
+    "",
+    "## Product progress",
+    "",
+    `- **Roadmap completion:** ${roadmap.completed} / ${roadmap.total} planned items (${roadmapPercentage}).`,
+    `- **Source:** ${roadmap.source.kind} [${roadmap.source.title}](${roadmap.source.url}) (#${roadmap.source.number}).`,
+    "",
+    "## Community activity",
+    "",
+    `- ${activity.mergedPullRequests} merged PRs, ${activity.closedIssues} closed issues, ${activity.humanContributors} human contributors, and ${activity.botContributors} automated contributors excluded from the human count.`,
+    "",
+    "## Inputs",
+    "",
+    `- Baseline tag: \`${baselineTag}\``,
+    `- Current tag: \`${currentTag}\``,
+    `- Roadmap source: ${roadmap.source.url}`,
+    "",
+  ].join("\n");
+}
+
+export function renderCoverageChart(report: ReleaseReport): string {
+  const { statements, functions } = report.quality.coverage;
+  return svg(
+    `Coverage: ${report.release.currentTag}`,
+    [
+      chartRow("Statements", statements.current, statements.baseline, statements.delta, 40),
+      chartRow("Functions", functions.current, functions.baseline, functions.delta, 100),
+    ].join("\n"),
+  );
+}
+
+export function renderRoadmapChart(report: ReleaseReport): string {
+  const { roadmap } = report.product;
+  const percentage = formatPercentage(roadmap.percentage);
+  const barWidth = roadmap.total === 0 ? 0 : Math.round(360 * roadmap.completed / roadmap.total);
+  return svg(
+    `Roadmap progress: ${report.release.currentTag}`,
+    [
+      `<text x="40" y="58" class="label">${escapeXml(roadmap.source.title)}</text>`,
+      `<rect x="40" y="78" width="360" height="28" rx="14" fill="#e5e7eb"/>`,
+      `<rect x="40" y="78" width="${barWidth}" height="28" rx="14" fill="#2563eb"/>`,
+      `<text x="40" y="145" class="value">${roadmap.completed} / ${roadmap.total}</text>`,
+      `<text x="40" y="174" class="detail">${percentage} complete</text>`,
+    ].join("\n"),
+  );
+}
+
+export function renderContributorsChart(report: ReleaseReport): string {
+  const contributors = report.activity.contributors.slice(0, 10);
+  const rows = contributors.length === 0
+    ? [`<text x="40" y="80" class="detail">No human contributors</text>`]
+    : contributors.flatMap((contributor, index) => {
+      const y = 58 + index * 38;
+      const barWidth = Math.min(360, contributor.mergedPullRequests * 48);
+      return [
+        `<text x="40" y="${y}" class="label">${escapeXml(contributor.login)}</text>`,
+        `<rect x="160" y="${y - 16}" width="${barWidth}" height="20" rx="10" fill="#16a34a"/>`,
+        `<text x="${Math.max(170, 168 + barWidth)}" y="${y}" class="detail">${contributor.mergedPullRequests} merged PRs</text>`,
+      ];
+    });
+  return svg(`Human contributors: ${report.release.currentTag}`, rows.join("\n"));
+}
+
+function chartRow(label: string, current: number, baseline: number, delta: number, y: number): string {
+  return [
+    `<text x="40" y="${y}" class="label">${label}</text>`,
+    `<rect x="160" y="${y - 16}" width="240" height="20" rx="10" fill="#e5e7eb"/>`,
+    `<rect x="160" y="${y - 16}" width="${Math.round(240 * current / 100)}" height="20" rx="10" fill="#2563eb"/>`,
+    `<text x="40" y="${y + 28}" class="detail">${formatPercentage(current)} current · ${formatPercentage(baseline)} baseline · ${formatDelta(delta, true)} pp</text>`,
+  ].join("\n");
+}
+
+function svg(title: string, body: string): string {
+  return [
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 220" role="img" aria-labelledby="title">`,
+    `<title id="title">${escapeXml(title)}</title>`,
+    `<style>.label{font:600 16px sans-serif;fill:#111827}.value{font:700 28px sans-serif;fill:#111827}.detail{font:14px sans-serif;fill:#4b5563}</style>`,
+    body,
+    "</svg>",
+    "",
+  ].join("\n");
+}
+
+function formatPercentage(value: number | null): string {
+  return value === null ? "n/a" : `${value.toFixed(2).replace(/\.00$/, "")}%`;
+}
+
+function formatDelta(value: number, preservePrecision = false): string {
+  const formatted = value.toFixed(2);
+  return `${value >= 0 ? "+" : ""}${preservePrecision ? formatted : formatted.replace(/\.00$/, "")}`;
+}
+
+function escapeXml(value: string): string {
+  return value.replace(/[<>&'"]/g, (character) => ({
+    "<": "&lt;",
+    ">": "&gt;",
+    "&": "&amp;",
+    "'": "&apos;",
+    "\"": "&quot;",
+  })[character] ?? character);
+}

--- a/scripts/release-report/sources.ts
+++ b/scripts/release-report/sources.ts
@@ -8,6 +8,7 @@ import type { RoadmapSource } from "./report.js";
 interface CoverageSummaryJson {
   total?: {
     lines?: unknown;
+    statements?: unknown;
     functions?: unknown;
   };
 }
@@ -42,8 +43,11 @@ export interface GitHubActivitySnapshot {
 export function parseCoverageSummary(value: unknown, label: string): CoverageSummaryInput {
   const summary = value as CoverageSummaryJson | null;
   const lines = readCoverageMetric(summary?.total?.lines, label, "lines");
+  const statements = summary?.total?.statements === undefined
+    ? undefined
+    : readCoverageMetric(summary.total.statements, label, "statements");
   const functions = readCoverageMetric(summary?.total?.functions, label, "functions");
-  return { lines, functions };
+  return { lines, ...(statements ? { statements } : {}), functions };
 }
 
 export function normalizeGitHubActivity(snapshot: GitHubActivitySnapshot): ActivityInput {

--- a/scripts/release-report/sources.ts
+++ b/scripts/release-report/sources.ts
@@ -1,0 +1,122 @@
+import type {
+  ActivityInput,
+  CoverageMetricInput,
+  CoverageSummaryInput,
+} from "./metrics.js";
+import type { RoadmapSource } from "./report.js";
+
+interface CoverageSummaryJson {
+  total?: {
+    lines?: unknown;
+    functions?: unknown;
+  };
+}
+
+export interface GitHubMilestoneRecord {
+  number: number;
+  title: string;
+  html_url: string;
+  open_issues: number;
+  closed_issues: number;
+}
+
+export interface GitHubPullRequestRecord {
+  number: number;
+  user?: { login?: string; type?: string };
+  merged_at?: string | null;
+}
+
+export interface GitHubIssueRecord {
+  number: number;
+  closed_at?: string | null;
+  pull_request?: unknown;
+}
+
+export interface GitHubActivitySnapshot {
+  baselineDate: string;
+  currentDate: string;
+  pullRequests: GitHubPullRequestRecord[];
+  issues: GitHubIssueRecord[];
+}
+
+export function parseCoverageSummary(value: unknown, label: string): CoverageSummaryInput {
+  const summary = value as CoverageSummaryJson | null;
+  const lines = readCoverageMetric(summary?.total?.lines, label, "lines");
+  const functions = readCoverageMetric(summary?.total?.functions, label, "functions");
+  return { lines, functions };
+}
+
+export function normalizeGitHubActivity(snapshot: GitHubActivitySnapshot): ActivityInput {
+  const baseline = parseDate(snapshot.baselineDate, "baseline tag");
+  const current = parseDate(snapshot.currentDate, "current tag");
+  if (baseline >= current) {
+    throw new Error("RELEASE_REPORT_ACTIVITY_WINDOW_INVALID: current must follow baseline");
+  }
+
+  const pullRequests = snapshot.pullRequests
+    .filter((pullRequest) => isWithinWindow(pullRequest.merged_at, baseline, current))
+    .map((pullRequest) => ({
+      number: pullRequest.number,
+      authorLogin: pullRequest.user?.login ?? "unknown",
+      authorType: pullRequest.user?.type ?? "User",
+      merged: true,
+    }));
+  const closedIssues = snapshot.issues.filter((issue) =>
+    issue.pull_request === undefined
+    && isWithinWindow(issue.closed_at, baseline, current),
+  ).length;
+
+  return { pullRequests, closedIssues };
+}
+
+export function selectGitHubMilestone(
+  milestones: GitHubMilestoneRecord[],
+  currentTag: string,
+): RoadmapSource {
+  const expectedTitle = `Release for ${currentTag}`;
+  const milestone = milestones.find((candidate) => candidate.title === expectedTitle);
+  if (!milestone) {
+    throw new Error(`RELEASE_REPORT_MILESTONE_NOT_FOUND: ${expectedTitle}`);
+  }
+  return {
+    kind: "github-milestone",
+    number: milestone.number,
+    title: milestone.title,
+    url: milestone.html_url,
+  };
+}
+
+function readCoverageMetric(value: unknown, label: string, metric: string): CoverageMetricInput {
+  const candidate = value as Partial<CoverageMetricInput> | null;
+  if (
+    !candidate
+    || !isFiniteNumber(candidate.total)
+    || !isFiniteNumber(candidate.covered)
+    || !isFiniteNumber(candidate.skipped)
+    || !isFiniteNumber(candidate.pct)
+  ) {
+    throw new Error(`RELEASE_REPORT_${label.toUpperCase()}_COVERAGE_INVALID: missing ${metric} totals`);
+  }
+  return {
+    total: candidate.total,
+    covered: candidate.covered,
+    skipped: candidate.skipped,
+    pct: candidate.pct,
+  };
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function parseDate(value: string, label: string): number {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) throw new Error(`RELEASE_REPORT_DATE_INVALID: ${label}`);
+  return parsed;
+}
+
+function isWithinWindow(value: string | null | undefined, baseline: number, current: number): boolean {
+  if (!value) return false;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) && parsed > baseline && parsed <= current;
+}

--- a/tests/release-report/artifacts.test.ts
+++ b/tests/release-report/artifacts.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { access, mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { writeReleaseReportArtifacts } from "../../scripts/release-report/artifacts.js";
+import { buildReleaseReport } from "../../scripts/release-report/report.js";
+
+test("release report artifacts follow the attachment contract", async () => {
+  const report = buildReleaseReport({
+    baselineTag: "v0.1.0",
+    currentTag: "v0.2.0",
+    coverage: {
+      current: {
+        lines: { total: 10, covered: 8, skipped: 0, pct: 80 },
+        functions: { total: 4, covered: 3, skipped: 0, pct: 75 },
+      },
+      baseline: {
+        lines: { total: 10, covered: 7, skipped: 0, pct: 70 },
+        functions: { total: 4, covered: 2, skipped: 0, pct: 50 },
+      },
+    },
+    roadmap: {
+      completed: 1,
+      total: 2,
+      source: { kind: "github-milestone", number: 1, title: "Release for v0.2.0", url: "https://example/1" },
+    },
+    activity: { pullRequests: [], closedIssues: 0 },
+  });
+  const directory = await mkdtemp(join(tmpdir(), "framekit-release-report-"));
+
+  const paths = await writeReleaseReportArtifacts(report, directory);
+
+  for (const path of [
+    paths.reportJson,
+    paths.reportMarkdown,
+    paths.charts.coverage,
+    paths.charts.roadmapProgress,
+    paths.charts.contributors,
+  ]) {
+    await access(path);
+  }
+  assert.deepEqual(JSON.parse(await readFile(paths.reportJson, "utf8")), report);
+  assert.match(await readFile(paths.reportMarkdown, "utf8"), /Framekit milestone report/);
+  assert.match(await readFile(paths.charts.coverage, "utf8"), /<svg/);
+});

--- a/tests/release-report/cli.test.ts
+++ b/tests/release-report/cli.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseReleaseReportArgs } from "../../scripts/release-report/args.js";
+
+test("release report CLI accepts explicit reproducible inputs", () => {
+  assert.deepEqual(
+    parseReleaseReportArgs([
+      "--baseline-tag", "v0.1.0",
+      "--current-tag", "v0.2.0",
+      "--baseline-coverage", "baseline.json",
+      "--current-coverage", "current.json",
+      "--data-file", "github.json",
+      "--output-dir", "artifacts/release-report",
+    ], "default-output"),
+    {
+      baselineTag: "v0.1.0",
+      currentTag: "v0.2.0",
+      baselineCoveragePath: "baseline.json",
+      currentCoveragePath: "current.json",
+      dataFilePath: "github.json",
+      outputDirectory: "artifacts/release-report",
+    },
+  );
+});
+
+test("release report CLI rejects missing, duplicate, and unsupported arguments", () => {
+  for (const args of [
+    [],
+    ["--baseline-tag", "v0.1.0"],
+    ["--baseline-tag", "v0.1.0", "--current-tag", "v0.2.0", "--current-tag", "v0.3.0"],
+    ["--baseline-tag", "v0.1.0", "--current-tag", "v0.2.0", "--unsupported"],
+  ]) {
+    assert.throws(() => parseReleaseReportArgs(args, "default-output"), /USAGE:/, args.join(" "));
+  }
+});

--- a/tests/release-report/generate.test.ts
+++ b/tests/release-report/generate.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { generateReleaseReport } from "../../scripts/generate-release-report.js";
+
+test("release report command regenerates all artifacts from explicit local inputs", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "framekit-release-report-cli-"));
+  const currentCoveragePath = join(directory, "current.json");
+  const baselineCoveragePath = join(directory, "baseline.json");
+  const dataFilePath = join(directory, "github.json");
+  const outputDirectory = join(directory, "artifacts");
+  const coverage = (lines: number, functions: number) => ({
+    total: {
+      lines: { total: 10, covered: lines, skipped: 0, pct: lines * 10 },
+      functions: { total: 4, covered: functions, skipped: 0, pct: functions * 25 },
+    },
+  });
+  await writeFile(currentCoveragePath, JSON.stringify(coverage(8, 3)));
+  await writeFile(baselineCoveragePath, JSON.stringify(coverage(7, 2)));
+  await writeFile(dataFilePath, JSON.stringify({
+    milestones: [{ number: 1, title: "Release for v0.2.0", html_url: "https://example/1", open_issues: 1, closed_issues: 2 }],
+    activity: {
+      baselineDate: "2026-01-01T00:00:00Z",
+      currentDate: "2026-02-01T00:00:00Z",
+      pullRequests: [],
+      issues: [],
+    },
+  }));
+
+  const paths = await generateReleaseReport({
+    baselineTag: "v0.1.0",
+    currentTag: "v0.2.0",
+    baselineCoveragePath,
+    currentCoveragePath,
+    dataFilePath,
+    outputDirectory,
+  });
+
+  const report = JSON.parse(await readFile(paths.reportJson, "utf8")) as {
+    release: { baselineTag: string; currentTag: string };
+    product: { roadmap: { completed: number; total: number } };
+  };
+  assert.deepEqual(report.release, { baselineTag: "v0.1.0", currentTag: "v0.2.0" });
+  assert.deepEqual(report.product.roadmap, {
+    completed: 2,
+    total: 3,
+    percentage: 66.67,
+    source: { kind: "github-milestone", number: 1, title: "Release for v0.2.0", url: "https://example/1" },
+  });
+});

--- a/tests/release-report/generator.test.ts
+++ b/tests/release-report/generator.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildReportFromData } from "../../scripts/release-report/generator.js";
+
+test("generator combines coverage, milestone, and activity snapshots", () => {
+  const report = buildReportFromData({
+    baselineTag: "v0.1.0",
+    currentTag: "v0.2.0",
+    currentCoverage: {
+      total: {
+        lines: { total: 100, covered: 80, skipped: 0, pct: 80 },
+        functions: { total: 20, covered: 15, skipped: 0, pct: 75 },
+      },
+    },
+    baselineCoverage: {
+      total: {
+        lines: { total: 80, covered: 56, skipped: 0, pct: 70 },
+        functions: { total: 10, covered: 6, skipped: 0, pct: 60 },
+      },
+    },
+    data: {
+      milestones: [
+        { number: 7, title: "Release for v0.2.0", html_url: "https://example/7", open_issues: 5, closed_issues: 18 },
+      ],
+      activity: {
+        baselineDate: "2026-01-01T00:00:00Z",
+        currentDate: "2026-02-01T00:00:00Z",
+        pullRequests: [
+          { number: 10, user: { login: "alice", type: "User" }, merged_at: "2026-01-15T00:00:00Z" },
+        ],
+        issues: [{ number: 11, closed_at: "2026-01-20T00:00:00Z" }],
+      },
+    },
+  });
+
+  assert.equal(report.product.roadmap.completed, 18);
+  assert.equal(report.product.roadmap.total, 23);
+  assert.equal(report.activity.mergedPullRequests, 1);
+  assert.equal(report.activity.closedIssues, 1);
+  assert.equal(report.quality.coverage.statements.delta, 10);
+});

--- a/tests/release-report/github.test.ts
+++ b/tests/release-report/github.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { flattenGitHubPages, parseGitHubRepository } from "../../scripts/release-report/github.js";
+
+test("GitHub repository parsing supports SSH and HTTPS remotes", () => {
+  assert.equal(parseGitHubRepository("git@github.com:morshoto/framekit.git"), "morshoto/framekit");
+  assert.equal(parseGitHubRepository("https://github.com/morshoto/framekit"), "morshoto/framekit");
+  assert.throws(() => parseGitHubRepository("https://example.com/other/repo"), /GitHub repository/i);
+});
+
+test("GitHub pagination normalization flattens slurped pages", () => {
+  assert.deepEqual(flattenGitHubPages([[{ id: 1 }], [{ id: 2 }, { id: 3 }]]), [{ id: 1 }, { id: 2 }, { id: 3 }]);
+  assert.deepEqual(flattenGitHubPages([{ id: 4 }]), [{ id: 4 }]);
+});

--- a/tests/release-report/metrics.test.ts
+++ b/tests/release-report/metrics.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  calculateActivityMetrics,
+  calculateCoverageMetrics,
+  calculateRoadmapProgress,
+  isMilestoneRelease,
+  selectPreviousMilestoneTag,
+} from "../../scripts/release-report/metrics.js";
+
+test("milestone releases are patch-zero tags only", () => {
+  assert.equal(isMilestoneRelease("v0.2.0"), true);
+  assert.equal(isMilestoneRelease("v1.0.0"), true);
+  assert.equal(isMilestoneRelease("v0.2.1"), false);
+  assert.equal(isMilestoneRelease("not-a-release"), false);
+});
+
+test("previous milestone selection is deterministic and excludes patch releases", () => {
+  assert.equal(
+    selectPreviousMilestoneTag("v0.2.0", ["v0.1.0", "v0.1.1", "v0.2.0", "v0.0.0"]),
+    "v0.1.0",
+  );
+  assert.throws(
+    () => selectPreviousMilestoneTag("v0.0.0", ["v0.0.0"]),
+    /previous milestone tag/i,
+  );
+});
+
+test("coverage metrics include current values and percentage-point deltas", () => {
+  assert.deepEqual(
+    calculateCoverageMetrics(
+      {
+        lines: { total: 100, covered: 80, skipped: 0, pct: 80 },
+        functions: { total: 20, covered: 15, skipped: 0, pct: 75 },
+      },
+      {
+        lines: { total: 80, covered: 56, skipped: 0, pct: 70 },
+        functions: { total: 10, covered: 6, skipped: 0, pct: 60 },
+      },
+    ),
+    {
+      statements: { current: 80, baseline: 70, delta: 10 },
+      functions: { current: 75, baseline: 60, delta: 15 },
+    },
+  );
+});
+
+test("roadmap progress reports completed, total, and meaningful percentage", () => {
+  assert.deepEqual(calculateRoadmapProgress({ completed: 18, total: 23 }), {
+    completed: 18,
+    total: 23,
+    percentage: 78.26,
+  });
+  assert.deepEqual(calculateRoadmapProgress({ completed: 0, total: 0 }), {
+    completed: 0,
+    total: 0,
+    percentage: null,
+  });
+});
+
+test("activity metrics exclude bot accounts from human contributor counts", () => {
+  assert.deepEqual(
+    calculateActivityMetrics({
+      pullRequests: [
+        { number: 1, authorLogin: "alice", authorType: "User", merged: true },
+        { number: 2, authorLogin: "dependabot[bot]", authorType: "Bot", merged: true },
+        { number: 3, authorLogin: "renovate[bot]", authorType: "User", merged: true },
+        { number: 4, authorLogin: "alice", authorType: "User", merged: true },
+      ],
+      closedIssues: 3,
+    }),
+    {
+      mergedPullRequests: 4,
+      closedIssues: 3,
+      humanContributors: 1,
+      botContributors: 2,
+      contributors: [{ login: "alice", mergedPullRequests: 2 }],
+    },
+  );
+});

--- a/tests/release-report/rendering.test.ts
+++ b/tests/release-report/rendering.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildReleaseReport,
+  renderContributorsChart,
+  renderCoverageChart,
+  renderReleaseMarkdown,
+  renderRoadmapChart,
+  serializeReleaseReport,
+} from "../../scripts/release-report/report.js";
+
+function report() {
+  return buildReleaseReport({
+    baselineTag: "v0.1.0",
+    currentTag: "v0.2.0",
+    coverage: {
+      current: {
+        lines: { total: 100, covered: 80, skipped: 0, pct: 80 },
+        functions: { total: 20, covered: 15, skipped: 0, pct: 75 },
+      },
+      baseline: {
+        lines: { total: 80, covered: 56, skipped: 0, pct: 70 },
+        functions: { total: 10, covered: 6, skipped: 0, pct: 60 },
+      },
+    },
+    roadmap: {
+      completed: 18,
+      total: 23,
+      source: {
+        kind: "github-milestone",
+        number: 7,
+        title: "Release for v0.2.0",
+        url: "https://github.com/morshoto/framekit/milestone/7",
+      },
+    },
+    activity: {
+      pullRequests: [
+        { number: 1, authorLogin: "alice", authorType: "User", merged: true },
+        { number: 2, authorLogin: "alice", authorType: "User", merged: true },
+      ],
+      closedIssues: 4,
+    },
+  });
+}
+
+test("release report serializes stable machine-readable metrics", () => {
+  const first = serializeReleaseReport(report());
+  const second = serializeReleaseReport(report());
+
+  assert.equal(first, second);
+  assert.deepEqual(JSON.parse(first).release, {
+    baselineTag: "v0.1.0",
+    currentTag: "v0.2.0",
+  });
+  assert.equal(JSON.parse(first).quality.coverage.statements.delta, 10);
+  assert.doesNotMatch(first, /\/Users\/|\/private\/|generatedAt/);
+});
+
+test("release Markdown summarizes auditable quality, product, and activity metrics", () => {
+  const markdown = renderReleaseMarkdown(report());
+
+  assert.match(markdown, /# Framekit milestone report: v0\.2\.0/);
+  assert.match(markdown, /Coverage.*80%.*70%.*\+10 percentage points/s);
+  assert.match(markdown, /18 \/ 23.*78\.26%/);
+  assert.match(markdown, /2 merged PRs.*1 human contributors/);
+  assert.match(markdown, /github-milestone/);
+  assert.match(markdown, /https:\/\/github\.com\/morshoto\/framekit\/milestone\/7/);
+});
+
+test("charts are deterministic SVG projections of the report data", () => {
+  const current = report();
+  assert.match(renderCoverageChart(current), /^<svg[^>]+viewBox=/);
+  assert.match(renderCoverageChart(current), /80%/);
+  assert.match(renderCoverageChart(current), /\+10\.00 pp/);
+  assert.match(renderRoadmapChart(current), /18 \/ 23/);
+  assert.match(renderRoadmapChart(current), /78\.26%/);
+  assert.match(renderContributorsChart(current), /alice/);
+  assert.match(renderContributorsChart(current), /merged PRs/);
+  for (const chart of [
+    renderCoverageChart(current),
+    renderRoadmapChart(current),
+    renderContributorsChart(current),
+  ]) {
+    assert.match(chart, /xmlns="http:\/\/www\.w3\.org\/2000\/svg"/);
+    assert.doesNotMatch(chart, /<script|onload=/i);
+  }
+});

--- a/tests/release-report/sources.test.ts
+++ b/tests/release-report/sources.test.ts
@@ -25,6 +25,18 @@ test("coverage source accepts c8 JSON summary totals", () => {
   );
 });
 
+test("coverage source preserves c8 statement totals", () => {
+  const parsed = parseCoverageSummary({
+    total: {
+      lines: { total: 100, covered: 80, skipped: 0, pct: 80 },
+      statements: { total: 120, covered: 66, skipped: 0, pct: 55 },
+      functions: { total: 20, covered: 15, skipped: 0, pct: 75 },
+    },
+  }, "current");
+
+  assert.deepEqual(parsed.statements, { total: 120, covered: 66, skipped: 0, pct: 55 });
+});
+
 test("GitHub activity is restricted to the exact milestone tag window", () => {
   assert.deepEqual(
     normalizeGitHubActivity({

--- a/tests/release-report/sources.test.ts
+++ b/tests/release-report/sources.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  normalizeGitHubActivity,
+  parseCoverageSummary,
+  selectGitHubMilestone,
+} from "../../scripts/release-report/sources.js";
+
+test("coverage source accepts c8 JSON summary totals", () => {
+  assert.deepEqual(
+    parseCoverageSummary({
+      total: {
+        lines: { total: 100, covered: 80, skipped: 0, pct: 80 },
+        functions: { total: 20, covered: 15, skipped: 0, pct: 75 },
+      },
+    }, "current"),
+    {
+      lines: { total: 100, covered: 80, skipped: 0, pct: 80 },
+      functions: { total: 20, covered: 15, skipped: 0, pct: 75 },
+    },
+  );
+  assert.throws(
+    () => parseCoverageSummary({ total: { lines: {} } }, "baseline"),
+    /baseline.*coverage/i,
+  );
+});
+
+test("GitHub activity is restricted to the exact milestone tag window", () => {
+  assert.deepEqual(
+    normalizeGitHubActivity({
+      baselineDate: "2026-01-01T00:00:00Z",
+      currentDate: "2026-02-01T00:00:00Z",
+      pullRequests: [
+        { number: 1, user: { login: "alice", type: "User" }, merged_at: "2026-01-15T00:00:00Z" },
+        { number: 2, user: { login: "bob", type: "User" }, merged_at: "2026-02-02T00:00:00Z" },
+        { number: 3, user: { login: "bot[bot]", type: "Bot" }, merged_at: "2026-01-20T00:00:00Z" },
+      ],
+      issues: [
+        { number: 4, closed_at: "2026-01-20T00:00:00Z" },
+        { number: 5, closed_at: "2026-01-20T00:00:00Z", pull_request: {} },
+        { number: 6, closed_at: "2026-02-03T00:00:00Z" },
+      ],
+    }),
+    {
+      pullRequests: [
+        { number: 1, authorLogin: "alice", authorType: "User", merged: true },
+        { number: 3, authorLogin: "bot[bot]", authorType: "Bot", merged: true },
+      ],
+      closedIssues: 1,
+    },
+  );
+});
+
+test("GitHub milestone selection uses an explicit release title", () => {
+  assert.deepEqual(
+    selectGitHubMilestone([
+      { number: 1, title: "Release for v0.1.0", html_url: "https://example/1", open_issues: 2, closed_issues: 3 },
+      { number: 2, title: "Release for v0.2.0", html_url: "https://example/2", open_issues: 5, closed_issues: 18 },
+    ], "v0.2.0"),
+    {
+      kind: "github-milestone",
+      number: 2,
+      title: "Release for v0.2.0",
+      url: "https://example/2",
+    },
+  );
+  assert.throws(
+    () => selectGitHubMilestone([], "v0.2.0"),
+    /milestone.*v0\.2\.0/i,
+  );
+});

--- a/tests/release-report/workflow.test.ts
+++ b/tests/release-report/workflow.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("release workflow runs the report only for milestone releases", async () => {
+  const workflow = await readFile(".github/workflows/release.yml", "utf8");
+  const packageJson = JSON.parse(await readFile("package.json", "utf8")) as {
+    scripts?: Record<string, string>;
+  };
+
+  assert.equal(packageJson.scripts?.["release-report"], "tsx scripts/generate-release-report.ts");
+  assert.match(packageJson.scripts?.["test:coverage"] ?? "", /c8 .*json-summary/);
+  assert.match(workflow, /milestone-release: \$\{\{ steps\.classify\.outputs\.milestone \}\}/);
+  assert.match(workflow, /name: Classify milestone release/);
+  assert.match(workflow, /v\[0-9\].*\[0-9\].*\.0/);
+  assert.match(workflow, /milestone-report:/);
+  assert.match(workflow, /if: needs\.tagpr\.outputs\.milestone-release == 'true'/);
+  assert.match(workflow, /pnpm run test:coverage/);
+  assert.match(workflow, /git worktree add --detach/);
+  assert.match(workflow, /pnpm run release-report/);
+  assert.match(workflow, /gh release upload/);
+  assert.match(workflow, /report\.json/);
+  assert.match(workflow, /report\.md/);
+  assert.match(workflow, /coverage\.svg/);
+  assert.match(workflow, /roadmap-progress\.svg/);
+  assert.match(workflow, /contributors\.svg/);
+  assert.match(workflow, /name: Skip milestone report for patch release/);
+
+  const publishJob = workflow.slice(workflow.indexOf("publish-npm:"));
+  assert.match(publishJob, /- milestone-report/);
+});

--- a/tests/release-report/workflow.test.ts
+++ b/tests/release-report/workflow.test.ts
@@ -26,6 +26,17 @@ test("release workflow runs the report only for milestone releases", async () =>
   assert.match(workflow, /contributors\.svg/);
   assert.match(workflow, /name: Skip milestone report for patch release/);
 
+  const baselineSelectionStart = workflow.indexOf("mapfile -t milestone_tags");
+  const baselineSelectionEnd = workflow.indexOf("current_coverage", baselineSelectionStart);
+  const baselineSelection = workflow.slice(baselineSelectionStart, baselineSelectionEnd);
+  assert.match(baselineSelection, /--sort=v:refname/);
+  assert.match(
+    baselineSelection,
+    /if \[ "\$\{candidate\}" = "\$\{RELEASE_TAG\}" \]; then\n\s+break/,
+  );
+  assert.match(baselineSelection, /break[\s\S]*baseline_tag="\$\{candidate\}"/);
+  assert.doesNotMatch(baselineSelection, /candidate\}" != "\$\{RELEASE_TAG\}/);
+
   const publishJob = workflow.slice(workflow.indexOf("publish-npm:"));
   assert.match(publishJob, /- milestone-report/);
 });


### PR DESCRIPTION
Closes #235

## Summary

- Add a reproducible `scripts/generate-release-report.ts` command.
- Produce deterministic `report.json`, `report.md`, and three SVG charts from the same report model.
- Collect c8 statement/function coverage for current and baseline milestone revisions and report percentage-point deltas.
- Derive roadmap completion from the matching GitHub milestone and activity from the exact tag window, excluding bot contributors from human counts.
- Run and upload the report only for patch-zero milestone releases; patch releases keep the lightweight flow.
- Document local regeneration with explicit inputs and optional offline GitHub snapshots.

## TDD evidence

The branch preserves Red/Green progression in short commits using the requested `update:` prefix. Tests cover:

- milestone tag classification and previous-baseline selection;
- c8 coverage parsing and deltas;
- roadmap completion and bot-safe contributor metrics;
- deterministic Markdown/JSON/SVG output;
- GitHub pagination, milestone selection, and exact tag-window filtering;
- artifact paths and release-workflow milestone/patch behavior.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm run test` — 719 passed
- `pnpm run check:boundaries`
- `C8_REPORTS_DIR=<temporary directory> pnpm run test:coverage` — passed; report modules measured 91.22% statements in that run
- `git diff --check`

No Swift, Xcode, or native adapter files changed, so native validation was not required for this PR.
