### PR TITLE
test: complete Basic Editing MVP evaluation

### DIFF
--- a/tests/evaluation/mcp-evaluation.test.ts
+++ b/tests/evaluation/mcp-evaluation.test.ts
@@ -7,14 +7,15 @@ test("deterministic MCP evaluation covers editing workflows and reports actionab
 
   assert.equal(report.correctness.failed, 0);
   assert.equal(report.correctness.rate, 1);
-  assert.equal(report.capability.supported, 14);
-  assert.equal(report.capability.unavailable, 4);
-  assert.equal(report.capability.coverageRate, 14 / 18);
+  assert.equal(report.capability.supported, 15);
+  assert.equal(report.capability.unavailable, 3);
+  assert.equal(report.capability.coverageRate, 15 / 18);
   assert.equal(report.scenarioConsistency.rate, 1);
   assert.deepEqual(Object.keys(report.byCategory).sort(), [
     "editing",
     "failure-path",
     "media",
+    "mvp-workflow",
     "project",
     "publishing",
     "workflow-assets",
@@ -23,9 +24,35 @@ test("deterministic MCP evaluation covers editing workflows and reports actionab
   assert.ok(report.byCategory["failure-path"].total >= 2);
   assert.equal(report.byCategory["workflow-assets"].supported, 3);
   assert.equal(report.byCategory["workflow-assets"].unavailable, 2);
+  assert.equal(report.byCategory["mvp-workflow"].correctnessRate, 1);
   assert.ok(report.scenarios.some((scenario) => scenario.id === "artifact-publish-capability"
     && scenario.intent === "Publish the verified FCPXML artifact as a new project"));
-  assert.equal(report.scenarios.some((scenario) => scenario.id === "export-capability"), false);
+  const mvpWorkflow = report.scenarios.find((scenario) => scenario.id === "basic-editing-mvp-workflow") as
+    | (typeof report.scenarios[number] & { tools?: string[]; operations?: string[] })
+    | undefined;
+  assert.ok(mvpWorkflow?.passed);
+  assert.deepEqual(mvpWorkflow.tools, [
+    "connection.status",
+    "editor.inspect",
+    "project.inspect",
+    "context.inspect",
+    "editor.assets",
+    "editor.timeline.edit.preview",
+    "editor.timeline.edit.execute",
+    "media.inspect",
+    "edit.diff",
+    "edit.verify",
+    "timeline.export",
+    "edit.undo",
+  ]);
+  assert.deepEqual(mvpWorkflow.operations, [
+    "media.import",
+    "timeline.media.add",
+    "trim-clip",
+    "media.import",
+    "timeline.media.add",
+    "timeline.title.add",
+  ]);
   assert.ok(report.scenarios.some((scenario) => scenario.id === "undo-verified" && scenario.passed && scenario.support === "supported"));
 
   const rendered = renderEvaluationReport(report);

--- a/tests/evaluation/mcp-evaluation.test.ts
+++ b/tests/evaluation/mcp-evaluation.test.ts
@@ -58,6 +58,6 @@ test("deterministic MCP evaluation covers editing workflows and reports actionab
   const rendered = renderEvaluationReport(report);
   assert.match(rendered, /MCP evaluation/);
   assert.match(rendered, /correctness_rate=100\.0%/);
-  assert.match(rendered, /capability_coverage=77\.8%/);
+  assert.match(rendered, /capability_coverage=83\.3%/);
   assert.match(rendered, /scenario_consistency_rate=100\.0%/);
 });

--- a/tests/evaluation/suite.ts
+++ b/tests/evaluation/suite.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
+import { writeFile } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import { join } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { FinalCutVideoExporter } from "@framekit/final-cut";
 import { AgentVideoRuntime, type MediaContext } from "@framekit/runtime";
 import { InMemoryEditorAdapter } from "@framekit/testkit";
 import { createMcpServer } from "../../apps/mcp-server/src/server.js";
@@ -8,7 +13,7 @@ import { createMcpServer } from "../../apps/mcp-server/src/server.js";
 type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
 type JsonObject = { [key: string]: JsonValue };
 
-type EvaluationCategory = "project" | "media" | "editing" | "workflow-assets" | "publishing" | "failure-path";
+type EvaluationCategory = "project" | "media" | "editing" | "mvp-workflow" | "workflow-assets" | "publishing" | "failure-path";
 type EvaluationSupport = "supported" | "unavailable";
 
 interface EvaluationExpectation {
@@ -39,6 +44,7 @@ interface EvaluationScenario {
   intent: string;
   expectedTool: string;
   steps: EvaluationStep[];
+  operations?: string[];
 }
 
 const editorTimelineTarget = {
@@ -52,6 +58,8 @@ export interface EvaluationScenarioResult {
   category: EvaluationCategory;
   support: EvaluationSupport;
   intent: string;
+  tools: string[];
+  operations: string[];
   passed: boolean;
   message?: string;
 }
@@ -127,12 +135,82 @@ const scenarios: EvaluationScenario[] = [
     }],
   },
   {
-    id: "media-import-capability",
-    category: "media",
-    support: "unavailable",
-    intent: "Import a new source media item into the project",
-    expectedTool: "media.import",
-    steps: [{ tool: "media.import", expect: { toolAvailable: false } }],
+    id: "basic-editing-mvp-workflow",
+    category: "mvp-workflow",
+    support: "supported",
+    intent: "Execute and verify the deterministic Basic Editing MVP workflow",
+    expectedTool: "edit.undo",
+    operations: [
+      "media.import",
+      "timeline.media.add",
+      "trim-clip",
+      "media.import",
+      "timeline.media.add",
+      "timeline.title.add",
+    ],
+    steps: [
+      { tool: "connection.status", expect: { json: { path: "state", equals: "ready" } } },
+      { tool: "editor.inspect", expect: { json: { path: "capabilities.editor.compositeTransactions", equals: true } } },
+      { tool: "project.inspect", expect: { json: { path: "projectName", equals: "MCP Evaluation Fixture" } } },
+      { tool: "context.inspect", expect: { json: { path: "project.timeline.id", equals: "timeline-evaluation" } } },
+      {
+        tool: "editor.assets",
+        arguments: { kind: "title", query: "lower" },
+        expect: { json: { path: "0.id", equals: "asset-lower-third" } },
+      },
+      {
+        tool: "editor.timeline.edit.preview",
+        arguments: {
+          ...editorTimelineTarget,
+          operations: [
+            { type: "media.import", mediaId: "mvp-video", source: "fixture://evaluation/video.mov", mediaKind: "video", duration: 6, sourceDigest: "sha256:40f61de46d9ff839cbab97b4da386f428b53200f61337118dd28f51b41107e10" },
+            { type: "timeline.media.add", occurrenceId: "mvp-video-occurrence", mediaId: "mvp-video", role: "video", start: 0, duration: 5, targetLane: "primary" },
+            { type: "trim-clip", clipId: "mvp-video-occurrence", duration: 4 },
+            { type: "media.import", mediaId: "mvp-music", source: "fixture://evaluation/music.wav", mediaKind: "audio", duration: 8, sourceDigest: "sha256:fa57a0847530fb480f5fc4df72b925baa1ca2ca1879b7232909bfd90df840b79" },
+            { type: "timeline.media.add", occurrenceId: "mvp-music-occurrence", mediaId: "mvp-music", role: "music", start: 0, duration: 4, targetLane: 1 },
+            { type: "timeline.title.add", occurrenceId: "mvp-title-occurrence", assetId: "asset-lower-third", text: "Framekit MVP", start: 1, duration: 2, targetLane: 2 },
+          ],
+        },
+        expect: { json: { path: "previewToken", includes: "preview-" } },
+        capture: { name: "previewToken", path: "previewToken" },
+      },
+      {
+        tool: "editor.timeline.edit.execute",
+        arguments: { previewToken: "$previewToken" },
+        expect: { json: { path: "status", equals: "VERIFIED" } },
+        capture: { name: "transactionId", path: "id" },
+      },
+      {
+        tool: "media.inspect",
+        arguments: { mediaId: "mvp-video" },
+        expect: { json: { path: "source", equals: "fixture://evaluation/video.mov" } },
+      },
+      {
+        tool: "edit.diff",
+        arguments: { transactionId: "$transactionId" },
+        expect: { json: { path: "added.0.itemId", equals: "mvp-video-occurrence" } },
+      },
+      {
+        tool: "edit.verify",
+        arguments: { transactionId: "$transactionId" },
+        expect: { json: { path: "passed", equals: true } },
+      },
+      {
+        tool: "timeline.export",
+        arguments: {
+          outputPath: "$outputPath",
+          preset: "master",
+          transactionId: "$transactionId",
+          expected: { durationSeconds: 12, hasAudio: true },
+        },
+        expect: { json: { path: "verified", equals: true } },
+      },
+      {
+        tool: "edit.undo",
+        arguments: { transactionId: "$transactionId" },
+        expect: { json: { path: "media.2.mediaId", equals: "media-music" } },
+      },
+    ],
   },
   {
     id: "rename-clip-and-verify",
@@ -392,8 +470,24 @@ export function renderEvaluationReport(report: EvaluationReport): string {
 async function runScenario(scenario: EvaluationScenario): Promise<EvaluationScenarioResult> {
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   const client = new Client({ name: "framekit-evaluation", version: "1.0.0" });
-  const server = createMcpServer(new AgentVideoRuntime(createEvaluationEditor()));
-  const captures: Record<string, JsonValue> = {};
+  const directory = await mkdtemp(join(os.tmpdir(), "framekit-mcp-evaluation-"));
+  const exporter = new FinalCutVideoExporter({
+    enabled: true,
+    executor: async (script) => {
+      const match = script.match(/set value of first text field of front window to "([^"]+)"/);
+      assert.ok(match?.[1]);
+      await writeFile(match[1], "deterministic MCP evaluation export");
+      return "started";
+    },
+    probe: async () => ({ durationSeconds: 12, width: 1920, height: 1080, frameRate: 30, hasAudio: true }),
+    sleep: async () => undefined,
+  });
+  const server = createMcpServer(new AgentVideoRuntime(createEvaluationEditor()), { videoExporter: exporter });
+  const captures: Record<string, JsonValue> = { outputPath: join(directory, "basic-mvp.mp4") };
+  const evidence = {
+    tools: scenario.steps.map((step) => step.tool),
+    operations: scenario.operations ?? [],
+  };
 
   try {
     await server.connect(serverTransport);
@@ -429,19 +523,21 @@ async function runScenario(scenario: EvaluationScenario): Promise<EvaluationScen
         captures[step.capture.name] = captureValue!;
       }
     }
-    return { id: scenario.id, category: scenario.category, support: scenario.support, intent: scenario.intent, passed: true };
+    return { id: scenario.id, category: scenario.category, support: scenario.support, intent: scenario.intent, ...evidence, passed: true };
   } catch (error) {
     return {
       id: scenario.id,
       category: scenario.category,
       support: scenario.support,
       intent: scenario.intent,
+      ...evidence,
       passed: false,
       message: error instanceof Error ? error.message : String(error),
     };
   } finally {
     await client.close().catch(() => undefined);
     await server.close().catch(() => undefined);
+    await rm(directory, { recursive: true, force: true });
   }
 }
 

--- a/tests/evaluation/suite.ts
+++ b/tests/evaluation/suite.ts
@@ -53,6 +53,15 @@ const editorTimelineTarget = {
   baseRevision: { id: "rev-0", sequence: 0, timestamp: new Date(0).toISOString() },
 };
 
+const basicEditingMvpOperations: JsonObject[] = [
+  { type: "media.import", mediaId: "mvp-video", source: "fixture://evaluation/video.mov", mediaKind: "video", duration: 6, sourceDigest: "sha256:40f61de46d9ff839cbab97b4da386f428b53200f61337118dd28f51b41107e10" },
+  { type: "timeline.media.add", occurrenceId: "mvp-video-occurrence", mediaId: "mvp-video", role: "video", start: 0, duration: 5, targetLane: "primary" },
+  { type: "trim-clip", clipId: "mvp-video-occurrence", duration: 4 },
+  { type: "media.import", mediaId: "mvp-music", source: "fixture://evaluation/music.wav", mediaKind: "audio", duration: 8, sourceDigest: "sha256:fa57a0847530fb480f5fc4df72b925baa1ca2ca1879b7232909bfd90df840b79" },
+  { type: "timeline.media.add", occurrenceId: "mvp-music-occurrence", mediaId: "mvp-music", role: "music", start: 0, duration: 4, targetLane: 1 },
+  { type: "timeline.title.add", occurrenceId: "mvp-title-occurrence", assetId: "asset-lower-third", text: "Framekit MVP", start: 1, duration: 2, targetLane: 2 },
+];
+
 export interface EvaluationScenarioResult {
   id: string;
   category: EvaluationCategory;
@@ -140,14 +149,7 @@ const scenarios: EvaluationScenario[] = [
     support: "supported",
     intent: "Execute and verify the deterministic Basic Editing MVP workflow",
     expectedTool: "edit.undo",
-    operations: [
-      "media.import",
-      "timeline.media.add",
-      "trim-clip",
-      "media.import",
-      "timeline.media.add",
-      "timeline.title.add",
-    ],
+    operations: basicEditingMvpOperations.map((operation) => String(operation.type)),
     steps: [
       { tool: "connection.status", expect: { json: { path: "state", equals: "ready" } } },
       { tool: "editor.inspect", expect: { json: { path: "capabilities.editor.compositeTransactions", equals: true } } },
@@ -162,14 +164,7 @@ const scenarios: EvaluationScenario[] = [
         tool: "editor.timeline.edit.preview",
         arguments: {
           ...editorTimelineTarget,
-          operations: [
-            { type: "media.import", mediaId: "mvp-video", source: "fixture://evaluation/video.mov", mediaKind: "video", duration: 6, sourceDigest: "sha256:40f61de46d9ff839cbab97b4da386f428b53200f61337118dd28f51b41107e10" },
-            { type: "timeline.media.add", occurrenceId: "mvp-video-occurrence", mediaId: "mvp-video", role: "video", start: 0, duration: 5, targetLane: "primary" },
-            { type: "trim-clip", clipId: "mvp-video-occurrence", duration: 4 },
-            { type: "media.import", mediaId: "mvp-music", source: "fixture://evaluation/music.wav", mediaKind: "audio", duration: 8, sourceDigest: "sha256:fa57a0847530fb480f5fc4df72b925baa1ca2ca1879b7232909bfd90df840b79" },
-            { type: "timeline.media.add", occurrenceId: "mvp-music-occurrence", mediaId: "mvp-music", role: "music", start: 0, duration: 4, targetLane: 1 },
-            { type: "timeline.title.add", occurrenceId: "mvp-title-occurrence", assetId: "asset-lower-third", text: "Framekit MVP", start: 1, duration: 2, targetLane: 2 },
-          ],
+          operations: basicEditingMvpOperations,
         },
         expect: { json: { path: "previewToken", includes: "preview-" } },
         capture: { name: "previewToken", path: "previewToken" },


### PR DESCRIPTION
- [ ] Request PR review
- [x] If you are unable to review, please set it as a [PR draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/) draft.
- [x] Github issue: Closes: #31

## Summary

Closes #31.

PR #143 added the executable Basic Editing MVP integration gate. This follow-up closes the remaining evaluation gap on current `main`:

- replace the stale unavailable media-import scenario with one supported composite MVP workflow
- execute connection/editor/project/context inspection, title discovery, preview, execute, media readback, diff, verification, transaction-bound export, and Undo
- record the exact `media.import`, `timeline.media.add`, trim, and `timeline.title.add` operation sequence from the inputs actually executed
- report MVP correctness in a separate `mvp-workflow` category while preserving unavailable out-of-scope coverage

The first commit is the expected failing TDD checkpoint; the following commits make it green and refactor evidence derivation without behavior changes.

## Validation

```bash
PATH=/Users/shotomorisaki/.nix-profile/bin:$PATH .agents/skills/validate-framekit/scripts/validate.sh
```

- frozen install passed with pnpm 12.3.4
- TypeScript build passed
- 702/702 tests passed
- package boundary checks passed
- native checks skipped because no native files changed

## Architecture and compatibility

- [x] Runtime remains independent of MCP and editor-specific implementations.
- [x] Public MCP behavior or package interfaces are documented if changed.
- [x] Existing adapters and test fixtures remain compatible, or the migration is explained above.

No public MCP or package contract changed; this PR exercises existing contracts through the deterministic evaluation harness.

## Safety

- [x] No credentials, private media, raw crash dumps, or user-specific local paths were added.
- [x] Generated files and build artifacts are excluded.
- [x] Documentation reflects any changed commands, paths, or environment variables.

This is deterministic fixture evidence only and does not claim headed Final Cut behavior.
