### PR TITLE
chore: collapse maintenance release notes

### DIFF
--- a/.github/workflows/format-release-notes.yml
+++ b/.github/workflows/format-release-notes.yml
@@ -1,0 +1,85 @@
+name: Format release notes
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  tagpr-pull-request:
+    if: >-
+      github.event_name == 'pull_request' &&
+      startsWith(github.head_ref, 'tagpr-from-') &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Collapse maintenance section in release PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          original="${RUNNER_TEMP}/release-pr-body.md"
+          formatted="${RUNNER_TEMP}/release-pr-body-formatted.md"
+          payload="${RUNNER_TEMP}/release-pr-body.json"
+
+          gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.body // ""' > "${original}"
+          node scripts/format-release-notes.mjs < "${original}" > "${formatted}"
+
+          if cmp -s "${original}" "${formatted}"; then
+            exit 0
+          fi
+
+          jq -Rs '{body: .}' < "${formatted}" > "${payload}"
+          gh api --method PATCH \
+            "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
+            --input "${payload}" \
+            --silent
+
+  github-release:
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Collapse maintenance section in GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ github.event.release.id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          original="${RUNNER_TEMP}/release-body.md"
+          formatted="${RUNNER_TEMP}/release-body-formatted.md"
+          payload="${RUNNER_TEMP}/release-body.json"
+
+          gh api "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" --jq '.body // ""' > "${original}"
+          node scripts/format-release-notes.mjs < "${original}" > "${formatted}"
+
+          if cmp -s "${original}" "${formatted}"; then
+            exit 0
+          fi
+
+          jq -Rs '{body: .}' < "${formatted}" > "${payload}"
+          gh api --method PATCH \
+            "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" \
+            --input "${payload}" \
+            --silent

--- a/scripts/format-release-notes.d.mts
+++ b/scripts/format-release-notes.d.mts
@@ -1,0 +1,3 @@
+export const MAINTENANCE_RELEASE_SUMMARY: "🧰 Maintenance & Internal";
+
+export function collapseMaintenanceReleaseNotes(markdown: string): string;

