### PR TITLE
fix: fail fast when release runner unavailable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,9 +78,34 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.TAGPR_TOKEN }}
 
-  native-release-assets:
+  release-runner-preflight:
     if: needs.tagpr.outputs.release-tag != ''
     needs: tagpr
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Check out workflow revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Verify required release runner
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runners?per_page=100" \
+            | node scripts/check-release-runner.mjs
+
+  native-release-assets:
+    if: needs.tagpr.outputs.release-tag != ''
+    needs:
+      - tagpr
+      - release-runner-preflight
     runs-on: [self-hosted, macOS, framekit-release]
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          gh api "repos/${GITHUB_REPOSITORY}/actions/runners?per_page=100" \
+          gh api --paginate --slurp "repos/${GITHUB_REPOSITORY}/actions/runners?per_page=100" \
             | node scripts/check-release-runner.mjs
 
   native-release-assets:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -34,16 +34,18 @@ repository. The workflow uses GitHub's OIDC identity and does not require an
 2. The `tagpr` job creates the version tag and a draft GitHub release with
    generated notes. If the merge already placed the release tag on `HEAD`,
    the workflow reuses that tag instead of trying to create it again.
-3. The `native-release-assets` job runs on the configured `framekit-release`
-   macOS runner, builds and signs the Final Cut Workflow Extension, and uploads
+3. A hosted preflight checks that a repository-scoped runner is online and idle
+   with the `self-hosted`, `macOS`, and `framekit-release` labels.
+4. The `native-release-assets` job runs on that macOS runner, builds and signs
+   the Final Cut Workflow Extension, and uploads
    `FramekitFinalCutWorkflow-<version>.zip` plus its checksum to the draft
    release.
-4. The `publish-npm` job installs npm 11.5.1, runs the v0.1.6 repository gate,
+5. The `publish-npm` job installs npm 11.5.1, runs the v0.1.6 repository gate,
    publishes the matching package, and verifies the version on the public
    registry. It waits for the native assets to be uploaded.
-5. The workflow verifies the native archive and checksum, then publishes the
+6. The workflow verifies the native archive and checksum, then publishes the
    GitHub release and its notes.
-6. A final provenance gate verifies package, MCP server, plugin, tag, workflow,
+7. A final provenance gate verifies package, MCP server, plugin, tag, workflow,
    GitHub release, npm, native archive, and checksum alignment before the
    workflow can succeed.
 
@@ -53,14 +55,33 @@ available to `codesign`. Configure the `FRAMEKIT_CODESIGN_IDENTITY` secret and
 the optional `FRAMEKIT_NOTARY_PROFILE` repository variable before merging a
 release PR. The runner must be registered with the `framekit-release` label.
 
+The hosted runner preflight fails with `RELEASE_RUNNER_UNAVAILABLE` when no
+online and idle runner has all three required labels. This keeps the release
+draft from waiting indefinitely for a native job that cannot be scheduled.
+
+### Recovering an unavailable release runner
+
+Restore or register the repository-scoped macOS runner, then verify that GitHub
+sees it online and idle with the required labels:
+
+```sh
+gh api 'repos/morshoto/framekit/actions/runners?per_page=100' \
+  --jq '.runners[] | select(.status == "online" and .busy == false) | [.name, (.labels | map(.name) | join(","))] | @tsv'
+```
+
+The output must include `self-hosted`, `macOS`, and `framekit-release` on the
+same runner. After the preflight succeeds, retry the existing release tag using
+the command below; the workflow will rebuild and upload the native assets
+before npm or GitHub publication.
+
 If npm publishing fails, the GitHub release remains a draft so the failure can
 be repaired without presenting an incomplete release as public.
 
 If a retry finds a draft release whose tag is shown as `untagged-*`, the
 workflow associates that draft with the release tag before publishing it.
 