--- a/scripts/format-release-notes.mjs
+++ b/scripts/format-release-notes.mjs
@@ -1,0 +1,67 @@
+export const MAINTENANCE_RELEASE_SUMMARY = "🧰 Maintenance & Internal";
+
+const MAINTENANCE_HEADING = `### ${MAINTENANCE_RELEASE_SUMMARY}`;
+
+export function collapseMaintenanceReleaseNotes(markdown) {
+  if (typeof markdown !== "string") {
+    throw new TypeError("release notes must be a string");
+  }
+
+  const lines = markdown.split("\n");
+  const headingIndex = lines.findIndex((line) => line.trimEnd() === MAINTENANCE_HEADING);
+  if (headingIndex === -1) {
+    return markdown;
+  }
+
+  let endIndex = lines.length;
+  for (let index = headingIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (/^#{2,3}\s/.test(line) || /^\*\*Full Changelog\*\*:/.test(line)) {
+      endIndex = index;
+      break;
+    }
+  }
+
+  const body = lines.slice(headingIndex + 1, endIndex);
+  while (body[0]?.trim() === "") body.shift();
+  while (body.at(-1)?.trim() === "") body.pop();
+
+  if (body.length === 0) {
+    return markdown;
+  }
+
+  const replacement = [
+    "<details>",
+    `<summary>${MAINTENANCE_RELEASE_SUMMARY}</summary>`,
+    "",
+    ...body,
+    "",
+    "</details>",
+    "",
+  ];
+
+  return [
+    ...lines.slice(0, headingIndex),
+    ...replacement,
+    ...lines.slice(endIndex),
+  ].join("\n");
+}
+
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function main() {
+  process.stdout.write(collapseMaintenanceReleaseNotes(await readStdin()));
+}
+
+if (process.argv[1] && new URL(import.meta.url).pathname === process.argv[1]) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/tests/integration/release-notes-format.test.ts
+++ b/tests/integration/release-notes-format.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  collapseMaintenanceReleaseNotes,
+  MAINTENANCE_RELEASE_SUMMARY,
+} from "../../scripts/format-release-notes.mjs";
+
+const repository = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+test("collapses maintenance release notes without hiding user-facing sections", () => {
+  const source = `## What's Changed
+### ✨ Features
+* feat: add something
+### 🐛 Fixes
+* fix: repair something
+### 🧰 Maintenance & Internal
+* chore: update tooling
+* test: expand coverage
+
+**Full Changelog**: https://github.com/example/repo/compare/v0.1.7...v0.1.8`;
+
+  const formatted = collapseMaintenanceReleaseNotes(source);
+
+  assert.match(formatted, /### ✨ Features\n\* feat: add something/);
+  assert.match(formatted, /### 🐛 Fixes\n\* fix: repair something/);
+  assert.match(
+    formatted,
+    new RegExp(`<details>\\n<summary>${MAINTENANCE_RELEASE_SUMMARY}</summary>\\n\\n\\* chore: update tooling\\n\\* test: expand coverage\\n\\n</details>`),
+  );
+  assert.match(formatted, /<\/details>\n\n\*\*Full Changelog\*\*:/);
+  assert.doesNotMatch(formatted, /### 🧰 Maintenance & Internal/);
+});
+
+test("keeps following generated sections outside the maintenance details block", () => {
+  const source = `## What's Changed
+### 🧰 Maintenance & Internal
+* chore: update tooling
+
+## New Contributors
+* @contributor made their first contribution
+
+**Full Changelog**: https://github.com/example/repo/compare/v0.1.7...v0.1.8`;
+
+  const formatted = collapseMaintenanceReleaseNotes(source);
+  const detailsEnd = formatted.indexOf("</details>");
+  const contributors = formatted.indexOf("## New Contributors");
+
+  assert.ok(detailsEnd !== -1);
+  assert.ok(contributors > detailsEnd, "New Contributors must remain outside the collapsed maintenance section");
+});
+
+test("release note formatting is idempotent", () => {
+  const source = `## What's Changed
+### 🧰 Maintenance & Internal
+* chore: update tooling
+
+**Full Changelog**: https://github.com/example/repo/compare/v0.1.7...v0.1.8`;
+
+  const once = collapseMaintenanceReleaseNotes(source);
+  assert.equal(collapseMaintenanceReleaseNotes(once), once);
+});
+
+test("leaves release notes without maintenance changes untouched", () => {
+  const source = `## What's Changed
+### ✨ Features
+* feat: add something
+
+**Full Changelog**: https://github.com/example/repo/compare/v0.1.7...v0.1.8`;
+
+  assert.equal(collapseMaintenanceReleaseNotes(source), source);
+});
+
+test("format workflow targets Tag PRs and published GitHub releases", async () => {
+  const workflow = await readFile(
+    resolve(repository, ".github/workflows/format-release-notes.yml"),
+    "utf8",
+  );
+
+  assert.match(workflow, /pull_request:\s*\n\s+types: \[opened, synchronize, reopened\]/);
+  assert.match(workflow, /release:\s*\n\s+types: \[published\]/);
+  assert.match(workflow, /startsWith\(github\.head_ref, 'tagpr-from-'\)/);
+  assert.match(workflow, /pull-requests: write/);
+  assert.match(workflow, /github-release:[\s\S]*?contents: write/);
+  assert.equal(
+    workflow.match(/node scripts\/format-release-notes\.mjs/g)?.length,
+    2,
+    "the same formatter should be used for the release PR and final release",
+  );
+});


### PR DESCRIPTION
## Summary

- collapse `🧰 Maintenance & Internal` release-note entries behind a GitHub `<details>` block
- keep Features, Fixes, New Contributors, and the Full Changelog visible by default
- apply the same deterministic formatter to Tag PR release pull requests and published GitHub Releases
- add regression coverage for formatting, idempotency, and workflow wiring

The current v0.1.8 release PR (#237) is the reference UX. Once this lands and Tag PR updates #237 again, the formatter workflow will rewrite its maintenance section automatically.

## Validation

- Added focused integration coverage in `tests/integration/release-notes-format.test.ts`.
- CI should run the repository test suite on this PR.

## Architecture and compatibility

- [x] Tag PR remains responsible for versioning and GitHub-generated release-note categorization.
- [x] `.github/release.yml` remains the source of category membership.
- [x] `CHANGELOG.md` stays normal Markdown; only the release PR / GitHub Release presentation is collapsed.

## Safety

- [x] Formatter is idempotent and only rewrites the exact `### 🧰 Maintenance & Internal` section.
- [x] No release artifacts, package publication, Final Cut state, user media, credentials, or private paths are changed.