-After repairing the npm Trusted Publisher relationship, retry an existing tag
-without creating a new commit or version:
+After repairing the runner and, if needed, the npm Trusted Publisher
+relationship, retry an existing tag without creating a new commit or version:
 
 ```sh
 gh workflow run release.yml \

--- a/scripts/check-release-runner.d.mts
+++ b/scripts/check-release-runner.d.mts
@@ -1,0 +1,21 @@
+export interface ReleaseRunnerLabel {
+  name?: unknown;
+}
+
+export interface ReleaseRunner {
+  id?: unknown;
+  name?: unknown;
+  status?: unknown;
+  busy?: unknown;
+  labels?: unknown;
+}
+
+export const REQUIRED_RELEASE_RUNNER_LABELS: readonly string[];
+
+export function findAvailableReleaseRunner(
+  runners: unknown,
+): ReleaseRunner | undefined;
+
+export function validateReleaseRunnerAvailability(
+  runners: unknown,
+): ReleaseRunner;

--- a/scripts/check-release-runner.mjs
+++ b/scripts/check-release-runner.mjs
@@ -32,6 +32,17 @@ export function validateReleaseRunnerAvailability(runners) {
   return selected;
 }
 
+function runnersFromApiPayload(payload) {
+  if (!Array.isArray(payload)) {
+    return payload?.runners;
+  }
+
+  const pages = payload.filter((page) => Array.isArray(page?.runners));
+  return pages.length > 0
+    ? pages.flatMap((page) => page.runners)
+    : payload;
+}
+
 async function readStdin() {
   const chunks = [];
   for await (const chunk of process.stdin) {
@@ -42,7 +53,7 @@ async function readStdin() {
 
 async function validateRunnerApiResponse() {
   const payload = JSON.parse(await readStdin());
-  const runners = Array.isArray(payload) ? payload : payload?.runners;
+  const runners = runnersFromApiPayload(payload);
   const selected = validateReleaseRunnerAvailability(runners);
   process.stdout.write(`Release runner available: ${selected.name ?? selected.id}\n`);
 }

--- a/scripts/check-release-runner.mjs
+++ b/scripts/check-release-runner.mjs
@@ -1,0 +1,49 @@
+import { readFile } from "node:fs/promises";
+
+export const REQUIRED_RELEASE_RUNNER_LABELS = Object.freeze([
+  "self-hosted",
+  "macOS",
+  "framekit-release",
+]);
+
+export function findAvailableReleaseRunner(runners) {
+  if (!Array.isArray(runners)) {
+    return undefined;
+  }
+
+  return runners.find((runner) => {
+    if (runner?.status !== "online" || runner?.busy !== false) {
+      return false;
+    }
+
+    return REQUIRED_RELEASE_RUNNER_LABELS.every((requiredLabel) => (
+      Array.isArray(runner.labels)
+      && runner.labels.some((label) => label?.name === requiredLabel)
+    ));
+  });
+}
+
+export function validateReleaseRunnerAvailability(runners) {
+  const selected = findAvailableReleaseRunner(runners);
+  if (!selected) {
+    throw new Error(
+      `RELEASE_RUNNER_UNAVAILABLE: no online and idle repository runner has labels `
+      + `${REQUIRED_RELEASE_RUNNER_LABELS.join(", ")}. Register or start the repository runner before retrying the release.`,
+    );
+  }
+  return selected;
+}
+
+async function validateRunnerApiResponse() {
+  const payload = JSON.parse(await readFile(0, "utf8"));
+  const runners = Array.isArray(payload) ? payload : payload?.runners;
+  const selected = validateReleaseRunnerAvailability(runners);
+  process.stdout.write(`Release runner available: ${selected.name ?? selected.id}\n`);
+}
+
+if (process.argv[1] && new URL(import.meta.url).pathname === process.argv[1]) {
+  validateRunnerApiResponse().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/check-release-runner.mjs
+++ b/scripts/check-release-runner.mjs
@@ -1,5 +1,3 @@
-import { readFile } from "node:fs/promises";
-
 export const REQUIRED_RELEASE_RUNNER_LABELS = Object.freeze([
   "self-hosted",
   "macOS",
@@ -34,8 +32,16 @@ export function validateReleaseRunnerAvailability(runners) {
   return selected;
 }
 
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
 async function validateRunnerApiResponse() {
-  const payload = JSON.parse(await readFile(0, "utf8"));
+  const payload = JSON.parse(await readStdin());
   const runners = Array.isArray(payload) ? payload : payload?.runners;
   const selected = validateReleaseRunnerAvailability(runners);
   process.stdout.write(`Release runner available: ${selected.name ?? selected.id}\n`);

--- a/tests/integration/release-runner.test.ts
+++ b/tests/integration/release-runner.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { findAvailableReleaseRunner } from "../../scripts/check-release-runner.mjs";
+import {
+  findAvailableReleaseRunner,
+  validateReleaseRunnerAvailability,
+} from "../../scripts/check-release-runner.mjs";
 
 const requiredLabels = ["self-hosted", "macOS", "framekit-release"];
 
@@ -36,4 +39,11 @@ test("release runner eligibility requires every release label", () => {
   ]);
 
   assert.equal(selected, undefined);
+});
+
+test("release runner availability explains how to recover", () => {
+  assert.throws(
+    () => validateReleaseRunnerAvailability([]),
+    /RELEASE_RUNNER_UNAVAILABLE:.*self-hosted, macOS, framekit-release.*Register or start the repository runner/i,
+  );
 });

--- a/tests/integration/release-runner.test.ts
+++ b/tests/integration/release-runner.test.ts
@@ -74,6 +74,16 @@ test("release runner checker accepts the API response on stdin", async () => {
   assert.match(result.stdout, /Release runner available: framekit-release-mac/);
 });
 
+test("release runner checker accepts an eligible runner on a later API page", async () => {
+  const result = await runChecker([
+    { runners: [runner({ id: 1, status: "offline" })] },
+    { runners: [runner({ id: 236 })] },
+  ]);
+
+  assert.equal(result.code, 0);
+  assert.match(result.stdout, /Release runner available: framekit-release-mac/);
+});
+
 test("release runner checker fails closed for an empty API response", async () => {
   const result = await runChecker({ runners: [] });
 

--- a/tests/integration/release-runner.test.ts
+++ b/tests/integration/release-runner.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { findAvailableReleaseRunner } from "../../scripts/check-release-runner.mjs";
+
+const requiredLabels = ["self-hosted", "macOS", "framekit-release"];
+
+function runner(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 236,
+    name: "framekit-release-mac",
+    status: "online",
+    busy: false,
+    labels: requiredLabels.map((name) => ({ name })),
+    ...overrides,
+  };
+}
+
+test("release runner eligibility accepts an online idle labeled runner", () => {
+  const selected = findAvailableReleaseRunner([runner()]);
+
+  assert.equal(selected?.id, 236);
+});
+
+test("release runner eligibility ignores busy and offline runners", () => {
+  const selected = findAvailableReleaseRunner([
+    runner({ id: 1, busy: true }),
+    runner({ id: 2, status: "offline" }),
+  ]);
+
+  assert.equal(selected, undefined);
+});
+
+test("release runner eligibility requires every release label", () => {
+  const selected = findAvailableReleaseRunner([
+    runner({ labels: requiredLabels.slice(0, -1).map((name) => ({ name })) }),
+  ]);
+
+  assert.equal(selected, undefined);
+});

--- a/tests/integration/release-runner.test.ts
+++ b/tests/integration/release-runner.test.ts
@@ -1,11 +1,15 @@
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { dirname, resolve } from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 import {
   findAvailableReleaseRunner,
   validateReleaseRunnerAvailability,
 } from "../../scripts/check-release-runner.mjs";
 
 const requiredLabels = ["self-hosted", "macOS", "framekit-release"];
+const checker = resolve(dirname(fileURLToPath(import.meta.url)), "../../scripts/check-release-runner.mjs");
 
 function runner(overrides: Record<string, unknown> = {}) {
   return {
@@ -16,6 +20,21 @@ function runner(overrides: Record<string, unknown> = {}) {
     labels: requiredLabels.map((name) => ({ name })),
     ...overrides,
   };
+}
+
+function runChecker(input: unknown) {
+  return new Promise<{ code: number | null; stderr: string; stdout: string }>((resolveResult, reject) => {
+    const child = spawn(process.execPath, [checker]);
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => { stdout += chunk; });
+    child.stderr.on("data", (chunk: string) => { stderr += chunk; });
+    child.on("error", reject);
+    child.on("close", (code) => resolveResult({ code, stderr, stdout }));
+    child.stdin.end(JSON.stringify(input));
+  });
 }
 
 test("release runner eligibility accepts an online idle labeled runner", () => {
@@ -46,4 +65,18 @@ test("release runner availability explains how to recover", () => {
     () => validateReleaseRunnerAvailability([]),
     /RELEASE_RUNNER_UNAVAILABLE:.*self-hosted, macOS, framekit-release.*Register or start the repository runner/i,
   );
+});
+
+test("release runner checker accepts the API response on stdin", async () => {
+  const result = await runChecker({ runners: [runner()] });
+
+  assert.equal(result.code, 0);
+  assert.match(result.stdout, /Release runner available: framekit-release-mac/);
+});
+
+test("release runner checker fails closed for an empty API response", async () => {
+  const result = await runChecker({ runners: [] });
+
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /RELEASE_RUNNER_UNAVAILABLE/);
 });

--- a/tests/integration/release-workflow.test.ts
+++ b/tests/integration/release-workflow.test.ts
@@ -267,3 +267,14 @@ test("release documentation provides the exact npm trust command", async () => {
   assert.match(documentation, /--allow-publish/);
   assert.match(documentation, /--yes/);
 });
+
+test("release documentation explains native runner preflight recovery", async () => {
+  const documentation = await readFile(resolve(repository, "docs/releasing.md"), "utf8");
+
+  assert.match(documentation, /preflight/i);
+  assert.match(documentation, /online and idle/i);
+  assert.match(documentation, /self-hosted.*macOS.*framekit-release/s);
+  assert.match(documentation, /RELEASE_RUNNER_UNAVAILABLE/);
+  assert.match(documentation, /actions\/runners\?per_page=100/);
+  assert.match(documentation, /retry an exact existing tag/i);
+});

--- a/tests/integration/release-workflow.test.ts
+++ b/tests/integration/release-workflow.test.ts
@@ -152,6 +152,7 @@ test("release workflow preflights the required native runner", async () => {
   assert.match(preflightJob, /actions: read/);
   assert.match(preflightJob, /actions\/checkout@(?:v7|[0-9a-f]{40}[ \t]+# v7)/);
   assert.match(preflightJob, /actions\/runners\?per_page=100/);
+  assert.match(preflightJob, /gh api --paginate --slurp/);
   assert.match(preflightJob, /node scripts\/check-release-runner\.mjs/);
 
   const nativeJob = workflow.slice(nativePackaging, publication);

--- a/tests/integration/release-workflow.test.ts
+++ b/tests/integration/release-workflow.test.ts
@@ -276,5 +276,5 @@ test("release documentation explains native runner preflight recovery", async ()
   assert.match(documentation, /self-hosted.*macOS.*framekit-release/s);
   assert.match(documentation, /RELEASE_RUNNER_UNAVAILABLE/);
   assert.match(documentation, /actions\/runners\?per_page=100/);
-  assert.match(documentation, /retry an exact existing tag/i);
+  assert.match(documentation, /retry the existing release tag/i);
 });

--- a/tests/integration/release-workflow.test.ts
+++ b/tests/integration/release-workflow.test.ts
@@ -137,6 +137,27 @@ test("release workflow gates publication on v0.1.6 evidence and native checksums
   );
 });
 
+test("release workflow preflights the required native runner", async () => {
+  const workflow = await readFile(resolve(repository, ".github/workflows/release.yml"), "utf8");
+  const preflight = workflow.indexOf("release-runner-preflight:");
+  const nativePackaging = workflow.indexOf("native-release-assets:");
+  const publication = workflow.indexOf("publish-npm:");
+
+  assert.notEqual(preflight, -1);
+  assert.ok(preflight < nativePackaging, "runner preflight must precede native packaging");
+  assert.ok(nativePackaging < publication, "native packaging must precede publication");
+
+  const preflightJob = workflow.slice(preflight, nativePackaging);
+  assert.match(preflightJob, /runs-on: ubuntu-latest/);
+  assert.match(preflightJob, /actions: read/);
+  assert.match(preflightJob, /actions\/checkout@(?:v7|[0-9a-f]{40}[ \t]+# v7)/);
+  assert.match(preflightJob, /actions\/runners\?per_page=100/);
+  assert.match(preflightJob, /node scripts\/check-release-runner\.mjs/);
+
+  const nativeJob = workflow.slice(nativePackaging, publication);
+  assert.match(nativeJob, /needs:\s*\n\s+- tagpr\s*\n\s+- release-runner-preflight/);
+});
+
 test("release workflow can retry an exact existing tag", async () => {
   const workflow = await readFile(resolve(repository, ".github/workflows/release.yml"), "utf8");
 


### PR DESCRIPTION
<!-- Title naming policy -->

- [ ] Request PR review
- [ ] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [x] Github issue: Closes: #236

## Summary

<!-- open -->
Added a hosted release-runner preflight that queries the repository Actions API
and requires an online, idle runner with `self-hosted`, `macOS`, and
`framekit-release` labels before native packaging is scheduled. Added a tested
fail-closed checker and documented runner recovery and exact-tag retry steps.
<!-- close -->

## Validation

<!-- open -->
- TDD red checkpoints captured missing checker, missing workflow preflight,
  missing documentation, and broken stdin handling.
- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm run build:package`
- `pnpm run test` (710 passed)
- `pnpm run check:boundaries`
- Workflow YAML parsed with `yq`.
- Live runner API check correctly failed closed: no online and idle eligible
  runner is currently registered.
<!-- close -->

Native checks were not required because no native files changed.

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Public MCP behavior or package interfaces are documented if changed.
- [x] Existing adapters and test fixtures remain compatible, or the migration is explained above.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [x] Documentation reflects the changed release workflow behavior.

## Review notes

The preflight changes an unavailable native release from an indefinite queued job
to an actionable failed workflow while keeping the release draft unpublished.
The external macOS runner still must be restored or registered before a release
can produce native assets; this repository change cannot register that host.
